### PR TITLE
Build intermediate nupkgs when /p:FromSource=true

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -27,4 +27,6 @@
       Text="A project name is duplicated. Every project name must be distinct to have separate output directories." />
   </Target>
 
+  <Import Project="Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildArcade.targets" Condition="'$(FromSource)' == 'true'" />
+
 </Project>

--- a/eng/Microsoft.DotNet.Arcade.Sdk/tools/Noop.proj
+++ b/eng/Microsoft.DotNet.Arcade.Sdk/tools/Noop.proj
@@ -1,0 +1,13 @@
+<!--
+  This project does nothing when run. It can be used as a ProjectToBuild: this makes ProjectToBuild
+  non-empty to avoid the default behavior of finding projects to build in the root, but still not do
+  anything. Used during source-build to no-op the entire default "outer" Arcade build.
+-->
+<Project>
+
+  <Target Name="Restore" />
+  <Target Name="Build" />
+  <Target Name="Pack" />
+  <Target Name="Test" />
+
+</Project>

--- a/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildArcade.targets
+++ b/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildArcade.targets
@@ -5,7 +5,6 @@
   -->
 
   <PropertyGroup>
-    <SourceBuildEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'source-build'))</SourceBuildEngineeringDir>
     <SourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build'))</SourceBuildArtifactsDir>
     <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build', 'self'))</CurrentRepoSourceBuildArtifactsDir>
     <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>

--- a/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildArcade.targets
+++ b/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildArcade.targets
@@ -1,0 +1,113 @@
+<Project>
+
+  <!--
+    These targets inject source-build into Arcade's build process.
+  -->
+
+  <PropertyGroup>
+    <SourceBuildEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'source-build'))</SourceBuildEngineeringDir>
+    <SourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build'))</SourceBuildArtifactsDir>
+    <CurrentRepoSourceBuildArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'source-build', 'self'))</CurrentRepoSourceBuildArtifactsDir>
+    <CurrentRepoSourceBuildArtifactsPackagesDir>$([MSBuild]::NormalizeDirectory('$(CurrentRepoSourceBuildArtifactsDir)', 'packages', '$(Configuration)'))</CurrentRepoSourceBuildArtifactsPackagesDir>
+
+    <CurrentRepoSourceBuildBinlogFile>$([MSBuild]::NormalizePath('$(CurrentRepoSourceBuildArtifactsDir)', 'sourcebuild.binlog'))</CurrentRepoSourceBuildBinlogFile>
+  </PropertyGroup>
+
+  <Target Name="BuildUpstreamRepos"
+          Condition="
+            '$(FromSource)' == 'true' and
+            '$(InnerBuildFromSource)' != 'true' and
+            '$(BuildUpstreamRepos)' == 'true'">
+    <!-- TODO: Clone upstream repos and build them, or download intermediate nupkgs to use. -->
+  </Target>
+
+  <!--
+    Set up build args to append to the passed build command. These args specify what is unique about
+    building from source, such as non-overlapping artifacts dirs and package caches. This target can
+    be BeforeTargets'd or replaced to customize source-build.
+  -->
+  <Target Name="GetSourceBuildCommandConfiguration">
+    <PropertyGroup>
+      <!-- Track that this is the inner build to prevent infinite recursion. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:InnerBuildFromSource=true</InnerBuildArgs>
+      <!-- Override the artifacts dir to cleanly separate the inner build from outer build. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /p:ArtifactsDir=$(CurrentRepoSourceBuildArtifactsDir)</InnerBuildArgs>
+      <!-- Set a custom binlog location to avoid clashing over the currenly specified file. -->
+      <InnerBuildArgs>$(InnerBuildArgs) /bl:$(CurrentRepoSourceBuildBinlogFile)</InnerBuildArgs>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ExecuteWithSourceBuiltTooling"
+          DependsOnTargets="
+            BuildUpstreamRepos;
+            GetSourceBuildCommandConfiguration;
+            ExecuteInnerSourceBuild;
+            PackSourceBuildIntermediateNupkg"
+          Condition="
+            '$(FromSource)' == 'true' and
+            '$(InnerBuildFromSource)' != 'true'"
+          BeforeTargets="Execute" />
+
+  <!--
+    Separate target to execute to provide easy hook point for BeforeTargets that will only trigger
+    when the inner build is actually happening. Hooking BeforeTargets on
+    ExecuteWithSourceBuiltTooling would run unconditionally.
+  -->
+  <Target Name="ExecuteInnerSourceBuild">
+    <PropertyGroup>
+      <!-- Prevent any projects from building in the outside build: they would use prebuilts. -->
+      <PreventPrebuiltBuild>true</PreventPrebuiltBuild>
+
+      <!--
+        Normally, the inner build should run using the original build command with some extra args
+        appended. Allow the repo to override this default behavior if the repo is e.g. not onboarded
+        enough on Arcade for this to work nicely.
+      -->
+      <BaseInnerSourceBuildCommand Condition="'$(BaseInnerSourceBuildCommand)' == ''">$(ARCADE_BUILD_TOOL_COMMAND)</BaseInnerSourceBuildCommand>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(BaseInnerSourceBuildCommand) $(InnerBuildArgs)"
+      WorkingDirectory="$(ProjectDirectory)"
+      EnvironmentVariables="@(InnerBuildEnv)"
+      IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
+  <!--
+    Create a source-build intermediate NuGet package for dependency transport.
+  -->
+  <Target Name="PackSourceBuildIntermediateNupkg">
+    <PropertyGroup>
+      <SourceBuildIntermediateProjFile>$(MSBuildThisFileDirectory)SourceBuildIntermediate.proj</SourceBuildIntermediateProjFile>
+      <SourceBuildIntermediateProjTargetFile>$(ArtifactsObjDir)ArcadeGeneratedProjects\SourceBuildIntermediate\SourceBuildIntermediate.proj</SourceBuildIntermediateProjTargetFile>
+    </PropertyGroup>
+
+    <!-- Copy the project to artifacts/ so that the repo's global.json is in an ancestor dir. -->
+    <Copy
+      SourceFiles="$(SourceBuildIntermediateProjFile)"
+      DestinationFiles="$(SourceBuildIntermediateProjTargetFile)" />
+
+    <ItemGroup>
+      <SourceBuildIntermediatePackTarget Include="Restore;Pack" />
+    </ItemGroup>
+
+    <MSBuild
+      Projects="$(SourceBuildIntermediateProjTargetFile)"
+      Targets="%(SourceBuildIntermediatePackTarget.Identity)"
+      Properties="CurrentRepoSourceBuildArtifactsPackagesDir=$(CurrentRepoSourceBuildArtifactsPackagesDir)" />
+  </Target>
+
+  <Target Name="PreventPrebuiltBuild"
+          DependsOnTargets="ExecuteWithSourceBuiltTooling"
+          Condition="'$(PreventPrebuiltBuild)' == 'true'"
+          BeforeTargets="Execute">
+    <ItemGroup>
+      <ProjectToBuild Remove="@(ProjectToBuild)" />
+      <ProjectToBuild Include="$(MSBuildThisFileDirectory)Noop.proj" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Repository extension point -->
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+
+</Project>

