### PR TITLE
Support RID-specific arcade-powered source-build with jobs template

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -27,8 +27,6 @@ stages:
           artifacts: true
           manifests: true
       runSourceBuild: true
-      sourceBuildParameters:
-          managedOnly: true
 
 # Based on - https://github.com/dotnet/arcade/blob/9b3f304c7bc9fd4d11be9ca0b466b83e98d2a191/Documentation/CorePackages/Publishing.md#moving-away-from-the-legacy-pushtoblobfeed-task
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <GitHubRepositoryName>source-build-reference-packages</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,9 +9,9 @@
       <SourceBuildRepoName>source-build-reference-packages</SourceBuildRepoName>
     </Dependency>
     -->
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20465.4">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.20468.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>bed89714c843bdb26956dd7d3cd13665a1a46e03</Sha>
+      <Sha>8a58f184e5c0b10f67c0a60f791206857c459c80</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20202.18">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
@@ -9,10 +8,8 @@
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
-
   <PropertyGroup>
     <MicrosoftNETCoreILAsmVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreILDAsmVersion>
   </PropertyGroup>
-
 </Project>

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.5.0-alpha" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "16.8.0-preview3" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/templates/steps/perf-send-to-helix.yml
+++ b/eng/common/templates/steps/perf-send-to-helix.yml
@@ -19,12 +19,18 @@ parameters:
   DisplayNamePrefix: 'Send job to Helix' # optional -- rename the beginning of the displayName of the steps in AzDO 
   condition: succeeded()                 # optional -- condition for step to execute; defaults to succeeded()
   continueOnError: false                 # optional -- determines whether to continue the build if the step errors; defaults to false
+  osGroup: ''                            # required -- operating system for the job
             
 
 steps:
-  - powershell: $(Build.SourcesDirectory)\eng\common\msbuild.ps1 $(Build.SourcesDirectory)\eng\common\performance\${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)\artifacts\log\$env:BuildConfig\SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Windows)
-    env:
+- template: /eng/pipelines/common/templates/runtimes/send-to-helix-inner-step.yml
+  parameters:
+    osGroup: ${{ parameters.osGroup }}
+    sendParams: $(Build.SourcesDirectory)/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+    displayName: ${{ parameters.DisplayNamePrefix }}
+    condition: ${{ parameters.condition }}
+    continueOnError: ${{ parameters.continueOnError }}
+    environment:
       BuildConfig: $(_BuildConfig)
       HelixSource: ${{ parameters.HelixSource }}
       HelixType: ${{ parameters.HelixType }}
@@ -42,27 +48,3 @@ steps:
       WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
       Creator: ${{ parameters.Creator }}
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}
-  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/performance/${{ parameters.ProjectFile }} /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
-    displayName: ${{ parameters.DisplayNamePrefix }} (Unix)
-    env:
-      BuildConfig: $(_BuildConfig)
-      HelixSource: ${{ parameters.HelixSource }}
-      HelixType: ${{ parameters.HelixType }}
-      HelixBuild: ${{ parameters.HelixBuild }}
-      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
-      HelixAccessToken: ${{ parameters.HelixAccessToken }}
-      HelixPreCommands: ${{ parameters.HelixPreCommands }}
-      HelixPostCommands: ${{ parameters.HelixPostCommands }}
-      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
-      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
-      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
-      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
-      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
-      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
-      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
-      Creator: ${{ parameters.Creator }}
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
-    continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -312,8 +312,14 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     return $global:_MSBuildExe
   }
 
-  $vsMinVersionReqdStr = '16.5'
+  # Minimum VS version to require.
+  $vsMinVersionReqdStr = '16.8'
   $vsMinVersionReqd = [Version]::new($vsMinVersionReqdStr)
+
+  # If the version of msbuild is going to be xcopied,
+  # use this version. Version matches a package here:
+  # https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-eng&package=RoslynTools.MSBuild&protocolType=NuGet&version=16.8.0-preview3&view=overview
+  $defaultXCopyMSBuildVersion = '16.8.0-preview3'
 
   if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
   $vsMinVersionStr = if ($vsRequirements.version) { $vsRequirements.version } else { $vsMinVersionReqdStr }
