### PR TITLE
Use StrongNameKeyId rather than directly using AssemblyOriginatorKeyFile: fix PublicKeyToken

### DIFF
--- a/src/referencePackages/src/microsoft.build.framework/15.1.1012/Microsoft.Build.Framework.15.1.1012.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.1.1012/Microsoft.Build.Framework.15.1.1012.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.framework/15.1.1012/microsoft.build.framework.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.framework/15.1.548/Microsoft.Build.Framework.15.1.548.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.1.548/Microsoft.Build.Framework.15.1.548.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.framework/15.1.548/microsoft.build.framework.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.framework/15.7.179/Microsoft.Build.Framework.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.7.179/Microsoft.Build.Framework.15.7.179.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.framework/15.7.179/microsoft.build.framework.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.tasks.core/15.1.1012/Microsoft.Build.Tasks.Core.15.1.1012.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/15.1.1012/Microsoft.Build.Tasks.Core.15.1.1012.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.tasks.core/15.1.1012/microsoft.build.tasks.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.tasks.core/15.1.548/Microsoft.Build.Tasks.Core.15.1.548.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/15.1.548/Microsoft.Build.Tasks.Core.15.1.548.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.tasks.core/15.1.548/microsoft.build.tasks.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.tasks.core/15.7.179/Microsoft.Build.Tasks.Core.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/15.7.179/Microsoft.Build.Tasks.Core.15.7.179.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.tasks.core/15.7.179/microsoft.build.tasks.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.1.1012/Microsoft.Build.Utilities.Core.15.1.1012.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.1.1012/Microsoft.Build.Utilities.Core.15.1.1012.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.utilities.core/15.1.1012/microsoft.build.utilities.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.1.548/Microsoft.Build.Utilities.Core.15.1.548.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.1.548/Microsoft.Build.Utilities.Core.15.1.548.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.utilities.core/15.1.548/microsoft.build.utilities.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.7.179/Microsoft.Build.Utilities.Core.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.7.179/Microsoft.Build.Utilities.Core.15.7.179.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.utilities.core/15.7.179/microsoft.build.utilities.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build/15.7.179/microsoft.build.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.csharp/4.0.1/Microsoft.CSharp.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.0.1/Microsoft.CSharp.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.csharp/4.0.1/microsoft.csharp.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.csharp/4.3.0/Microsoft.CSharp.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.3.0/Microsoft.CSharp.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.csharp/4.3.0/microsoft.csharp.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.dotnet.platformabstractions/2.0.0/Microsoft.DotNet.PlatformAbstractions.2.0.0.csproj
+++ b/src/referencePackages/src/microsoft.dotnet.platformabstractions/2.0.0/Microsoft.DotNet.PlatformAbstractions.2.0.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.dotnet.platformabstractions/2.0.0/microsoft.dotnet.platformabstractions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)AspNetCore.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.dotnet.platformabstractions/2.1.0/Microsoft.DotNet.PlatformAbstractions.2.1.0.csproj
+++ b/src/referencePackages/src/microsoft.dotnet.platformabstractions/2.1.0/Microsoft.DotNet.PlatformAbstractions.2.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.dotnet.platformabstractions/2.1.0/microsoft.dotnet.platformabstractions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)AspNetCore.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.extensions.dependencymodel/2.1.0/Microsoft.Extensions.DependencyModel.2.1.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.dependencymodel/2.1.0/Microsoft.Extensions.DependencyModel.2.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.6;net451</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.extensions.dependencymodel/2.1.0/microsoft.extensions.dependencymodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)AspNetCore.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.win32.primitives/4.0.1/Microsoft.Win32.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.win32.primitives/4.0.1/Microsoft.Win32.Primitives.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.primitives/4.0.1/microsoft.win32.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.win32.primitives/4.3.0/Microsoft.Win32.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.primitives/4.3.0/Microsoft.Win32.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.win32.registry/4.0.0/Microsoft.Win32.Registry.4.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.0.0/Microsoft.Win32.Registry.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.registry/4.0.0/microsoft.win32.registry.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/microsoft.win32.registry/4.3.0/Microsoft.Win32.Registry.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.3.0/Microsoft.Win32.Registry.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.registry/4.3.0/microsoft.win32.registry.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.build.tasks/5.1.0/NuGet.Build.Tasks.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.build.tasks/5.1.0/NuGet.Build.Tasks.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.build.tasks/5.1.0/nuget.build.tasks.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.commands/5.1.0/nuget.commands.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.common/5.1.0/NuGet.Common.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.common/5.1.0/NuGet.Common.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.common/5.1.0/nuget.common.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.configuration/5.1.0/NuGet.Configuration.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.configuration/5.1.0/NuGet.Configuration.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.configuration/5.1.0/nuget.configuration.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.credentials/5.1.0/NuGet.Credentials.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.credentials/5.1.0/NuGet.Credentials.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.credentials/5.1.0/nuget.credentials.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/5.1.0/NuGet.DependencyResolver.Core.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/5.1.0/NuGet.DependencyResolver.Core.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.dependencyresolver.core/5.1.0/nuget.dependencyresolver.core.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.frameworks/5.1.0/NuGet.Frameworks.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.frameworks/5.1.0/NuGet.Frameworks.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.frameworks/5.1.0/nuget.frameworks.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.librarymodel/5.1.0/NuGet.LibraryModel.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/5.1.0/NuGet.LibraryModel.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.librarymodel/5.1.0/nuget.librarymodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.packaging/5.1.0/NuGet.Packaging.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.packaging/5.1.0/NuGet.Packaging.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.packaging/5.1.0/nuget.packaging.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.projectmodel/5.1.0/NuGet.ProjectModel.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/5.1.0/NuGet.ProjectModel.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.projectmodel/5.1.0/nuget.projectmodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.protocol/5.1.0/NuGet.Protocol.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.protocol/5.1.0/NuGet.Protocol.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.protocol/5.1.0/nuget.protocol.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/4.3.0/NuGet.Versioning.4.3.0.csproj
+++ b/src/referencePackages/src/nuget.versioning/4.3.0/NuGet.Versioning.4.3.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.versioning/4.3.0/nuget.versioning.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/4.4.0/NuGet.Versioning.4.4.0.csproj
+++ b/src/referencePackages/src/nuget.versioning/4.4.0/NuGet.Versioning.4.4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.versioning/4.4.0/nuget.versioning.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/5.1.0/NuGet.Versioning.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.versioning/5.1.0/NuGet.Versioning.5.1.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)nuget.versioning/5.1.0/nuget.versioning.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.appcontext/4.1.0/System.AppContext.4.1.0.csproj
+++ b/src/referencePackages/src/system.appcontext/4.1.0/System.AppContext.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.6;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.appcontext/4.1.0/system.appcontext.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.appcontext/4.3.0/System.AppContext.4.3.0.csproj
+++ b/src/referencePackages/src/system.appcontext/4.3.0/System.AppContext.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.6;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.appcontext/4.3.0/system.appcontext.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.0.0/System.Buffers.4.0.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.0.0/System.Buffers.4.0.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.0.0/system.buffers.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.3.0/System.Buffers.4.3.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.3.0/System.Buffers.4.3.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.3.0/system.buffers.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.4.0/System.Buffers.4.4.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.4.0/System.Buffers.4.4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.4.0/system.buffers.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.5.0/System.Buffers.4.5.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.5.0/System.Buffers.4.5.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.5.0/system.buffers.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
+++ b/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.5.1/system.buffers.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.codedom/4.4.0/System.CodeDom.4.4.0.csproj
+++ b/src/referencePackages/src/system.codedom/4.4.0/System.CodeDom.4.4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.codedom/4.4.0/system.codedom.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.concurrent/4.0.12/system.collections.concurrent.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.concurrent/4.3.0/system.collections.concurrent.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.2.0/system.collections.immutable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.0/system.collections.immutable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.1/system.collections.immutable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.4.0/System.Collections.Immutable.1.4.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.4.0/System.Collections.Immutable.1.4.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.4.0/system.collections.immutable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.5.0/system.collections.immutable.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/1.7.1/System.Collections.Immutable.1.7.1.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.7.1/System.Collections.Immutable.1.7.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.7.1/system.collections.immutable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.nongeneric/4.0.1/System.Collections.NonGeneric.4.0.1.csproj
+++ b/src/referencePackages/src/system.collections.nongeneric/4.0.1/System.Collections.NonGeneric.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.nongeneric/4.0.1/system.collections.nongeneric.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.nongeneric/4.3.0/system.collections.nongeneric.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.specialized/4.0.1/System.Collections.Specialized.4.0.1.csproj
+++ b/src/referencePackages/src/system.collections.specialized/4.0.1/System.Collections.Specialized.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.specialized/4.0.1/system.collections.specialized.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.specialized/4.3.0/system.collections.specialized.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
+++ b/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections/4.0.11/system.collections.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections/4.3.0/system.collections.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel.eventbasedasync/4.0.11/System.ComponentModel.EventBasedAsync.4.0.11.csproj
+++ b/src/referencePackages/src/system.componentmodel.eventbasedasync/4.0.11/System.ComponentModel.EventBasedAsync.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.eventbasedasync/4.0.11/system.componentmodel.eventbasedasync.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel.primitives/4.1.0/System.ComponentModel.Primitives.4.1.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.primitives/4.1.0/System.ComponentModel.Primitives.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.primitives/4.1.0/system.componentmodel.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel.primitives/4.3.0/System.ComponentModel.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.primitives/4.3.0/System.ComponentModel.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.primitives/4.3.0/system.componentmodel.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel.typeconverter/4.1.0/System.ComponentModel.TypeConverter.4.1.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.typeconverter/4.1.0/System.ComponentModel.TypeConverter.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.typeconverter/4.1.0/system.componentmodel.typeconverter.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel.typeconverter/4.3.0/System.ComponentModel.TypeConverter.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.typeconverter/4.3.0/System.ComponentModel.TypeConverter.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.typeconverter/4.3.0/system.componentmodel.typeconverter.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel/4.0.1/System.ComponentModel.4.0.1.csproj
+++ b/src/referencePackages/src/system.componentmodel/4.0.1/System.ComponentModel.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel/4.0.1/system.componentmodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.componentmodel/4.3.0/System.ComponentModel.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel/4.3.0/System.ComponentModel.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel/4.3.0/system.componentmodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.console/4.0.0/System.Console.4.0.0.csproj
+++ b/src/referencePackages/src/system.console/4.0.0/System.Console.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.console/4.0.0/system.console.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.console/4.3.0/System.Console.4.3.0.csproj
+++ b/src/referencePackages/src/system.console/4.3.0/System.Console.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.console/4.3.0/system.console.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.contracts/4.0.1/System.Diagnostics.Contracts.4.0.1.csproj
+++ b/src/referencePackages/src/system.diagnostics.contracts/4.0.1/System.Diagnostics.Contracts.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.contracts/4.0.1/system.diagnostics.contracts.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.debug/4.0.11/System.Diagnostics.Debug.4.0.11.csproj
+++ b/src/referencePackages/src/system.diagnostics.debug/4.0.11/System.Diagnostics.Debug.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.debug/4.0.11/system.diagnostics.debug.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.debug/4.3.0/System.Diagnostics.Debug.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.debug/4.3.0/System.Diagnostics.Debug.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.debug/4.3.0/system.diagnostics.debug.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/4.0.0/System.Diagnostics.DiagnosticSource.4.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/4.0.0/System.Diagnostics.DiagnosticSource.4.0.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.diagnosticsource/4.0.0/system.diagnostics.diagnosticsource.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/4.3.0/System.Diagnostics.DiagnosticSource.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/4.3.0/System.Diagnostics.DiagnosticSource.4.3.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/4.4.0/System.Diagnostics.DiagnosticSource.4.4.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/4.4.0/System.Diagnostics.DiagnosticSource.4.4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net45;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.diagnosticsource/4.4.0/system.diagnostics.diagnosticsource.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.fileversioninfo/4.0.0/System.Diagnostics.FileVersionInfo.4.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.fileversioninfo/4.0.0/System.Diagnostics.FileVersionInfo.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.fileversioninfo/4.0.0/system.diagnostics.fileversioninfo.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.fileversioninfo/4.3.0/System.Diagnostics.FileVersionInfo.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.fileversioninfo/4.3.0/System.Diagnostics.FileVersionInfo.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.fileversioninfo/4.3.0/system.diagnostics.fileversioninfo.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.process/4.1.0/System.Diagnostics.Process.4.1.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.process/4.1.0/System.Diagnostics.Process.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.process/4.1.0/system.diagnostics.process.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.process/4.3.0/System.Diagnostics.Process.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.process/4.3.0/System.Diagnostics.Process.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.process/4.3.0/system.diagnostics.process.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.stacktrace/4.3.0/System.Diagnostics.StackTrace.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.stacktrace/4.3.0/System.Diagnostics.StackTrace.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.stacktrace/4.3.0/system.diagnostics.stacktrace.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.textwritertracelistener/4.0.0/System.Diagnostics.TextWriterTraceListener.4.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.textwritertracelistener/4.0.0/System.Diagnostics.TextWriterTraceListener.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.textwritertracelistener/4.0.0/system.diagnostics.textwritertracelistener.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tools/4.0.1/System.Diagnostics.Tools.4.0.1.csproj
+++ b/src/referencePackages/src/system.diagnostics.tools/4.0.1/System.Diagnostics.Tools.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tools/4.0.1/system.diagnostics.tools.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tools/4.3.0/System.Diagnostics.Tools.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tools/4.3.0/System.Diagnostics.Tools.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tools/4.3.0/system.diagnostics.tools.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tracesource/4.0.0/System.Diagnostics.TraceSource.4.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracesource/4.0.0/System.Diagnostics.TraceSource.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracesource/4.0.0/system.diagnostics.tracesource.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tracesource/4.3.0/System.Diagnostics.TraceSource.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracesource/4.3.0/System.Diagnostics.TraceSource.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracesource/4.3.0/system.diagnostics.tracesource.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tracing/4.1.0/System.Diagnostics.Tracing.4.1.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracing/4.1.0/System.Diagnostics.Tracing.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracing/4.1.0/system.diagnostics.tracing.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.tracing/4.3.0/System.Diagnostics.Tracing.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracing/4.3.0/System.Diagnostics.Tracing.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.dynamic.runtime/4.0.11/System.Dynamic.Runtime.4.0.11.csproj
+++ b/src/referencePackages/src/system.dynamic.runtime/4.0.11/System.Dynamic.Runtime.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.dynamic.runtime/4.0.11/system.dynamic.runtime.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.dynamic.runtime/4.3.0/System.Dynamic.Runtime.4.3.0.csproj
+++ b/src/referencePackages/src/system.dynamic.runtime/4.3.0/System.Dynamic.Runtime.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.dynamic.runtime/4.3.0/system.dynamic.runtime.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization.calendars/4.0.1/System.Globalization.Calendars.4.0.1.csproj
+++ b/src/referencePackages/src/system.globalization.calendars/4.0.1/System.Globalization.Calendars.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.calendars/4.0.1/system.globalization.calendars.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization.calendars/4.3.0/System.Globalization.Calendars.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization.calendars/4.3.0/System.Globalization.Calendars.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.calendars/4.3.0/system.globalization.calendars.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization.extensions/4.0.1/System.Globalization.Extensions.4.0.1.csproj
+++ b/src/referencePackages/src/system.globalization.extensions/4.0.1/System.Globalization.Extensions.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.extensions/4.0.1/system.globalization.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization.extensions/4.3.0/System.Globalization.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization.extensions/4.3.0/System.Globalization.Extensions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.extensions/4.3.0/system.globalization.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization/4.0.11/System.Globalization.4.0.11.csproj
+++ b/src/referencePackages/src/system.globalization/4.0.11/System.Globalization.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization/4.0.11/system.globalization.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.globalization/4.3.0/System.Globalization.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization/4.3.0/System.Globalization.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization/4.3.0/system.globalization.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.filesystem.primitives/4.0.1/System.IO.FileSystem.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/system.io.filesystem.primitives/4.0.1/System.IO.FileSystem.Primitives.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.filesystem.primitives/4.3.0/System.IO.FileSystem.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem.primitives/4.3.0/System.IO.FileSystem.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.filesystem/4.0.1/System.IO.FileSystem.4.0.1.csproj
+++ b/src/referencePackages/src/system.io.filesystem/4.0.1/System.IO.FileSystem.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem/4.0.1/system.io.filesystem.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.filesystem/4.3.0/System.IO.FileSystem.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem/4.3.0/System.IO.FileSystem.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem/4.3.0/system.io.filesystem.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.pipelines/4.7.0/System.IO.Pipelines.4.7.0.csproj
+++ b/src/referencePackages/src/system.io.pipelines/4.7.0/System.IO.Pipelines.4.7.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.pipelines/4.7.0/system.io.pipelines.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/4.3.0/System.IO.Pipes.AccessControl.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/4.3.0/System.IO.Pipes.AccessControl.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.pipes.accesscontrol/4.3.0/system.io.pipes.accesscontrol.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io.pipes/4.3.0/System.IO.Pipes.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.pipes/4.3.0/System.IO.Pipes.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.pipes/4.3.0/system.io.pipes.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io/4.1.0/System.IO.4.1.0.csproj
+++ b/src/referencePackages/src/system.io/4.1.0/System.IO.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io/4.1.0/system.io.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.io/4.3.0/System.IO.4.3.0.csproj
+++ b/src/referencePackages/src/system.io/4.3.0/System.IO.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io/4.3.0/system.io.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq.expressions/4.1.0/System.Linq.Expressions.4.1.0.csproj
+++ b/src/referencePackages/src/system.linq.expressions/4.1.0/System.Linq.Expressions.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.expressions/4.1.0/system.linq.expressions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq.expressions/4.3.0/System.Linq.Expressions.4.3.0.csproj
+++ b/src/referencePackages/src/system.linq.expressions/4.3.0/System.Linq.Expressions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.expressions/4.3.0/system.linq.expressions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq.parallel/4.0.1/System.Linq.Parallel.4.0.1.csproj
+++ b/src/referencePackages/src/system.linq.parallel/4.0.1/System.Linq.Parallel.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.parallel/4.0.1/system.linq.parallel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq.queryable/4.3.0/System.Linq.Queryable.4.3.0.csproj
+++ b/src/referencePackages/src/system.linq.queryable/4.3.0/System.Linq.Queryable.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.queryable/4.3.0/system.linq.queryable.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq/4.1.0/System.Linq.4.1.0.csproj
+++ b/src/referencePackages/src/system.linq/4.1.0/System.Linq.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq/4.1.0/system.linq.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.linq/4.3.0/System.Linq.4.3.0.csproj
+++ b/src/referencePackages/src/system.linq/4.3.0/System.Linq.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq/4.3.0/system.linq.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.5.1/System.Memory.4.5.1.csproj
+++ b/src/referencePackages/src/system.memory/4.5.1/System.Memory.4.5.1.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.1/system.memory.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.5.2/System.Memory.4.5.2.csproj
+++ b/src/referencePackages/src/system.memory/4.5.2/System.Memory.4.5.2.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.2/system.memory.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.5.3/System.Memory.4.5.3.csproj
+++ b/src/referencePackages/src/system.memory/4.5.3/System.Memory.4.5.3.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.3/system.memory.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
+++ b/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.4/system.memory.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.http/4.1.0/System.Net.Http.4.1.0.csproj
+++ b/src/referencePackages/src/system.net.http/4.1.0/System.Net.Http.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.1.0/system.net.http.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.http/4.3.0/System.Net.Http.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.0/System.Net.Http.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.0/system.net.http.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.http/4.3.2/System.Net.Http.4.3.2.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.2/System.Net.Http.4.3.2.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.2/system.net.http.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.http/4.3.3/System.Net.Http.4.3.3.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.3/System.Net.Http.4.3.3.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.3/system.net.http.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.http/4.3.4/System.Net.Http.4.3.4.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.4/System.Net.Http.4.3.4.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.4/system.net.http.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.primitives/4.0.11/System.Net.Primitives.4.0.11.csproj
+++ b/src/referencePackages/src/system.net.primitives/4.0.11/System.Net.Primitives.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.primitives/4.0.11/system.net.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.primitives/4.3.0/System.Net.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.primitives/4.3.0/System.Net.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.primitives/4.3.0/system.net.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.requests/4.0.11/System.Net.Requests.4.0.11.csproj
+++ b/src/referencePackages/src/system.net.requests/4.0.11/System.Net.Requests.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.requests/4.0.11/system.net.requests.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.requests/4.3.0/System.Net.Requests.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.requests/4.3.0/System.Net.Requests.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.requests/4.3.0/system.net.requests.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.security/4.3.0/System.Net.Security.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.security/4.3.0/System.Net.Security.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.security/4.3.0/system.net.security.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.sockets/4.1.0/System.Net.Sockets.4.1.0.csproj
+++ b/src/referencePackages/src/system.net.sockets/4.1.0/System.Net.Sockets.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.sockets/4.1.0/system.net.sockets.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.sockets/4.3.0/System.Net.Sockets.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.sockets/4.3.0/System.Net.Sockets.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.sockets/4.3.0/system.net.sockets.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.webheadercollection/4.0.1/System.Net.WebHeaderCollection.4.0.1.csproj
+++ b/src/referencePackages/src/system.net.webheadercollection/4.0.1/System.Net.WebHeaderCollection.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.webheadercollection/4.0.1/system.net.webheadercollection.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.net.webheadercollection/4.3.0/System.Net.WebHeaderCollection.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.webheadercollection/4.3.0/System.Net.WebHeaderCollection.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.webheadercollection/4.3.0/system.net.webheadercollection.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.numerics.vectors/4.4.0/system.numerics.vectors.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net45;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.numerics.vectors/4.5.0/system.numerics.vectors.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.objectmodel/4.0.12/System.ObjectModel.4.0.12.csproj
+++ b/src/referencePackages/src/system.objectmodel/4.0.12/System.ObjectModel.4.0.12.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.objectmodel/4.0.12/system.objectmodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.objectmodel/4.3.0/System.ObjectModel.4.3.0.csproj
+++ b/src/referencePackages/src/system.objectmodel/4.3.0/System.ObjectModel.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.objectmodel/4.3.0/system.objectmodel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.private.datacontractserialization/4.1.1/System.Private.DataContractSerialization.4.1.1.csproj
+++ b/src/referencePackages/src/system.private.datacontractserialization/4.1.1/System.Private.DataContractSerialization.4.1.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.private.datacontractserialization/4.1.1/system.private.datacontractserialization.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.3.0/System.Reflection.Emit.ILGeneration.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.3.0/System.Reflection.Emit.ILGeneration.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.ilgeneration/4.3.0/system.reflection.emit.ilgeneration.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.3.0/System.Reflection.Emit.Lightweight.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.3.0/System.Reflection.Emit.Lightweight.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit/4.0.1/system.reflection.emit.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.emit/4.3.0/System.Reflection.Emit.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.3.0/System.Reflection.Emit.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit/4.3.0/system.reflection.emit.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.extensions/4.0.1/System.Reflection.Extensions.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.extensions/4.0.1/System.Reflection.Extensions.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.extensions/4.0.1/system.reflection.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.extensions/4.3.0/System.Reflection.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.extensions/4.3.0/System.Reflection.Extensions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.extensions/4.3.0/system.reflection.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.3.0/System.Reflection.Metadata.1.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.3.0/System.Reflection.Metadata.1.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.3.0/system.reflection.metadata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.4.1/System.Reflection.Metadata.1.4.1.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.4.1/System.Reflection.Metadata.1.4.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.4.1/system.reflection.metadata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.4.2/System.Reflection.Metadata.1.4.2.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.4.2/System.Reflection.Metadata.1.4.2.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.4.2/system.reflection.metadata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.5.0/System.Reflection.Metadata.1.5.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.5.0/System.Reflection.Metadata.1.5.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.5.0/system.reflection.metadata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.6.0/System.Reflection.Metadata.1.6.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.6.0/System.Reflection.Metadata.1.6.0.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.6.0/system.reflection.metadata.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadata/1.8.1/System.Reflection.Metadata.1.8.1.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.8.1/System.Reflection.Metadata.1.8.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.8.1/system.reflection.metadata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.primitives/4.0.1/System.Reflection.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.primitives/4.0.1/System.Reflection.Primitives.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.primitives/4.0.1/system.reflection.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.primitives/4.3.0/System.Reflection.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.primitives/4.3.0/System.Reflection.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.primitives/4.3.0/system.reflection.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.1.0/System.Reflection.TypeExtensions.4.1.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.1.0/System.Reflection.TypeExtensions.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.3.0/System.Reflection.TypeExtensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.3.0/System.Reflection.TypeExtensions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.typeextensions/4.3.0/system.reflection.typeextensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection/4.1.0/System.Reflection.4.1.0.csproj
+++ b/src/referencePackages/src/system.reflection/4.1.0/System.Reflection.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection/4.1.0/system.reflection.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.reflection/4.3.0/System.Reflection.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection/4.3.0/System.Reflection.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection/4.3.0/system.reflection.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.resources.reader/4.0.0/System.Resources.Reader.4.0.0.csproj
+++ b/src/referencePackages/src/system.resources.reader/4.0.0/System.Resources.Reader.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.reader/4.0.0/system.resources.reader.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.resources.resourcemanager/4.0.1/System.Resources.ResourceManager.4.0.1.csproj
+++ b/src/referencePackages/src/system.resources.resourcemanager/4.0.1/System.Resources.ResourceManager.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.resources.resourcemanager/4.3.0/System.Resources.ResourceManager.4.3.0.csproj
+++ b/src/referencePackages/src/system.resources.resourcemanager/4.3.0/System.Resources.ResourceManager.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.resourcemanager/4.3.0/system.resources.resourcemanager.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.resources.writer/4.0.0/System.Resources.Writer.4.0.0.csproj
+++ b/src/referencePackages/src/system.resources.writer/4.0.0/System.Resources.Writer.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.writer/4.0.0/system.resources.writer.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.3/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.1/System.Runtime.CompilerServices.Unsafe.4.7.1.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.1/System.Runtime.CompilerServices.Unsafe.4.7.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.7.1/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.extensions/4.1.0/System.Runtime.Extensions.4.1.0.csproj
+++ b/src/referencePackages/src/system.runtime.extensions/4.1.0/System.Runtime.Extensions.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.extensions/4.1.0/system.runtime.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.extensions/4.3.0/System.Runtime.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.extensions/4.3.0/System.Runtime.Extensions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.extensions/4.3.0/system.runtime.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.handles/4.0.1/System.Runtime.Handles.4.0.1.csproj
+++ b/src/referencePackages/src/system.runtime.handles/4.0.1/System.Runtime.Handles.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.handles/4.0.1/system.runtime.handles.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.handles/4.3.0/System.Runtime.Handles.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.handles/4.3.0/System.Runtime.Handles.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.handles/4.3.0/system.runtime.handles.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.0.0/System.Runtime.InteropServices.RuntimeInformation.4.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.0.0/System.Runtime.InteropServices.RuntimeInformation.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.3.0/System.Runtime.InteropServices.RuntimeInformation.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.3.0/System.Runtime.InteropServices.RuntimeInformation.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.interopservices/4.1.0/System.Runtime.InteropServices.4.1.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices/4.1.0/System.Runtime.InteropServices.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices/4.1.0/system.runtime.interopservices.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices/4.3.0/system.runtime.interopservices.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.loader/4.0.0/System.Runtime.Loader.4.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.loader/4.0.0/System.Runtime.Loader.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.loader/4.0.0/system.runtime.loader.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.loader/4.3.0/System.Runtime.Loader.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.loader/4.3.0/System.Runtime.Loader.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.loader/4.3.0/system.runtime.loader.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.numerics/4.0.1/System.Runtime.Numerics.4.0.1.csproj
+++ b/src/referencePackages/src/system.runtime.numerics/4.0.1/System.Runtime.Numerics.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.numerics/4.0.1/system.runtime.numerics.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.numerics/4.3.0/System.Runtime.Numerics.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.numerics/4.3.0/System.Runtime.Numerics.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.numerics/4.3.0/system.runtime.numerics.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.serialization.formatters/4.3.0/System.Runtime.Serialization.Formatters.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.formatters/4.3.0/System.Runtime.Serialization.Formatters.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46;netstandard1.4</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.formatters/4.3.0/system.runtime.serialization.formatters.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.serialization.json/4.0.2/System.Runtime.Serialization.Json.4.0.2.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.json/4.0.2/System.Runtime.Serialization.Json.4.0.2.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.json/4.0.2/system.runtime.serialization.json.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.serialization.primitives/4.1.1/System.Runtime.Serialization.Primitives.4.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.primitives/4.1.1/System.Runtime.Serialization.Primitives.4.1.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.serialization.primitives/4.3.0/System.Runtime.Serialization.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.primitives/4.3.0/System.Runtime.Serialization.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime.serialization.xml/4.1.1/System.Runtime.Serialization.Xml.4.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.xml/4.1.1/System.Runtime.Serialization.Xml.4.1.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.xml/4.1.1/system.runtime.serialization.xml.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.runtime/4.1.0/System.Runtime.4.1.0.csproj
+++ b/src/referencePackages/src/system.runtime/4.1.0/System.Runtime.4.1.0.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <ItemGroup>

