### PR TITLE
Update version to 6.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
 
   <PropertyGroup>
-    <MajorVersion>5</MajorVersion>
+    <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
Earlier today, the `master` branch default channel assignment was changed from `.NET 5 Dev` -> `.NET 6 Dev` because the 5.0 release is forking now. We should produce 6.0 packages, to match.

Normally we would create a `release/5.0` branch off `master` just before making this change, for 5.0 servicing work. I'm opting not to at the moment, because `master` isn't actually used by anything yet and needs some work for arcade-powered source-build. By branching `release/5.0` a bit later we can avoid doing tedious cherry-picks from `master` -> `release/5.0` in the meantime.

So far it looks like we can expect the overall branching strategy for 5.0 to go like this:

* `release/5.0` = rc 1 until rc 1 ships
* `release/5.0-rc2` = rc 2, branched off `release/5.0`
* `release/5.0` = brand rtm after rc 1 ships

