### PR TITLE
Fix system.reflection.emit and system.runtime.serialization

### DIFF
--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.csproj
@@ -15,7 +15,7 @@
     <Compile Include="**/lib/$(TargetFramework)/*.cs" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <ItemGroup>
         <PackageReference Include="System.Reflection" Version="4.1.0" />
         <PackageReference Include="System.Reflection.Primitives" Version="4.0.1" />
         <PackageReference Include="System.Runtime" Version="4.1.0" />

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/lib/netstandard1.3/System.Reflection.Emit.ILGeneration.cs
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/lib/netstandard1.3/System.Reflection.Emit.ILGeneration.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyDescription("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyDefaultAlias("System.Reflection.Emit.ILGeneration")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+
+
+

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.csproj
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.csproj
@@ -15,7 +15,7 @@
     <Compile Include="**/lib/$(TargetFramework)/*.cs" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <ItemGroup>
         <PackageReference Include="System.Reflection" Version="4.1.0" />
         <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.0.1" />
         <PackageReference Include="System.Reflection.Primitives" Version="4.0.1" />

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/lib/netstandard1.3/System.Reflection.Emit.Lightweight.cs
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/lib/netstandard1.3/System.Reflection.Emit.Lightweight.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyDescription("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyDefaultAlias("System.Reflection.Emit.Lightweight")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+
+
+

--- a/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.csproj
@@ -15,7 +15,7 @@
     <Compile Include="**/lib/$(TargetFramework)/*.cs" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <ItemGroup>
         <PackageReference Include="System.IO" Version="4.1.0" />
         <PackageReference Include="System.Reflection" Version="4.1.0" />
         <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.0.1" />

--- a/src/referencePackages/src/system.reflection.emit/4.0.1/lib/netstandard1.3/System.Reflection.Emit.cs
+++ b/src/referencePackages/src/system.reflection.emit/4.0.1/lib/netstandard1.3/System.Reflection.Emit.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Reflection.Emit")]
+[assembly: AssemblyDescription("System.Reflection.Emit")]
+[assembly: AssemblyDefaultAlias("System.Reflection.Emit")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+
+
+

--- a/src/referencePackages/src/system.runtime.serialization.json/4.0.2/System.Runtime.Serialization.Json.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.json/4.0.2/System.Runtime.Serialization.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.json/4.0.2/system.runtime.serialization.json.nuspec</NuspecFile>
    </PropertyGroup>
 


### PR DESCRIPTION
Add back lib code for system.reflection.emit.* and build them for all TFMs.
Remove netstandard1.3 from build of system.runtime.serialization