### PR TITLE
Add System.Composition.* 1.3.0 packages

### DIFF
--- a/src/referencePackages/src/ProjectsToBuild.props
+++ b/src/referencePackages/src/ProjectsToBuild.props
@@ -256,5 +256,10 @@
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)microsoft.build.utilities.core/16.6.0/Microsoft.Build.Utilities.Core.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.text.encoding.codepages/4.5.1/System.Text.Encoding.CodePages.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)microsoft.build/16.6.0/Microsoft.Build.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.composition.runtime/1.3.0/System.Composition.Runtime.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.composition.attributedmodel/1.3.0/System.Composition.AttributedModel.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.composition.convention/1.3.0/System.Composition.Convention.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.composition.hosting/1.3.0/System.Composition.Hosting.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.composition.typedparts/1.3.0/System.Composition.TypedParts.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/referencePackages/src/system.composition.attributedmodel/1.3.0/System.Composition.AttributedModel.csproj
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.3.0/System.Composition.AttributedModel.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.composition.attributedmodel/1.3.0/system.composition.attributedmodel.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.composition.attributedmodel/1.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.composition.attributedmodel/1.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.attributedmodel/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.attributedmodel/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.composition.attributedmodel/1.3.0/lib/netstandard1.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.3.0/lib/netstandard1.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: AssemblyDescription("System.Composition.AttributedModel")]
+[assembly: AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26515.06")]
+[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.33.0")]
+
+
+
+
+namespace System.Composition
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Property, AllowMultiple=true, Inherited=false)]
+    public partial class ExportAttribute : System.Attribute
+    {
+        public ExportAttribute() { }
+        public ExportAttribute(string contractName) { }
+        public ExportAttribute(string contractName, System.Type contractType) { }
+        public ExportAttribute(System.Type contractType) { }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.Property, AllowMultiple=true, Inherited=false)]
+    public sealed partial class ExportMetadataAttribute : System.Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    public partial class ImportAttribute : System.Attribute
+    {
+        public ImportAttribute() { }
+        public ImportAttribute(string contractName) { }
+        public bool AllowDefault { get { throw null; } set { } }
+        public string ContractName { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Constructor, AllowMultiple=false, Inherited=false)]
+    public sealed partial class ImportingConstructorAttribute : System.Attribute
+    {
+        public ImportingConstructorAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    public partial class ImportManyAttribute : System.Attribute
+    {
+        public ImportManyAttribute() { }
+        public ImportManyAttribute(string contractName) { }
+        public string ContractName { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, Inherited=false)]
+    public sealed partial class ImportMetadataConstraintAttribute : System.Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed partial class MetadataAttributeAttribute : System.Attribute
+    {
+        public MetadataAttributeAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
+    public sealed partial class OnImportsSatisfiedAttribute : System.Attribute
+    {
+        public OnImportsSatisfiedAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public partial class PartMetadataAttribute : System.Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed partial class PartNotDiscoverableAttribute : System.Attribute
+    {
+        public PartNotDiscoverableAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
+    public partial class SharedAttribute : System.Composition.PartMetadataAttribute
+    {
+        public SharedAttribute() : base (default(string), default(object)) { }
+        public SharedAttribute(string sharingBoundaryName) : base (default(string), default(object)) { }
+        public string SharingBoundary { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, Inherited=false)]
+    [System.CLSCompliantAttribute(false)]
+    [System.Composition.MetadataAttributeAttribute]
+    public sealed partial class SharingBoundaryAttribute : System.Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        protected AttributedModelProvider() { }
+        public abstract System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.MemberInfo member);
+        public abstract System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/1.3.0/lib/netstandard2.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.3.0/lib/netstandard2.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: AssemblyDescription("System.Composition.AttributedModel")]
+[assembly: AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.46214")]
+[assembly: AssemblyInformationalVersion("4.700.19.46214 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.34.0")]
+
+
+
+
+namespace System.Composition
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Property, AllowMultiple=true, Inherited=false)]
+    public partial class ExportAttribute : System.Attribute
+    {
+        public ExportAttribute() { }
+        public ExportAttribute(string contractName) { }
+        public ExportAttribute(string contractName, System.Type contractType) { }
+        public ExportAttribute(System.Type contractType) { }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.Property, AllowMultiple=true, Inherited=false)]
+    public sealed partial class ExportMetadataAttribute : System.Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    public partial class ImportAttribute : System.Attribute
+    {
+        public ImportAttribute() { }
+        public ImportAttribute(string contractName) { }
+        public bool AllowDefault { get { throw null; } set { } }
+        public string ContractName { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Constructor, AllowMultiple=false, Inherited=false)]
+    public sealed partial class ImportingConstructorAttribute : System.Attribute
+    {
+        public ImportingConstructorAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false, Inherited=false)]
+    public partial class ImportManyAttribute : System.Attribute
+    {
+        public ImportManyAttribute() { }
+        public ImportManyAttribute(string contractName) { }
+        public string ContractName { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, Inherited=false)]
+    public sealed partial class ImportMetadataConstraintAttribute : System.Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
+    public sealed partial class MetadataAttributeAttribute : System.Attribute
+    {
+        public MetadataAttributeAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
+    public sealed partial class OnImportsSatisfiedAttribute : System.Attribute
+    {
+        public OnImportsSatisfiedAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public partial class PartMetadataAttribute : System.Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+        public string Name { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public sealed partial class PartNotDiscoverableAttribute : System.Attribute
+    {
+        public PartNotDiscoverableAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=false)]
+    public partial class SharedAttribute : System.Composition.PartMetadataAttribute
+    {
+        public SharedAttribute() : base (default(string), default(object)) { }
+        public SharedAttribute(string sharingBoundaryName) : base (default(string), default(object)) { }
+        public string SharingBoundary { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter | System.AttributeTargets.Property, Inherited=false)]
+    [System.CLSCompliantAttribute(false)]
+    [System.Composition.MetadataAttributeAttribute]
+    public sealed partial class SharingBoundaryAttribute : System.Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        protected AttributedModelProvider() { }
+        public abstract System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.MemberInfo member);
+        public abstract System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/1.3.0/system.composition.attributedmodel.nuspec
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.3.0/system.composition.attributedmodel.nuspec
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Composition.AttributedModel</id>
+    <version>1.3.0</version>
+    <title>System.Composition.AttributedModel</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides common attributes used by System.Composition types.
+
+Commonly Used Types:
+System.Composition.ExportAttribute
+System.Composition.ImportAttribute
+System.Composition.Convention.AttributedModelProvider
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5" />
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework=".NETPortable4.5-Profile259" />
+      <group targetFramework="Windows8.0" />
+      <group targetFramework="WindowsPhone8.0" />
+      <group targetFramework="WindowsPhoneApp8.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.convention/1.3.0/System.Composition.Convention.csproj
+++ b/src/referencePackages/src/system.composition.convention/1.3.0/System.Composition.Convention.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.composition.convention/1.3.0/system.composition.convention.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.composition.convention/1.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.composition.convention/1.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.convention/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.convention/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.AttributedModel" Version="1.3.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.AttributedModel" Version="1.3.0" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.composition.convention/1.3.0/lib/netstandard1.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/1.3.0/lib/netstandard1.0/System.Composition.Convention.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Convention")]
+[assembly: AssemblyDescription("System.Composition.Convention")]
+[assembly: AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26515.06")]
+[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.33.0")]
+
+
+
+
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : System.Composition.Convention.AttributedModelProvider
+    {
+        public ConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder ForType(System.Type type) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ForTypesDerivedFrom(System.Type type) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ForTypesMatching(System.Predicate<System.Type> typeFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForTypesMatching<T>(System.Predicate<System.Type> typeFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForType<T>() { throw null; }
+        public override System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.MemberInfo member) { throw null; }
+        public override System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.ParameterInfo parameter) { throw null; }
+    }
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+        public System.Composition.Convention.ExportConventionBuilder AddMetadata(string name, System.Func<System.Type, object> getValueFromPartType) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractName(System.Func<System.Type, string> getContractNameFromPartType) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractName(string contractName) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractType(System.Type type) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+        public System.Composition.Convention.ImportConventionBuilder AddMetadataConstraint(string name, System.Func<System.Type, object> getConstraintValueFromPartType) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AllowDefault() { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsContractName(System.Func<System.Type, string> getContractNameFromPartType) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsContractName(string contractName) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsMany() { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+        public T Import<T>() { throw null; }
+        public T Import<T>(System.Action<System.Composition.Convention.ImportConventionBuilder> configure) { throw null; }
+    }
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder AddPartMetadata(string name, System.Func<System.Type, object> getValueFromPartType) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export(System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces(System.Predicate<System.Type> interfaceFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces(System.Predicate<System.Type> interfaceFilter, System.Action<System.Type, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export<T>() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export<T>(System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder NotifyImportsSatisfied(System.Predicate<System.Reflection.MethodInfo> methodFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder SelectConstructor(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo>, System.Reflection.ConstructorInfo> constructorSelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder SelectConstructor(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo>, System.Reflection.ConstructorInfo> constructorSelector, System.Action<System.Reflection.ParameterInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Shared() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+    public partial class PartConventionBuilder<T> : System.Composition.Convention.PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> NotifyImportsSatisfied(System.Linq.Expressions.Expression<System.Action<T>> methodSelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> SelectConstructor(System.Linq.Expressions.Expression<System.Func<System.Composition.Convention.ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/1.3.0/lib/netstandard2.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/1.3.0/lib/netstandard2.0/System.Composition.Convention.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Convention")]
+[assembly: AssemblyDescription("System.Composition.Convention")]
+[assembly: AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.46214")]
+[assembly: AssemblyInformationalVersion("4.700.19.46214 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.34.0")]
+
+
+
+
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : System.Composition.Convention.AttributedModelProvider
+    {
+        public ConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder ForType(System.Type type) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ForTypesDerivedFrom(System.Type type) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ForTypesMatching(System.Predicate<System.Type> typeFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForTypesMatching<T>(System.Predicate<System.Type> typeFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ForType<T>() { throw null; }
+        public override System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.MemberInfo member) { throw null; }
+        public override System.Collections.Generic.IEnumerable<System.Attribute> GetCustomAttributes(System.Type reflectedType, System.Reflection.ParameterInfo parameter) { throw null; }
+    }
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+        public System.Composition.Convention.ExportConventionBuilder AddMetadata(string name, System.Func<System.Type, object> getValueFromPartType) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractName(System.Func<System.Type, string> getContractNameFromPartType) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractName(string contractName) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractType(System.Type type) { throw null; }
+        public System.Composition.Convention.ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+        public System.Composition.Convention.ImportConventionBuilder AddMetadataConstraint(string name, System.Func<System.Type, object> getConstraintValueFromPartType) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AllowDefault() { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsContractName(System.Func<System.Type, string> getContractNameFromPartType) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsContractName(string contractName) { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsMany() { throw null; }
+        public System.Composition.Convention.ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+        public T Import<T>() { throw null; }
+        public T Import<T>(System.Action<System.Composition.Convention.ImportConventionBuilder> configure) { throw null; }
+    }
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder AddPartMetadata(string name, System.Func<System.Type, object> getValueFromPartType) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export(System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces(System.Predicate<System.Type> interfaceFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportInterfaces(System.Predicate<System.Type> interfaceFilter, System.Action<System.Type, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ExportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export<T>() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Export<T>(System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder ImportProperties<T>(System.Predicate<System.Reflection.PropertyInfo> propertyFilter, System.Action<System.Reflection.PropertyInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder NotifyImportsSatisfied(System.Predicate<System.Reflection.MethodInfo> methodFilter) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder SelectConstructor(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo>, System.Reflection.ConstructorInfo> constructorSelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder SelectConstructor(System.Func<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo>, System.Reflection.ConstructorInfo> constructorSelector, System.Action<System.Reflection.ParameterInfo, System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Shared() { throw null; }
+        public System.Composition.Convention.PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+    public partial class PartConventionBuilder<T> : System.Composition.Convention.PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ExportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ExportConventionBuilder> exportConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> ImportProperty<TContract>(System.Linq.Expressions.Expression<System.Func<T, object>> propertySelector, System.Action<System.Composition.Convention.ImportConventionBuilder> importConfiguration) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> NotifyImportsSatisfied(System.Linq.Expressions.Expression<System.Action<T>> methodSelector) { throw null; }
+        public System.Composition.Convention.PartConventionBuilder<T> SelectConstructor(System.Linq.Expressions.Expression<System.Func<System.Composition.Convention.ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/1.3.0/system.composition.convention.nuspec
+++ b/src/referencePackages/src/system.composition.convention/1.3.0/system.composition.convention.nuspec
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Composition.Convention</id>
+    <version>1.3.0</version>
+    <title>System.Composition.Convention</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides types that support using Managed Extensibility Framework with a convention-based configuration model.
+
+Commonly Used Types:
+System.Composition.Convention.ConventionBuilder
+System.Composition.Convention.ExportConventionBuilder
+System.Composition.Convention.ImportConventionBuilder
+System.Composition.Convention.PartConventionBuilder
+System.Composition.Convention.ParameterImportConventionBuilder
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile259">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework="UAP10.0.16299">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework="Windows8.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhone8.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhoneApp8.1">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.hosting/1.3.0/System.Composition.Hosting.csproj
+++ b/src/referencePackages/src/system.composition.hosting/1.3.0/System.Composition.Hosting.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.composition.hosting/1.3.0/system.composition.hosting.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.composition.hosting/1.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.composition.hosting/1.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.hosting/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.hosting/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.Runtime" Version="1.3.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.Runtime" Version="1.3.0" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.composition.hosting/1.3.0/lib/netstandard1.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/1.3.0/lib/netstandard1.0/System.Composition.Hosting.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Hosting")]
+[assembly: AssemblyDescription("System.Composition.Hosting")]
+[assembly: AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26515.06")]
+[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.33.0")]
+
+
+
+
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : System.Composition.CompositionContext, System.IDisposable
+    {
+        internal CompositionHost() { }
+        public static System.Composition.Hosting.CompositionHost CreateCompositionHost(System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorProvider> providers) { throw null; }
+        public static System.Composition.Hosting.CompositionHost CreateCompositionHost(params System.Composition.Hosting.Core.ExportDescriptorProvider[] providers) { throw null; }
+        public void Dispose() { }
+        public override bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(System.Composition.Hosting.Core.LifetimeContext context, System.Composition.Hosting.Core.CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+        public System.Composition.Hosting.Core.CompositionContract Contract { get { throw null; } }
+        public bool IsPrerequisite { get { throw null; } }
+        public object Site { get { throw null; } }
+        public System.Composition.Hosting.Core.ExportDescriptorPromise Target { get { throw null; } }
+        public static System.Composition.Hosting.Core.CompositionDependency Missing(System.Composition.Hosting.Core.CompositionContract contract, object site) { throw null; }
+        public static System.Composition.Hosting.Core.CompositionDependency Oversupplied(System.Composition.Hosting.Core.CompositionContract contract, System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> targets, object site) { throw null; }
+        public static System.Composition.Hosting.Core.CompositionDependency Satisfied(System.Composition.Hosting.Core.CompositionContract contract, System.Composition.Hosting.Core.ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public sealed partial class CompositionOperation : System.IDisposable
+    {
+        internal CompositionOperation() { }
+        public void AddNonPrerequisiteAction(System.Action action) { }
+        public void AddPostCompositionAction(System.Action action) { }
+        public void Dispose() { }
+        public static object Run(System.Composition.Hosting.Core.LifetimeContext outermostLifetimeContext, System.Composition.Hosting.Core.CompositeActivator compositionRootActivator) { throw null; }
+    }
+    public abstract partial class DependencyAccessor
+    {
+        protected DependencyAccessor() { }
+        protected abstract System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> GetPromises(System.Composition.Hosting.Core.CompositionContract exportKey);
+        public System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency> ResolveDependencies(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite) { throw null; }
+        public System.Composition.Hosting.Core.CompositionDependency ResolveRequiredDependency(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite) { throw null; }
+        public bool TryResolveOptionalDependency(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite, out System.Composition.Hosting.Core.CompositionDependency dependency) { throw null; }
+    }
+    public abstract partial class ExportDescriptor
+    {
+        protected ExportDescriptor() { }
+        public abstract System.Composition.Hosting.Core.CompositeActivator Activator { get; }
+        public abstract System.Collections.Generic.IDictionary<string, object> Metadata { get; }
+        public static System.Composition.Hosting.Core.ExportDescriptor Create(System.Composition.Hosting.Core.CompositeActivator activator, System.Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(System.Composition.Hosting.Core.CompositionContract contract, string origin, bool isShared, System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>> dependencies, System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>, System.Composition.Hosting.Core.ExportDescriptor> getDescriptor) { }
+        public System.Composition.Hosting.Core.CompositionContract Contract { get { throw null; } }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Composition.Hosting.Core.CompositionDependency> Dependencies { get { throw null; } }
+        public bool IsShared { get { throw null; } }
+        public string Origin { get { throw null; } }
+        public System.Composition.Hosting.Core.ExportDescriptor GetDescriptor() { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>> NoDependencies;
+        protected static readonly System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly System.Collections.Generic.IDictionary<string, object> NoMetadata;
+        protected ExportDescriptorProvider() { }
+        public abstract System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract contract, System.Composition.Hosting.Core.DependencyAccessor descriptorAccessor);
+    }
+    public sealed partial class LifetimeContext : System.Composition.CompositionContext, System.IDisposable
+    {
+        internal LifetimeContext() { }
+        public void AddBoundInstance(System.IDisposable instance) { }
+        public static int AllocateSharingId() { throw null; }
+        public void Dispose() { }
+        public System.Composition.Hosting.Core.LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+        public object GetOrCreate(int sharingId, System.Composition.Hosting.Core.CompositionOperation operation, System.Composition.Hosting.Core.CompositeActivator creator) { throw null; }
+        public override string ToString() { throw null; }
+        public override bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/1.3.0/lib/netstandard2.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/1.3.0/lib/netstandard2.0/System.Composition.Hosting.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Hosting")]
+[assembly: AssemblyDescription("System.Composition.Hosting")]
+[assembly: AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.46214")]
+[assembly: AssemblyInformationalVersion("4.700.19.46214 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.34.0")]
+
+
+
+
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : System.Composition.CompositionContext, System.IDisposable
+    {
+        internal CompositionHost() { }
+        public static System.Composition.Hosting.CompositionHost CreateCompositionHost(System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorProvider> providers) { throw null; }
+        public static System.Composition.Hosting.CompositionHost CreateCompositionHost(params System.Composition.Hosting.Core.ExportDescriptorProvider[] providers) { throw null; }
+        public void Dispose() { }
+        public override bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(System.Composition.Hosting.Core.LifetimeContext context, System.Composition.Hosting.Core.CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+        public System.Composition.Hosting.Core.CompositionContract Contract { get { throw null; } }
+        public bool IsPrerequisite { get { throw null; } }
+        public object Site { get { throw null; } }
+        public System.Composition.Hosting.Core.ExportDescriptorPromise Target { get { throw null; } }
+        public static System.Composition.Hosting.Core.CompositionDependency Missing(System.Composition.Hosting.Core.CompositionContract contract, object site) { throw null; }
+        public static System.Composition.Hosting.Core.CompositionDependency Oversupplied(System.Composition.Hosting.Core.CompositionContract contract, System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> targets, object site) { throw null; }
+        public static System.Composition.Hosting.Core.CompositionDependency Satisfied(System.Composition.Hosting.Core.CompositionContract contract, System.Composition.Hosting.Core.ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public sealed partial class CompositionOperation : System.IDisposable
+    {
+        internal CompositionOperation() { }
+        public void AddNonPrerequisiteAction(System.Action action) { }
+        public void AddPostCompositionAction(System.Action action) { }
+        public void Dispose() { }
+        public static object Run(System.Composition.Hosting.Core.LifetimeContext outermostLifetimeContext, System.Composition.Hosting.Core.CompositeActivator compositionRootActivator) { throw null; }
+    }
+    public abstract partial class DependencyAccessor
+    {
+        protected DependencyAccessor() { }
+        protected abstract System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> GetPromises(System.Composition.Hosting.Core.CompositionContract exportKey);
+        public System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency> ResolveDependencies(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite) { throw null; }
+        public System.Composition.Hosting.Core.CompositionDependency ResolveRequiredDependency(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite) { throw null; }
+        public bool TryResolveOptionalDependency(object site, System.Composition.Hosting.Core.CompositionContract contract, bool isPrerequisite, out System.Composition.Hosting.Core.CompositionDependency dependency) { throw null; }
+    }
+    public abstract partial class ExportDescriptor
+    {
+        protected ExportDescriptor() { }
+        public abstract System.Composition.Hosting.Core.CompositeActivator Activator { get; }
+        public abstract System.Collections.Generic.IDictionary<string, object> Metadata { get; }
+        public static System.Composition.Hosting.Core.ExportDescriptor Create(System.Composition.Hosting.Core.CompositeActivator activator, System.Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(System.Composition.Hosting.Core.CompositionContract contract, string origin, bool isShared, System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>> dependencies, System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>, System.Composition.Hosting.Core.ExportDescriptor> getDescriptor) { }
+        public System.Composition.Hosting.Core.CompositionContract Contract { get { throw null; } }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Composition.Hosting.Core.CompositionDependency> Dependencies { get { throw null; } }
+        public bool IsShared { get { throw null; } }
+        public string Origin { get { throw null; } }
+        public System.Composition.Hosting.Core.ExportDescriptor GetDescriptor() { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly System.Func<System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.CompositionDependency>> NoDependencies;
+        protected static readonly System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly System.Collections.Generic.IDictionary<string, object> NoMetadata;
+        protected ExportDescriptorProvider() { }
+        public abstract System.Collections.Generic.IEnumerable<System.Composition.Hosting.Core.ExportDescriptorPromise> GetExportDescriptors(System.Composition.Hosting.Core.CompositionContract contract, System.Composition.Hosting.Core.DependencyAccessor descriptorAccessor);
+    }
+    public sealed partial class LifetimeContext : System.Composition.CompositionContext, System.IDisposable
+    {
+        internal LifetimeContext() { }
+        public void AddBoundInstance(System.IDisposable instance) { }
+        public static int AllocateSharingId() { throw null; }
+        public void Dispose() { }
+        public System.Composition.Hosting.Core.LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+        public object GetOrCreate(int sharingId, System.Composition.Hosting.Core.CompositionOperation operation, System.Composition.Hosting.Core.CompositeActivator creator) { throw null; }
+        public override string ToString() { throw null; }
+        public override bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/1.3.0/system.composition.hosting.nuspec
+++ b/src/referencePackages/src/system.composition.hosting/1.3.0/system.composition.hosting.nuspec
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Composition.Hosting</id>
+    <version>1.3.0</version>
+    <title>System.Composition.Hosting</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.
+
+Commonly Used Types:
+System.Composition.Hosting.CompositionHost
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile259">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="UAP10.0.16299">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="Windows8.0">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhone8.0">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhoneApp8.1">
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.runtime/1.3.0/System.Composition.Runtime.csproj
+++ b/src/referencePackages/src/system.composition.runtime/1.3.0/System.Composition.Runtime.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.composition.runtime/1.3.0/system.composition.runtime.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.composition.runtime/1.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.composition.runtime/1.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.runtime/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.runtime/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.composition.runtime/1.3.0/lib/netstandard1.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/1.3.0/lib/netstandard1.0/System.Composition.Runtime.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Runtime")]
+[assembly: AssemblyDescription("System.Composition.Runtime")]
+[assembly: AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26515.06")]
+[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.33.0")]
+
+
+
+
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        protected CompositionContext() { }
+        public object GetExport(System.Composition.Hosting.Core.CompositionContract contract) { throw null; }
+        public object GetExport(System.Type exportType) { throw null; }
+        public object GetExport(System.Type exportType, string contractName) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetExports(System.Type exportType) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetExports(System.Type exportType, string contractName) { throw null; }
+        public System.Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+        public System.Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+        public TExport GetExport<TExport>() { throw null; }
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+        public abstract bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(System.Type exportType, out object export) { throw null; }
+        public bool TryGetExport(System.Type exportType, string contractName, out object export) { throw null; }
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+    }
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(System.Func<System.Tuple<T, System.Action>> exportCreator) { }
+        public System.Composition.Export<T> CreateExport() { throw null; }
+    }
+    public partial class ExportFactory<T, TMetadata> : System.Composition.ExportFactory<T>
+    {
+        public ExportFactory(System.Func<System.Tuple<T, System.Action>> exportCreator, TMetadata metadata) : base (default(System.Func<System.Tuple<T, System.Action>>)) { }
+        public TMetadata Metadata { get { throw null; } }
+    }
+    public sealed partial class Export<T> : System.IDisposable
+    {
+        public Export(T value, System.Action disposeAction) { }
+        public T Value { get { throw null; } }
+        public void Dispose() { }
+    }
+}
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : System.Exception
+    {
+        public CompositionFailedException() { }
+        public CompositionFailedException(string message) { }
+        public CompositionFailedException(string message, System.Exception innerException) { }
+    }
+}
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(System.Type contractType) { }
+        public CompositionContract(System.Type contractType, string contractName) { }
+        public CompositionContract(System.Type contractType, string contractName, System.Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+        public System.Composition.Hosting.Core.CompositionContract ChangeType(System.Type newContractType) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out System.Composition.Hosting.Core.CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/1.3.0/lib/netstandard2.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/1.3.0/lib/netstandard2.0/System.Composition.Runtime.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.Runtime")]
+[assembly: AssemblyDescription("System.Composition.Runtime")]
+[assembly: AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.46214")]
+[assembly: AssemblyInformationalVersion("4.700.19.46214 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.34.0")]
+
+
+
+
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        protected CompositionContext() { }
+        public object GetExport(System.Composition.Hosting.Core.CompositionContract contract) { throw null; }
+        public object GetExport(System.Type exportType) { throw null; }
+        public object GetExport(System.Type exportType, string contractName) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetExports(System.Type exportType) { throw null; }
+        public System.Collections.Generic.IEnumerable<object> GetExports(System.Type exportType, string contractName) { throw null; }
+        public System.Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+        public System.Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+        public TExport GetExport<TExport>() { throw null; }
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+        public abstract bool TryGetExport(System.Composition.Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(System.Type exportType, out object export) { throw null; }
+        public bool TryGetExport(System.Type exportType, string contractName, out object export) { throw null; }
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+    }
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(System.Func<System.Tuple<T, System.Action>> exportCreator) { }
+        public System.Composition.Export<T> CreateExport() { throw null; }
+    }
+    public partial class ExportFactory<T, TMetadata> : System.Composition.ExportFactory<T>
+    {
+        public ExportFactory(System.Func<System.Tuple<T, System.Action>> exportCreator, TMetadata metadata) : base (default(System.Func<System.Tuple<T, System.Action>>)) { }
+        public TMetadata Metadata { get { throw null; } }
+    }
+    public sealed partial class Export<T> : System.IDisposable
+    {
+        public Export(T value, System.Action disposeAction) { }
+        public T Value { get { throw null; } }
+        public void Dispose() { }
+    }
+}
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : System.Exception
+    {
+        public CompositionFailedException() { }
+        public CompositionFailedException(string message) { }
+        public CompositionFailedException(string message, System.Exception innerException) { }
+    }
+}
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(System.Type contractType) { }
+        public CompositionContract(System.Type contractType, string contractName) { }
+        public CompositionContract(System.Type contractType, string contractName, System.Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+        public string ContractName { get { throw null; } }
+        public System.Type ContractType { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+        public System.Composition.Hosting.Core.CompositionContract ChangeType(System.Type newContractType) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out System.Composition.Hosting.Core.CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/1.3.0/system.composition.runtime.nuspec
+++ b/src/referencePackages/src/system.composition.runtime/1.3.0/system.composition.runtime.nuspec
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Composition.Runtime</id>
+    <version>1.3.0</version>
+    <title>System.Composition.Runtime</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Contains runtime components of the Managed Extensibility Framework.
+
+Commonly Used Types:
+System.Composition.CompositionContext
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5" />
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework=".NETPortable4.5-Profile259" />
+      <group targetFramework="Windows8.0" />
+      <group targetFramework="WindowsPhone8.0" />
+      <group targetFramework="WindowsPhoneApp8.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.typedparts/1.3.0/System.Composition.TypedParts.csproj
+++ b/src/referencePackages/src/system.composition.typedparts/1.3.0/System.Composition.TypedParts.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.composition.typedparts/1.3.0/system.composition.typedparts.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)MSFT.snk</AssemblyOriginatorKeyFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.composition.typedparts/1.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.composition.typedparts/1.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.typedparts/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <OutputPath>$(ArtifactsBinDir)system.composition.typedparts/1.3.0/lib/</OutputPath>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.AttributedModel" Version="1.3.0" />
+        <PackageReference Include="System.Composition.Hosting" Version="1.3.0" />
+        <PackageReference Include="System.Composition.Runtime" Version="1.3.0" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+        <PackageReference Include="NETStandard.Library" Version="$(NETStandardLibraryPackageVersion)" />
+        <PackageReference Include="System.Composition.AttributedModel" Version="1.3.0" />
+        <PackageReference Include="System.Composition.Hosting" Version="1.3.0" />
+        <PackageReference Include="System.Composition.Runtime" Version="1.3.0" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.composition.typedparts/1.3.0/lib/netstandard1.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/1.3.0/lib/netstandard1.0/System.Composition.TypedParts.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.TypedParts")]
+[assembly: AssemblyDescription("System.Composition.TypedParts")]
+[assembly: AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26515.06")]
+[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.33.0")]
+
+
+
+
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this System.Composition.CompositionContext compositionContext, object objectWithLooseImports) { }
+        public static void SatisfyImports(this System.Composition.CompositionContext compositionContext, object objectWithLooseImports, System.Composition.Convention.AttributedModelProvider conventions) { }
+    }
+}
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public ContainerConfiguration() { }
+        public System.Composition.Hosting.CompositionHost CreateContainer() { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssembly(System.Reflection.Assembly assembly) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssembly(System.Reflection.Assembly assembly, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithDefaultConventions(System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart(System.Type partType) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart(System.Type partType, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(System.Collections.Generic.IEnumerable<System.Type> partTypes) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(System.Collections.Generic.IEnumerable<System.Type> partTypes, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(params System.Type[] partTypes) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart<TPart>() { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart<TPart>(System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithProvider(System.Composition.Hosting.Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/1.3.0/lib/netstandard2.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/1.3.0/lib/netstandard2.0/System.Composition.TypedParts.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Composition.TypedParts")]
+[assembly: AssemblyDescription("System.Composition.TypedParts")]
+[assembly: AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.46214")]
+[assembly: AssemblyInformationalVersion("4.700.19.46214 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.34.0")]
+
+
+
+
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this System.Composition.CompositionContext compositionContext, object objectWithLooseImports) { }
+        public static void SatisfyImports(this System.Composition.CompositionContext compositionContext, object objectWithLooseImports, System.Composition.Convention.AttributedModelProvider conventions) { }
+    }
+}
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public ContainerConfiguration() { }
+        public System.Composition.Hosting.CompositionHost CreateContainer() { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssembly(System.Reflection.Assembly assembly) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithAssembly(System.Reflection.Assembly assembly, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithDefaultConventions(System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart(System.Type partType) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart(System.Type partType, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(System.Collections.Generic.IEnumerable<System.Type> partTypes) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(System.Collections.Generic.IEnumerable<System.Type> partTypes, System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithParts(params System.Type[] partTypes) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart<TPart>() { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithPart<TPart>(System.Composition.Convention.AttributedModelProvider conventions) { throw null; }
+        public System.Composition.Hosting.ContainerConfiguration WithProvider(System.Composition.Hosting.Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/1.3.0/system.composition.typedparts.nuspec
+++ b/src/referencePackages/src/system.composition.typedparts/1.3.0/system.composition.typedparts.nuspec
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Composition.TypedParts</id>
+    <version>1.3.0</version>
+    <title>System.Composition.TypedParts</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides some extension methods for the Managed Extensibility Framework.
+
+Commonly Used Types:
+System.Composition.CompositionContextExtensions
+System.Composition.Hosting.ContainerConfiguration
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile259">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="UAP10.0.16299">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="Windows8.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhone8.0">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+      <group targetFramework="WindowsPhoneApp8.1">
+        <dependency id="System.Composition.AttributedModel" version="1.3.0" />
+        <dependency id="System.Composition.Hosting" version="1.3.0" />
+        <dependency id="System.Composition.Runtime" version="1.3.0" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Add the following packages for 5.0P8 prebuilt removal:
  - System.Composition.AttributedModel,1.3.0
  - System.Composition.Convention,1.3.0
  - System.Composition.Hosting,1.3.0
  - System.Composition.Runtime,1.3.0
  - System.Composition.TypedParts,1.3.0  