--- a/src/referencePackages/src/system.runtime/4.3.0/System.Runtime.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime/4.3.0/System.Runtime.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime/4.3.0/system.runtime.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.accesscontrol/4.3.0/System.Security.AccessControl.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/4.3.0/System.Security.AccessControl.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.accesscontrol/4.3.0/system.security.accesscontrol.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.claims/4.0.1/System.Security.Claims.4.0.1.csproj
+++ b/src/referencePackages/src/system.security.claims/4.0.1/System.Security.Claims.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.claims/4.0.1/system.security.claims.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.claims/4.3.0/System.Security.Claims.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.claims/4.3.0/System.Security.Claims.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.claims/4.3.0/system.security.claims.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.2.0/System.Security.Cryptography.Algorithms.4.2.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.2.0/System.Security.Cryptography.Algorithms.4.2.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.algorithms/4.2.0/system.security.cryptography.algorithms.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.0/System.Security.Cryptography.Algorithms.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.0/System.Security.Cryptography.Algorithms.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.cng/4.2.0/System.Security.Cryptography.Cng.4.2.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/4.2.0/System.Security.Cryptography.Cng.4.2.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.cng/4.2.0/system.security.cryptography.cng.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.cng/4.3.0/System.Security.Cryptography.Cng.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/4.3.0/System.Security.Cryptography.Cng.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.cng/4.5.0/System.Security.Cryptography.Cng.4.5.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/4.5.0/System.Security.Cryptography.Cng.4.5.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;netstandard2.0;net46;net461;net462;net47</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.cng/4.5.0/system.security.cryptography.cng.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.csp/4.0.0/System.Security.Cryptography.Csp.4.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.csp/4.0.0/System.Security.Cryptography.Csp.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.csp/4.0.0/system.security.cryptography.csp.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.csp/4.3.0/System.Security.Cryptography.Csp.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.csp/4.3.0/System.Security.Cryptography.Csp.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.encoding/4.0.0/System.Security.Cryptography.Encoding.4.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.encoding/4.0.0/System.Security.Cryptography.Encoding.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.encoding/4.0.0/system.security.cryptography.encoding.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.encoding/4.3.0/System.Security.Cryptography.Encoding.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.encoding/4.3.0/System.Security.Cryptography.Encoding.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.0.0/System.Security.Cryptography.OpenSsl.4.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.0.0/System.Security.Cryptography.OpenSsl.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.0.0/system.security.cryptography.openssl.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.5.0/System.Security.Cryptography.OpenSsl.4.5.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.5.0/System.Security.Cryptography.OpenSsl.4.5.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.5.0/system.security.cryptography.openssl.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.5.1/System.Security.Cryptography.OpenSsl.4.5.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.5.1/System.Security.Cryptography.OpenSsl.4.5.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.5.1/system.security.cryptography.openssl.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.5.0/System.Security.Cryptography.Pkcs.4.5.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.5.0/System.Security.Cryptography.Pkcs.4.5.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.pkcs/4.5.0/system.security.cryptography.pkcs.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.5.2/System.Security.Cryptography.Pkcs.4.5.2.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.5.2/System.Security.Cryptography.Pkcs.4.5.2.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.pkcs/4.5.2/system.security.cryptography.pkcs.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.primitives/4.0.0/System.Security.Cryptography.Primitives.4.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.primitives/4.0.0/System.Security.Cryptography.Primitives.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.primitives/4.0.0/system.security.cryptography.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/System.Security.Cryptography.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/System.Security.Cryptography.Primitives.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.3.0/System.Security.Cryptography.ProtectedData.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.3.0/System.Security.Cryptography.ProtectedData.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.protecteddata/4.3.0/system.security.cryptography.protecteddata.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.x509certificates/4.1.0/System.Security.Cryptography.X509Certificates.4.1.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.x509certificates/4.1.0/System.Security.Cryptography.X509Certificates.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.x509certificates/4.1.0/system.security.cryptography.x509certificates.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.x509certificates/4.3.0/System.Security.Cryptography.X509Certificates.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.x509certificates/4.3.0/System.Security.Cryptography.X509Certificates.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.principal.windows/4.0.0/System.Security.Principal.Windows.4.0.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/4.0.0/System.Security.Principal.Windows.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal.windows/4.0.0/system.security.principal.windows.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.principal.windows/4.3.0/System.Security.Principal.Windows.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/4.3.0/System.Security.Principal.Windows.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal.windows/4.3.0/system.security.principal.windows.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.principal/4.0.1/System.Security.Principal.4.0.1.csproj
+++ b/src/referencePackages/src/system.security.principal/4.0.1/System.Security.Principal.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal/4.0.1/system.security.principal.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.security.principal/4.3.0/System.Security.Principal.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.principal/4.3.0/System.Security.Principal.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal/4.3.0/system.security.principal.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.0.1/System.Text.Encoding.CodePages.4.0.1.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.0.1/System.Text.Encoding.CodePages.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.3.0/System.Text.Encoding.CodePages.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.3.0/System.Text.Encoding.CodePages.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.codepages/4.3.0/system.text.encoding.codepages.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.4.0/System.Text.Encoding.CodePages.4.4.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.4.0/System.Text.Encoding.CodePages.4.4.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.codepages/4.4.0/system.text.encoding.codepages.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding.extensions/4.0.11/System.Text.Encoding.Extensions.4.0.11.csproj
+++ b/src/referencePackages/src/system.text.encoding.extensions/4.0.11/System.Text.Encoding.Extensions.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding.extensions/4.3.0/System.Text.Encoding.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.extensions/4.3.0/System.Text.Encoding.Extensions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding/4.0.11/System.Text.Encoding.4.0.11.csproj
+++ b/src/referencePackages/src/system.text.encoding/4.0.11/System.Text.Encoding.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding/4.0.11/system.text.encoding.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.encoding/4.3.0/System.Text.Encoding.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.encoding/4.3.0/System.Text.Encoding.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding/4.3.0/system.text.encoding.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.regularexpressions/4.1.0/System.Text.RegularExpressions.4.1.0.csproj
+++ b/src/referencePackages/src/system.text.regularexpressions/4.1.0/System.Text.RegularExpressions.4.1.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.regularexpressions/4.1.0/system.text.regularexpressions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.text.regularexpressions/4.3.0/System.Text.RegularExpressions.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.regularexpressions/4.3.0/System.Text.RegularExpressions.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.regularexpressions/4.3.0/system.text.regularexpressions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.overlapped/4.3.0/System.Threading.Overlapped.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.overlapped/4.3.0/System.Threading.Overlapped.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.overlapped/4.3.0/system.threading.overlapped.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/4.6.0/System.Threading.Tasks.Dataflow.4.6.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/4.6.0/System.Threading.Tasks.Dataflow.4.6.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.dataflow/4.6.0/system.threading.tasks.dataflow.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/4.9.0/System.Threading.Tasks.Dataflow.4.9.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/4.9.0/System.Threading.Tasks.Dataflow.4.9.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.dataflow/4.9.0/system.threading.tasks.dataflow.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.0.0/System.Threading.Tasks.Extensions.4.0.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.0.0/System.Threading.Tasks.Extensions.4.0.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.3.0/System.Threading.Tasks.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.3.0/System.Threading.Tasks.Extensions.4.3.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.1/System.Threading.Tasks.Extensions.4.5.1.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.1/System.Threading.Tasks.Extensions.4.5.1.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.5.1/system.threading.tasks.extensions.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.2/System.Threading.Tasks.Extensions.4.5.2.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.2/System.Threading.Tasks.Extensions.4.5.2.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.5.2/system.threading.tasks.extensions.nuspec</NuspecFile>
     <LangVersion>7.2</LangVersion>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.3/System.Threading.Tasks.Extensions.4.5.3.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.3/System.Threading.Tasks.Extensions.4.5.3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.5.3/system.threading.tasks.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/System.Threading.Tasks.Parallel.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/System.Threading.Tasks.Parallel.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.parallel/4.3.0/system.threading.tasks.parallel.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks/4.0.11/System.Threading.Tasks.4.0.11.csproj
