### PR TITLE
Split the source-build template for expected reuse

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -27,6 +27,8 @@ stages:
           artifacts: true
           manifests: true
       runSourceBuild: true
+      sourceBuildParameters:
+        includeDefaultManagedPlatform: true
 
 # Based on - https://github.com/dotnet/arcade/blob/9b3f304c7bc9fd4d11be9ca0b466b83e98d2a191/Documentation/CorePackages/Publishing.md#moving-away-from-the-legacy-pushtoblobfeed-task
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/templates/job/source-build.yml
+++ b/eng/templates/job/source-build.yml
@@ -1,0 +1,49 @@
+parameters:
+  # This template adds arcade-powered source-build to CI. The template produces a server job with a
+  # default ID 'Source_Build_Complete' to put in a dependency list if necessary.
+
+  # Specifies the prefix for source-build jobs added to pipeline. Use this if disambiguation needed.
+  jobNamePrefix: 'Source_Build'
+
+  # Defines the platform on which to run the job. By default, a linux-x64 machine, suitable for
+  # managed-only repositories. This is an object with these properties:
+  #
+  # name: ''
+  #   The name of the job. This is included in the job ID.
+  # targetRID: ''
+  #   The name of the target RID to use, instead of the one auto-detected by Arcade.
+  # nonPortable: false
+  #   Enables non-portable mode. This means a more specific RID (e.g. fedora.32-x64 rather than
+  #   linux-x64), and compiling against distro-provided packages rather than portable ones.
+  # container: ''
+  #   A container to use. Runs in docker.
+  # pool: {}
+  #   A pool to use. Runs directly on an agent.
+  # buildScript: ''
+  #   Specifies the build script to invoke to perform the build in the repo. The default
+  #   './build.sh' should work for typical Arcade repositories, but this is customizable for
+  #   difficult situations.
+  # jobProperties: {}
+  #   A list of job properties to inject at the top level, for potential extensibility beyond
+  #   container and pool.
+  platform: {}
+
+jobs:
+- job: ${{ parameters.jobNamePrefix }}_${{ parameters.platform.name }}
+  displayName: Source-Build (${{ parameters.platform.name }})
+
+  ${{ each property in parameters.platform.jobProperties }}:
+    ${{ property.key }}: ${{ property.value }}
+
+  ${{ if ne(parameters.platform.container, '') }}:
+    container: ${{ parameters.platform.container }}
+  ${{ if ne(parameters.platform.pool, '') }}:
+    pool: ${{ parameters.platform.pool }}
+
+  workspace:
+    clean: all
+
+  steps:
+  - template: /eng/templates/steps/source-build.yml
+    parameters:
+      platform: ${{ parameters.platform }}

--- a/eng/templates/jobs/jobs.yml
+++ b/eng/templates/jobs/jobs.yml
@@ -53,6 +53,7 @@ jobs:
 - ${{ if eq(parameters.runSourceBuild, true) }}:
   - template: /eng/templates/jobs/source-build.yml
     parameters:
+      allCompletedJobId: Source_Build_Complete
       ${{ each parameter in parameters.sourceBuildParameters }}:
         ${{ parameter.key }}: ${{ parameter.value }}
 

--- a/eng/templates/jobs/source-build.yml
+++ b/eng/templates/jobs/source-build.yml
@@ -1,107 +1,48 @@
 parameters:
-  # This template adds arcade-powered source-build to CI. The template produces a server job with a
-  # default ID 'Source_Build_Complete' to put in a dependency list if necessary.
+  # This template adds arcade-powered source-build to CI. A job is created for each platform, as
+  # well as an optional server job that completes when all platform jobs complete.
 
-  # Specifies the prefix for source-build jobs added to pipeline. Use this if disambiguation is
-  # necessary. This also changes the ID of 'Source_Build_Complete'.
+  # The name of the "join" job for all source-build platforms. If set to empty string, the job is
+  # not included. Existing repo pipelines can use this job depend on all source-build jobs
+  # completing without maintaining a separate list of every single job ID: just depend on this one
+  # server job. By default, not included. Recommended name if used: 'Source_Build_Complete'.
+  allCompletedJobId: ''
+
+  # See eng/common/templates/job/source-build.yml
   jobNamePrefix: 'Source_Build'
 