@@ -349,23 +355,28 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
       $vsMajorVersion = $xcopyMSBuildVersion.Split('.')[0]
     } else {
-      #if vs version provided in global.json is incompatible then use the default version for xcopy msbuild download
+      #if vs version provided in global.json is incompatible (too low) then use the default version for xcopy msbuild download
       if($vsMinVersion -lt $vsMinVersionReqd){
-        Write-Host "Using xcopy-msbuild version of $vsMinVersionReqdStr.0-alpha since VS version $vsMinVersionStr provided in global.json is not compatible"
-        $vsMajorVersion = $vsMinVersionReqd.Major
-        $vsMinorVersion = $vsMinVersionReqd.Minor
+        Write-Host "Using xcopy-msbuild version of $defaultXCopyMSBuildVersion since VS version $vsMinVersionStr provided in global.json is not compatible"
+        $xcopyMSBuildVersion = $defaultXCopyMSBuildVersion
       }
       else{
+        # If the VS version IS compatible, look for an xcopy msbuild package
+        # with a version matching VS.
+        # Note: If this version does not exist, then an explicit version of xcopy msbuild
+        # can be specified in global.json. This will be required for pre-release versions of msbuild.
         $vsMajorVersion = $vsMinVersion.Major
         $vsMinorVersion = $vsMinVersion.Minor
+        $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0"
       }
-
-      $xcopyMSBuildVersion = "$vsMajorVersion.$vsMinorVersion.0-alpha"
     }
 
     $vsInstallDir = $null
     if ($xcopyMSBuildVersion.Trim() -ine "none") {
         $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
+        if ($vsInstallDir -eq $null) {
+            throw "Could not xcopy msbuild. Please check that package 'RoslynTools.MSBuild @ $xcopyMSBuildVersion' exists on feed 'dotnet-eng'."
+        }
     }
     if ($vsInstallDir -eq $null) {
       throw 'Unable to find Visual Studio that has required version and components installed'

--- a/eng/templates/jobs/source-build.yml
+++ b/eng/templates/jobs/source-build.yml
@@ -6,23 +6,27 @@ parameters:
   # necessary. This also changes the ID of 'Source_Build_Complete'.
   jobNamePrefix: 'Source_Build'
 
-  # A container to use. Runs in docker.
-  container: ''
-
-  # A pool to use. Runs directly on an agent.
-  pool: null
-
-  # A list of job properties to inject at the top level. Only 'container' and 'pool' are expected so
-  # far (so we provided shortcut parameters for those in particular), but this is left in for
-  # potential extensibility.
-  jobProperties: {}
-
   # Specifies the build script to invoke to perform the build in the repo. The default should work
   # for typical Arcade repositories, but this is customizable for difficult situations.
   buildScript: './build.sh'
 
-  # Defines the platforms on which to run each build job. By default, runs one job on a linux-x64
-  # machine, suitable for managed-only repositories.
+  # Defines the platforms on which to run build jobs. By default, one job on a linux-x64 machine,
+  # suitable for managed-only repositories. This is an array of objects with these properties:
+  #
+  # name: ''
+  #   The name of the job, included in the ID.
+  # targetRID: ''
+  #   The name of the target RID to use, instead of the one auto-detected by Arcade.
+  # nonPortable: false
+  #   Enables non-portable mode. This means a more specific RID (e.g. fedora.32-x64 rather than
+  #   linux-x64), and compiling against distro-provided packages rather than portable ones.
+  # container: ''
+  #   A container to use. Runs in docker.
+  # pool: {}
+  #   A pool to use. Runs directly on an agent.
+  # jobProperties: {}
+  #   A list of job properties to inject at the top level, for potential extensibility beyond
+  #   container and pool.
   platforms:
   - name: 'Managed'
     container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'

--- a/eng/templates/jobs/source-build.yml
+++ b/eng/templates/jobs/source-build.yml
@@ -1,139 +1,103 @@
 parameters:
-  # Specifies the prefix for source-build jobs added to pipeline. Use this if disambiguation is necessary.
+  # This template adds arcade-powered source-build to CI. The template produces a server job with a
+  # default ID 'Source_Build_Complete' to put in a dependency list if necessary.
+
+  # Specifies the prefix for source-build jobs added to pipeline. Use this if disambiguation is
+  # necessary. This also changes the ID of 'Source_Build_Complete'.
   jobNamePrefix: 'Source_Build'
 
-  # Specifies that the repo only builds managed components. This indicates that output is not RID-specific 
-  # and only one build job is required. A linux x64 machine will be used, but the build must continue to 
-  # work on all supported platforms equally.
-  # If false, specifies that the repo has native components that can link to platform-provided libraries.
-  #   - Adds additional portable jobs for supported portable platforms
-  #   - Adds additional non-portable jobs for supported non-portable platforms
-  #     - The job passes /p:ArcadeBuildNonPortable=true to the build to enable non-portable behavior.
-  #     - The job passes a platform-specific TargetRid MSBuild property.
-  managedOnly: false
+  # A container to use. Runs in docker.
+  container: ''
 
-  # Specifies the build script to invoke to perform the build in the repo
+  # A pool to use. Runs directly on an agent.
+  pool: null
+
+  # A list of job properties to inject at the top level. Only 'container' and 'pool' are expected so
+  # far (so we provided shortcut parameters for those in particular), but this is left in for
+  # potential extensibility.
+  jobProperties: {}
+
+  # Specifies the build script to invoke to perform the build in the repo. The default should work
+  # for typical Arcade repositories, but this is customizable for difficult situations.
   buildScript: './build.sh'
 
-  # Defines the platforms on which to run each build job
-  # Note: This parameter is not expected to be set by the consumer of this template
+  # Defines the platforms on which to run each build job. By default, runs one job on a linux-x64
+  # machine, suitable for managed-only repositories.
   platforms:
-
-  # Always run centos71 portable build
-  - name: 'Centos71_Portable'
-    include: 'always'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
-  
-  # If managedOnly is false, run a macOS portable build
-  - name: 'MacOS_Portable'
-    jobProperties:
-      pool:
-        name: Hosted macOS
-
-  # Non-portable platforms
-  - name: 'Centos71'
-    targetRID: 'centos.7-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
-
-  - name: 'Centos8'
-    targetRID: 'centos.8-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-8-daa5116-20200325130212'
-
-  - name: 'Debian9'
-    targetRID: 'debian.9-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-d61254f-20190807161114'
-
-  - name: 'Fedora30'
-    targetRID: 'fedora.30-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30-38e0f29-20191126135223'
-
-  - name: 'Fedora32'
-    targetRID: 'fedora.32-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-32-20200512010618-163ed2a'
-
-  - name: 'MacOS'
-    targetRID: 'osx.10.14-x64'
-    jobProperties:
-      pool:
-        name: Hosted macOS
-
-  - name: 'Ubuntu1804'
-    targetRID: 'ubuntu.18.04-x64'
-    jobProperties:
-      container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-f90bc20-20180320154721'
+  - name: 'Managed'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
 
 jobs:
-- job: Source_Build_Complete
+
+- job: ${{ parameters.jobNamePrefix }}_Complete
   displayName: Source-Build Complete
   pool: server
   dependsOn:
   - ${{ each platform in parameters.platforms }}:
-    - ${{ if or(eq(platform.include, 'always'), eq(parameters.managedOnly, false)) }}:
-      - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
+    - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
 
 - ${{ each platform in parameters.platforms }}:
-  - ${{ if or(eq(platform.include, 'always'), eq(parameters.managedOnly, false)) }}:
-    - job: ${{ parameters.jobNamePrefix }}_${{ platform.name }}
-      displayName: Source-Build (${{ platform.name }})
-      ${{ each property in platform.jobProperties }}:
-        ${{ property.key }}: ${{ property.value }}
-      workspace:
-        clean: all
+  - job: ${{ parameters.jobNamePrefix }}_${{ platform.name }}
+    displayName: Source-Build (${{ platform.name }})
 
-      variables:
-      - name: _BuildConfig
-        value: Release
+    ${{ each property in platform.jobProperties }}:
+      ${{ property.key }}: ${{ property.value }}
+
+    ${{ if ne(platform.container, '') }}:
+      container: ${{ platform.container }}
+    ${{ if ne(platform.pool, '') }}:
+      pool: ${{ platform.pool }}
+
+    workspace:
+      clean: all
+
+    variables:
+    - name: _BuildConfig
+      value: Release
+    - name: _InternalBuildArgs
+      value: ''
+    - name: _TargetRidArgs
+      value: ''
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - name: _InternalBuildArgs
-        value: ''
-      - name: _NonPortableBuildArgs
-        value: ''
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _InternalBuildArgs
-          value: >-
-            /p:DotNetPublishUsingPipelines=true
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-      - ${{ if ne(platform.targetRID, '') }}:
-        - name: _NonPortableBuildArgs
-          value: >-
-            /p:ArcadeBuildNonPortable=true
-            /p:TargetRid=${{ platform.targetRID }}
+        value: >-
+          /p:DotNetPublishUsingPipelines=true
+          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - ${{ if ne(platform.targetRID, '') }}:
+      - name: _TargetRidArgs
+        value: /p:TargetRid=${{ platform.targetRID }}
 
-      steps:
-      - script: |
-          set -x
-          df -h
-          ${{ parameters.buildScript }} --ci \
-            --configuration $(_BuildConfig) \
-            --restore --build --pack --publish \
-            $(_InternalBuildArgs) \
-            $(_NonPortableBuildArgs) \
-           /p:ArcadeBuildFromSource=true
-        displayName: Build
+    steps:
+    - script: |
+        set -x
+        df -h
+        ${{ parameters.buildScript }} --ci \
+          --configuration $(_BuildConfig) \
+          --restore --build --pack --publish \
+          $(_InternalBuildArgs) \
+          $(_TargetRidArgs) \
+          /p:SourceBuildNonPortable=${{ platform.nonPortable }} \
+          /p:ArcadeBuildFromSource=true
+      displayName: Build
 
-      # Upload build logs for diagnosis.
-      - task: CopyFiles@2
-        displayName: Prepare BuildLogs staging directory
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)'
-          Contents: |
-            **/*.log
-            **/*.binlog
-            artifacts/source-build/self/prebuilt-report/**
-          TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-          CleanTargetFolder: true
-        continueOnError: true
-        condition: succeededOrFailed()
+    # Upload build logs for diagnosis.
+    - task: CopyFiles@2
+      displayName: Prepare BuildLogs staging directory
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: |
+          **/*.log
+          **/*.binlog
+          artifacts/source-build/self/prebuilt-report/**
+        TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+        CleanTargetFolder: true
+      continueOnError: true
+      condition: succeededOrFailed()
 
-      - task: PublishPipelineArtifact@1
-        displayName: Publish BuildLogs
-        inputs:
-          targetPath: '$(Build.StagingDirectory)/BuildLogs'
-          artifactName: BuildLogs
-        continueOnError: true
-        condition: succeededOrFailed()
+    - task: PublishPipelineArtifact@1
+      displayName: Publish BuildLogs
+      inputs:
+        targetPath: '$(Build.StagingDirectory)/BuildLogs'
+        artifactName: BuildLogs_SourceBuild_${{ platform.name }}_Attempt$(System.JobAttempt)
+      continueOnError: true
+      condition: succeededOrFailed()

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
   "tools": {
-    "dotnet": "5.0.100-preview.6.20310.4"
+    "dotnet": "5.0.100-rc.1.20452.10"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20465.4"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20468.1"
   }
 }


### PR DESCRIPTION
Use https://github.com/dotnet/arcade/pull/6197 to do RID-specific builds, or managed only builds that have no suffix. This is in support of moving the template to dotnet/arcade: https://github.com/dotnet/source-build/issues/1699.

This repo is managed-only, so it looks like https://dev.azure.com/dnceng/internal/_build/results?buildId=820925&view=results:

> ![image](https://user-images.githubusercontent.com/12819531/93626219-be416480-f9a8-11ea-896f-c072ec5fb76f.png)

A RID-specific build must provide its own platform configuration. It can't be passed down by Arcade, because then we have no way to gradually roll out RID adds/removes without also blocking Arcade SDK updates. For example, this:

```yaml
      runSourceBuild: true
      sourceBuildParameters:
        platforms:
        - name: 'Centos71_Portable'
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
        - name: 'MacOS_Portable'
          pool: { vmImage: 'macOS-10.14' }
        - name: 'Centos71'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
        - name: 'Centos8'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-8-daa5116-20200325130212'
        - name: 'Debian9'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:debian-stretch-20200918130533-047508b'
        - name: 'Fedora30'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-30-38e0f29-20191126135223'
        - name: 'Fedora32'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-32-20200512010618-163ed2a'
        - name: 'MacOS'
          nonPortable: true
          pool: { vmImage: 'macOS-10.14' }
        - name: 'Ubuntu1804'
          nonPortable: true
          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20200918145614-047508b'
```

Produces https://dev.azure.com/dnceng/internal/_build/results?buildId=820919&view=results:

> ![image](https://user-images.githubusercontent.com/12819531/93626412-006aa600-f9a9-11ea-9aa5-9fcfa471e4bd.png)

(That's just for testing, this repo should never produce RID-specific packages. In fact, I think very few repos will, maybe only dotnet/runtime, dotnet/aspnetcore, and dotnet/installer.)