### PR TITLE
Add build-il.sh that uses bash to fix Debian build, get further on macOS build

### DIFF
--- a/src/targetPacks/Directory.Build.targets
+++ b/src/targetPacks/Directory.Build.targets
@@ -52,12 +52,8 @@
 
   <Target Name="BuildIlFile"
           DependsOnTargets="ResolveIlToolPaths">
-    <!--
-      Note: Use awk as hack below to not fill up build logs. Ilasm produces warning on validly
-      disassembled il src. The awk expression eats just that warning.
-    -->
     <Exec
-      Command="set -o pipefail;$(IlasmDir)ilasm $(IlFile) -dll -quiet -nologo -output=$(OutputFile) |&amp; awk '!/warning : Method has no body/'"
+      Command="$(MSBuildThisFileDirectory)build-il.sh $(IlasmDir) $(IlFile) $(OutputFile)"
       IgnoreStandardErrorWarningFormat="true"
       CustomErrorRegularExpression=": error : " />
   </Target>

--- a/src/targetPacks/build-il.sh
+++ b/src/targetPacks/build-il.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+IlasmDir=$1
+IlFile=$2
+OutputFile=$3
+
+set -o pipefail
+
+# Note: Use awk as hack below to not fill up build logs. Ilasm produces warning
+# on validly disassembled il src. The awk expression eats just that warning.
+"${IlasmDir}ilasm" "${IlFile}" -dll -quiet -nologo "-output=${OutputFile}" 2>&1 | awk '!/warning : Method has no body/'


### PR DESCRIPTION
Use a shell script so that we can use `#!` to switch to bash. Also uses the `2>&1` syntax rather than `|&` because `|&` isn't widely supported. (Related to https://github.com/dotnet/source-build/issues/1757.)