-  # Specifies the build script to invoke to perform the build in the repo. The default should work
-  # for typical Arcade repositories, but this is customizable for difficult situations.
-  buildScript: './build.sh'
-
-  # Defines the platforms on which to run build jobs. By default, one job on a linux-x64 machine,
-  # suitable for managed-only repositories. This is an array of objects with these properties:
-  #
-  # name: ''
-  #   The name of the job, included in the ID.
-  # targetRID: ''
-  #   The name of the target RID to use, instead of the one auto-detected by Arcade.
-  # nonPortable: false
-  #   Enables non-portable mode. This means a more specific RID (e.g. fedora.32-x64 rather than
-  #   linux-x64), and compiling against distro-provided packages rather than portable ones.
-  # container: ''
-  #   A container to use. Runs in docker.
-  # pool: {}
-  #   A pool to use. Runs directly on an agent.
-  # jobProperties: {}
-  #   A list of job properties to inject at the top level, for potential extensibility beyond
-  #   container and pool.
-  platforms:
-  - name: 'Managed'
+  # If changed to true, causes this template to include the default platform for a managed-only
+  # repo. The exact Docker image used for this build will be provided by Arcade. This has some risk,
+  # but since the repo is supposed to be managed-only, the risk should be very low.
+  includeDefaultManagedPlatform: false
+  defaultManagedPlatform:
+    name: 'Managed'
     container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
+
+  # Defines the platforms on which to run build jobs. One job is created for each platform, and the
+  # object in this array is sent to the job template as 'platform'.
+  platforms: []
 
 jobs:
 
-- job: ${{ parameters.jobNamePrefix }}_Complete
-  displayName: Source-Build Complete
-  pool: server
-  dependsOn:
-  - ${{ each platform in parameters.platforms }}:
-    - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
+- ${{ if ne(parameters.allCompletedJobId, '') }}:
+  - job: ${{ parameters.allCompletedJobId }}
+    displayName: Source-Build Complete
+    pool: server
+    dependsOn:
+    - ${{ each platform in parameters.platforms }}:
+      - ${{ parameters.jobNamePrefix }}_${{ platform.name }}
+    - ${{ if eq(parameters.includeDefaultManagedPlatform, true) }}:
+      - ${{ parameters.jobNamePrefix }}_${{ parameters.defaultManagedPlatform.name }}
 
 - ${{ each platform in parameters.platforms }}:
-  - job: ${{ parameters.jobNamePrefix }}_${{ platform.name }}
-    displayName: Source-Build (${{ platform.name }})
+  - template: /eng/templates/job/source-build.yml
+    parameters:
+      jobNamePrefix: ${{ parameters.jobNamePrefix }}
+      platform: ${{ platform }}
 
