### PR TITLE
Add info about 'pre-arcade'; fix license sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # .NET Source-build Reference Packages
 
-This repository contains source and build scripts for source-buildable reference versions of historical .NET Core packages that are referenced by the [source-build](https://github.com/dotnet/source-build) repo.  These are used only when building the source-build repo.
+This repository contains source and build scripts for source-buildable reference versions of historical .NET Core packages that are referenced by the [source-build] repo.  These are used only when building the source-build repo.
+
+## The `pre-arcade` branch
+
+This branch doesn't implement [arcade-powered source-build]. Instead, it
+generates outputs that are used indirectly by [source-build]. The outputs are
+either downloaded as `tar.gz` files from Microsoft, or consumed from a specialty
+distro package built separately from the rest of source-build.
+
+`pre-arcade` is maintained for [source-build] branches still using the
+pre-arcade approach.
 
 ### Continuous builds
 
@@ -16,4 +26,8 @@ the repo. This repo doesn't change often, making a cache particularly useful.
 
 ## License
 
-This repo is licensed with [MIT](LICENSE.txt).
+This repo is licensed under the [MIT](LICENSE.txt) license.
+
+
+[source-build]: https://github.com/dotnet/source-build
+[arcade-powered source-build]: https://github.com/dotnet/source-build/tree/release/3.1/Documentation/planning/arcade-powered-source-build


### PR DESCRIPTION
* Adds info about the `pre-arcade` branch. `release/3.1` doesn't really describe what we're maintaining here and the new name represents it better. (We will be adding 5.0 reference assemblies for some short-term work on 5.0 and probably prebuilt reduction.)
* Fixes `This repo is licensed with MIT` to `This repo is licensed under the MIT license` to match source-build and other repos and be less open to odd interpretations.