--- a/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildIntermediate.proj
+++ b/eng/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuildIntermediate.proj
@@ -1,0 +1,53 @@
+<Project>
+
+  <!-- Shield this project from nonstandard Directory.Build.props/targets. -->
+  <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- Repository extension point -->
+  <Import Project="$(RepositoryEngineeringDir)SourceBuild.props" Condition="Exists('$(RepositoryEngineeringDir)SourceBuild.props')" />
+
+  <PropertyGroup>
+    <SourceBuildPackageRid Condition="'$(SourceBuildPackageRid)' == ''">linux-x64</SourceBuildPackageRid>
+    <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">no-repo-name-defined</GitHubRepositoryName>
+
+    <Copyright Condition="'$(Copyright)' == ''">$(CopyrightNetFoundation)</Copyright>
+    <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">MIT</PackageLicenseExpression>
+
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <!-- NuGet excludes nupkgs by default: disable this behavior. -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+
+    <EnableDefaultSourceBuildIntermediateItems Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == ''">true</EnableDefaultSourceBuildIntermediateItems>
+
+    <!-- Arbitrary TargetFramework to appease SDK. -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultSourceBuildIntermediateItems)' == 'true'">
+    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.nupkg" PackagePath="artifacts" />
+    <Content Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)**\*.tar.gz" PackagePath="artifacts" />
+  </ItemGroup>
+
+  <Target Name="InitializeSourceBuildIntermediatePackageId"
+          BeforeTargets="GenerateNuspec;InitializeStandardNuspecProperties">
+    <PropertyGroup>
+      <PackageId>Microsoft.SourceBuild.Intermediate.$(GitHubRepositoryName).$(SourceBuildPackageRid)</PackageId>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <Target Name="Build" />
+
+</Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>source-build-reference-packages</GitHubRepositoryName>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Bring forward prototype code from https://github.com/dotnet/source-build/issues/1543 and https://github.com/dotnet/source-build/issues/1466 to generate an intermediate nupkg when running `./build.sh /p:FromSource=true`.

The results of ordinary `./build.sh` are basically:

```
artifacts/packages/Debug/Shipping/{outputs}.nupkg
```

Then with `./build.sh /p:FromSource=true` you get an isolated artifacts dir and an output intermediate nupkg:

```
artifacts/source-build/self/packages/Debug/Shipping/{outputs}.nupkg
artifacts/packages/Debug/NonShipping/Microsoft.SourceBuild.Intermediate.source-build-reference-packages.linux-x64.5.0.0-dev.nupkg
```

The isolation reduces the risk of accidentally publishing the source-built nupkgs themselves rather than the intermediate nupkg, and there are plans to use the isolation for other things later. The isolation implementation (recursive build using `Exec` after appending extra args) is based on https://github.com/dotnet/arcade/issues/5116.

(You can also run `./build.sh` then `./build.sh /p:FromSource=true` without your builds clashing, but this isn't a scenario that's worth truly supporting IMO.)