-    ${{ each property in platform.jobProperties }}:
-      ${{ property.key }}: ${{ property.value }}
-
-    ${{ if ne(platform.container, '') }}:
-      container: ${{ platform.container }}
-    ${{ if ne(platform.pool, '') }}:
-      pool: ${{ platform.pool }}
-
-    workspace:
-      clean: all
-
-    variables:
-    - name: _BuildConfig
-      value: Release
-    - name: _InternalBuildArgs
-      value: ''
-    - name: _TargetRidArgs
-      value: ''
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - name: _InternalBuildArgs
-        value: >-
-          /p:DotNetPublishUsingPipelines=true
-          /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-    - ${{ if ne(platform.targetRID, '') }}:
-      - name: _TargetRidArgs
-        value: /p:TargetRid=${{ platform.targetRID }}
-
-    steps:
-    - script: |
-        set -x
-        df -h
-        ${{ parameters.buildScript }} --ci \
-          --configuration $(_BuildConfig) \
-          --restore --build --pack --publish \
-          $(_InternalBuildArgs) \
-          $(_TargetRidArgs) \
-          /p:SourceBuildNonPortable=${{ platform.nonPortable }} \
-          /p:ArcadeBuildFromSource=true
-      displayName: Build
-
-    # Upload build logs for diagnosis.
-    - task: CopyFiles@2
-      displayName: Prepare BuildLogs staging directory
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)'
-        Contents: |
-          **/*.log
-          **/*.binlog
-          artifacts/source-build/self/prebuilt-report/**
-        TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
-        CleanTargetFolder: true
-      continueOnError: true
-      condition: succeededOrFailed()
-
-    - task: PublishPipelineArtifact@1
-      displayName: Publish BuildLogs
-      inputs:
-        targetPath: '$(Build.StagingDirectory)/BuildLogs'
-        artifactName: BuildLogs_SourceBuild_${{ platform.name }}_Attempt$(System.JobAttempt)
-      continueOnError: true
-      condition: succeededOrFailed()
+- ${{ if eq(parameters.includeDefaultManagedPlatform, true) }}:
+  - template: /eng/templates/job/source-build.yml
+    parameters:
+      jobNamePrefix: ${{ parameters.jobNamePrefix }}
+      platform: ${{ parameters.defaultManagedPlatform }}

--- a/eng/templates/steps/source-build.yml
+++ b/eng/templates/steps/source-build.yml
@@ -1,0 +1,66 @@
+parameters:
+  # This template adds arcade-powered source-build to CI.
+
+  # This is a 'steps' template, and is intended for advanced scenarios where the existing build
+  # infra has a careful build methodology that must be followed. For example, a repo
+  # (dotnet/runtime) might choose to clone the GitHub repo only once and store it as a pipeline
+  # artifact for all subsequent jobs to use, to reduce dependence on a strong network connection to
+  # GitHub. Using this steps template leaves room for that infra to be included.
+
+  # Defines the platform on which to run the steps. See 'eng/common/templates/job/source-build.yml'
+  # for details. The entire object is described in the 'job' template for simplicity, even though
+  # the usage of the properties on this object is split between the 'job' and 'steps' templates.
+  platform: {}
+
+steps:
+# Run the build. Avoid requiring job variables, to keep reuse simple.
+- script: |
+    set -x
+    df -h
+
+    buildConfig=Release
+    # Check if AzDO substitutes in a build config from a variable, and use it if so.
+    if [ '$(_BuildConfig)' != '$''(_BuildConfig)' ]; then
+      buildConfig='$(_BuildConfig)'
+    fi
+
+    officialBuildArgs=
+    if [ '${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}' = 'True' ]; then
+      officialBuildArgs='/p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)'
+    fi
+
+    targetRidArgs=
+    if [ '${{ parameters.platform.targetRID }}' != '' ]; then
+      targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
+    fi
+
+    ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
+      --configuration $buildConfig \
+      --restore --build --pack --publish \
+      $officialBuildArgs \
+      $targetRidArgs \
+      /p:SourceBuildNonPortable=${{ parameters.platform.nonPortable }} \
+      /p:ArcadeBuildFromSource=true
+  displayName: Build
+
+# Upload build logs for diagnosis.
+- task: CopyFiles@2
+  displayName: Prepare BuildLogs staging directory
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: |
+      **/*.log
+      **/*.binlog
+      artifacts/source-build/self/prebuilt-report/**
+    TargetFolder: '$(Build.StagingDirectory)/BuildLogs'
+    CleanTargetFolder: true
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- task: PublishPipelineArtifact@1
+  displayName: Publish BuildLogs
+  inputs:
+    targetPath: '$(Build.StagingDirectory)/BuildLogs'
+    artifactName: BuildLogs_SourceBuild_${{ parameters.platform.name }}_Attempt$(System.JobAttempt)
+  continueOnError: true
+  condition: succeededOrFailed()


### PR DESCRIPTION
I expect that repos will want to integrate these ways:
* Adding a few args to the Arcade jobs template they're already using.
* Add source-build jobs to their own list of jobs. (And they don't use the Arcade jobs template.)
* Integrate the source-build job template into their existing logic to that interprets and expands a platform matrix.
  * This, but the jobs also have specialized pre-build steps, or other parts of the source-build job template interfere in other ways with their build system.

To let repos do all that without forcing them to maintain their own copy-pasted source-build yaml, we can just split up our template into parts that fit the scenarios.

I kept the idea of having `eng/common` contain a default managed-only platform docker image, but made it more explicit. If we have to update the managed-only build image, it's good to be able to do it in Arcade and have it automatically flow to the managed repos that have opted in.

RID-specific dev build: https://dev.azure.com/dnceng/internal/_build/results?buildId=823827&view=results
Managed-only dev build: https://dev.azure.com/dnceng/internal/_build/results?buildId=823858&view=results