+++ b/src/referencePackages/src/system.threading.tasks/4.0.11/System.Threading.Tasks.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks/4.0.11/system.threading.tasks.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks/4.3.0/System.Threading.Tasks.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks/4.3.0/System.Threading.Tasks.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks/4.3.0/system.threading.tasks.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.thread/4.0.0/System.Threading.Thread.4.0.0.csproj
+++ b/src/referencePackages/src/system.threading.thread/4.0.0/System.Threading.Thread.4.0.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.thread/4.0.0/system.threading.thread.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.thread/4.3.0/System.Threading.Thread.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.thread/4.3.0/System.Threading.Thread.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.thread/4.3.0/system.threading.thread.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.threadpool/4.0.10/System.Threading.ThreadPool.4.0.10.csproj
+++ b/src/referencePackages/src/system.threading.threadpool/4.0.10/System.Threading.ThreadPool.4.0.10.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.threadpool/4.0.10/system.threading.threadpool.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.threadpool/4.3.0/System.Threading.ThreadPool.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.threadpool/4.3.0/System.Threading.ThreadPool.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.threadpool/4.3.0/system.threading.threadpool.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.timer/4.0.1/System.Threading.Timer.4.0.1.csproj
+++ b/src/referencePackages/src/system.threading.timer/4.0.1/System.Threading.Timer.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.timer/4.0.1/system.threading.timer.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading.timer/4.3.0/System.Threading.Timer.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.timer/4.3.0/System.Threading.Timer.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.timer/4.3.0/system.threading.timer.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj
+++ b/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading/4.0.11/system.threading.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.threading/4.3.0/System.Threading.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading/4.3.0/System.Threading.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading/4.3.0/system.threading.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.valuetuple/4.4.0/System.ValueTuple.4.4.0.csproj
+++ b/src/referencePackages/src/system.valuetuple/4.4.0/System.ValueTuple.4.4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;net47;netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.valuetuple/4.4.0/system.valuetuple.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.readerwriter/4.0.11/system.xml.readerwriter.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.readerwriter/4.3.0/System.Xml.ReaderWriter.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.readerwriter/4.3.0/System.Xml.ReaderWriter.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.readerwriter/4.3.0/system.xml.readerwriter.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xdocument/4.0.11/System.Xml.XDocument.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.xdocument/4.0.11/System.Xml.XDocument.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xdocument/4.0.11/system.xml.xdocument.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xdocument/4.3.0/System.Xml.XDocument.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xdocument/4.3.0/System.Xml.XDocument.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xdocument/4.3.0/system.xml.xdocument.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xmldocument/4.0.1/System.Xml.XmlDocument.4.0.1.csproj
+++ b/src/referencePackages/src/system.xml.xmldocument/4.0.1/System.Xml.XmlDocument.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmldocument/4.0.1/system.xml.xmldocument.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xmldocument/4.3.0/System.Xml.XmlDocument.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xmldocument/4.3.0/System.Xml.XmlDocument.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmldocument/4.3.0/system.xml.xmldocument.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xmlserializer/4.0.11/System.Xml.XmlSerializer.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.xmlserializer/4.0.11/System.Xml.XmlSerializer.4.0.11.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmlserializer/4.0.11/system.xml.xmlserializer.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xpath.xdocument/4.3.0/System.Xml.XPath.XDocument.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xpath.xdocument/4.3.0/System.Xml.XPath.XDocument.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xpath.xdocument/4.3.0/system.xml.xpath.xdocument.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xpath/4.0.1/System.Xml.XPath.4.0.1.csproj
+++ b/src/referencePackages/src/system.xml.xpath/4.0.1/System.Xml.XPath.4.0.1.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xpath/4.0.1/system.xml.xpath.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/src/system.xml.xpath/4.3.0/System.Xml.XPath.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xpath/4.3.0/System.Xml.XPath.4.3.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xpath/4.3.0/system.xml.xpath.nuspec</NuspecFile>
-    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
    </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The projects currently use lines like `<AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>` to set the key to use for strong-name signing. This seems to conflict with the Arcade configuration method, which looks like this:

```
    <When Condition="'$(StrongNameKeyId)' == 'Microsoft'">
      <PropertyGroup>
        <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)snk/MSFT.snk</AssemblyOriginatorKeyFile>
        <PublicKey>$(MicrosoftPublicKey)</PublicKey>
        <PublicKeyToken>b03f5f7f11d50a3a</PublicKeyToken>
      </PropertyGroup>
    </When>
```

The result is that the dev branch is building assemblies with the wrong PublicKeyToken. This gets caught when trying to build with bootstrap flow using intermediate nupkgs:

1. On compile phase 1, `NuGet.LibraryModel` compiles using `Microsoft` key against prebuilts from NuGet.org that use `Shared` key in their identities. This means the intermediate nupkg contains a set of DLLs where the identity is `Microsoft` with references to `Shared` identities. This already won't work if used: the output doesn't fulfill its own references.

2. On compile phase 2, `NuGet.LibraryModel` compiles using `Microsoft` key against source-built DLLs with `Microsoft` identities and references to `Shared` identities. `Csc` fails with `CS0012` failing to load:

    ```
    Errors
        lib/netstandard2.0/NuGet.Commands.cs(1002,63): error CS0012: The type 'LibraryIdentity' is defined in an assembly that is not referenced. You must add a reference to assembly 'NuGet.LibraryModel, Version=5.1.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. [/work/artifacts/source-build/self/src/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj]
        lib/netstandard2.0/NuGet.Commands.cs(1002,63): error CS0012: The type 'NuGetVersion' is defined in an assembly that is not referenced. You must add a reference to assembly 'NuGet.Versioning, Version=5.1.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. [/work/artifacts/source-build/self/src/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj]
        lib/netstandard2.0/NuGet.Commands.cs(1002,63): error CS0012: The type 'LibraryDependencyInfo' is defined in an assembly that is not referenced. You must add a reference to assembly 'NuGet.LibraryModel, Version=5.1.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. [/work/artifacts/source-build/self/src/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj]
        lib/netstandard2.0/NuGet.Commands.cs(1002,63): error CS0012: The type 'IPackageDownloader' is defined in an assembly that is not referenced. You must add a reference to assembly 'NuGet.Packaging, Version=5.1.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. [/work/artifacts/source-build/self/src/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj]
        lib/netstandard2.0/NuGet.Commands.cs(1002,63): error CS0012: The type 'PackageSource' is defined in an assembly that is not referenced. You must add a reference to assembly 'NuGet.Configuration, Version=5.1.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. [/work/artifacts/source-build/self/src/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj]
    ```

I think that I need to rebuild SBRP with this change to generate new intermediate nupkgs that I can use to get further in the sort-of-bootstrapping work I'm doing now.

I've separated this into one commit per global find-replace. (It touches one line in basically every reference package `csproj`.)