### PR TITLE
Fix intermediate nupkg publish: Update Arcade => '5.0.0-beta.20465.4'

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,9 @@
       <SourceBuildRepoName>source-build-reference-packages</SourceBuildRepoName>
     </Dependency>
     -->
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20461.6">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20465.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>1dca5888f7471cad1390ca20de820284a931df5d</Sha>
+      <Sha>bed89714c843bdb26956dd7d3cd13665a1a46e03</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20202.18">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/common/post-build/symbols-validation.ps1
+++ b/eng/common/post-build/symbols-validation.ps1
@@ -141,11 +141,6 @@ $CountMissingSymbols = {
   if ($using:Clean) {
     Remove-Item $ExtractPath -Recurse -Force
   }
-
-  if ($MissingSymbols -ne 0)
-  {
-    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $MissingSymbols modules in the package $PackagePath"
-  }
   
   Pop-Location
 
@@ -165,6 +160,7 @@ function CheckJobResult(
     $DupedSymbols.Value++
   } 
   elseif ($jobResult.result -ne '0') {
+    Write-PipelineTelemetryError -Category 'CheckSymbols' -Message "Missing symbols for $result modules in the package $packagePath"
     $TotalFailures.Value++
   }
 }
@@ -201,7 +197,6 @@ function CheckSymbolsAvailable {
       Start-Job -ScriptBlock $CountMissingSymbols -ArgumentList $FullName | Out-Null
 
       $NumJobs = @(Get-Job -State 'Running').Count
-      Write-Host $NumJobs
 
       while ($NumJobs -ge $MaxParallelJobs) {
         Write-Host "There are $NumJobs validation jobs running right now. Waiting $SecondsBetweenLoadChecks seconds to check again."

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "5.0.100-preview.6.20310.4"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20461.6"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20465.4"
   }
 }


### PR DESCRIPTION
Takes https://github.com/dotnet/arcade/pull/6177 to fix intermediate nupkg publish from the official build. This is an ordinary Arcade update (just accelerated a little)--planning to simply merge when green.