### PR TITLE
Add Microsoft.Bcl.AsyncInterfaces/1.1.1

### DIFF
--- a/src/referencePackages/src/ProjectsToBuild.props
+++ b/src/referencePackages/src/ProjectsToBuild.props
@@ -267,6 +267,7 @@
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.resources.extensions/4.6.0/System.Resources.Extensions.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)microsoft.bcl.asyncinterfaces/1.0.0/Microsoft.Bcl.AsyncInterfaces.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)microsoft.bcl.asyncinterfaces/1.1.0/Microsoft.Bcl.AsyncInterfaces.csproj"/>
+    <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)microsoft.bcl.asyncinterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.runtime.compilerservices.unsafe/4.6.0/System.Runtime.CompilerServices.Unsafe.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.csproj"/>
     <ProjectsToBuild Include="$(ReferenceAssemblySourcePath)system.text.encodings.web/4.6.0/System.Text.Encodings.Web.csproj"/>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/Microsoft.Bcl.AsyncInterfaces.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)microsoft.bcl.asyncinterfaces/1.1.1/microsoft.bcl.asyncinterfaces.nuspec</NuspecFile>
+    <AssemblyOriginatorKeyFile>$(KeyFileDir)Open.snk</AssemblyOriginatorKeyFile>
+  <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)microsoft.bcl.asyncinterfaces/1.1.1/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)microsoft.bcl.asyncinterfaces/1.1.1</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/microsoft.bcl.asyncinterfaces.nuspec
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/microsoft.bcl.asyncinterfaces.nuspec
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>Microsoft.Bcl.AsyncInterfaces</id>
+    <version>1.1.1</version>
+    <title>Microsoft.Bcl.AsyncInterfaces</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <icon>Icon.png</icon>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides the IAsyncEnumerable&lt;T&gt; and IAsyncDisposable interfaces and helper types for .NET Standard 2.0. This package is not required starting with .NET Standard 2.1 and .NET Core 3.0.
+
+Commonly Used Types:
+System.IAsyncDisposable
+System.Collections.Generic.IAsyncEnumerable
+System.Collections.Generic.IAsyncEnumerator
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+      </group>
+      <group targetFramework=".NETCoreApp2.1" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/net461/Microsoft.Bcl.AsyncInterfaces.cs
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/net461/Microsoft.Bcl.AsyncInterfaces.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDescription("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDefaultAlias("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.20.21406")]
+[assembly: AssemblyInformationalVersion("4.700.20.21406 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+
+
+
+namespace System
+{
+    public partial interface IAsyncDisposable
+    {
+        System.Threading.Tasks.ValueTask DisposeAsync();
+    }
+}
+namespace System.Collections.Generic
+{
+    public partial interface IAsyncEnumerable<out T>
+    {
+        System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial interface IAsyncEnumerator<out T> : System.IAsyncDisposable
+    {
+        T Current { get; }
+        System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    public partial struct AsyncIteratorMethodBuilder
+    {
+        private object _dummy;
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+        public void Complete() { }
+        public static System.Runtime.CompilerServices.AsyncIteratorMethodBuilder Create() { throw null; }
+        public void MoveNext<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false, AllowMultiple=false)]
+    public sealed partial class AsyncIteratorStateMachineAttribute : System.Runtime.CompilerServices.StateMachineAttribute
+    {
+        public AsyncIteratorStateMachineAttribute(System.Type stateMachineType) : base (default(System.Type)) { }
+    }
+    public readonly partial struct ConfiguredAsyncDisposable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
+    }
+    public readonly partial struct ConfiguredCancelableAsyncEnumerable<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T>.Enumerator GetAsyncEnumerator() { throw null; }
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public readonly partial struct Enumerator
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public T Current { get { throw null; } }
+            public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
+            public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<bool> MoveNextAsync() { throw null; }
+        }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited=false)]
+    public sealed partial class EnumeratorCancellationAttribute : System.Attribute
+    {
+        public EnumeratorCancellationAttribute() { }
+    }
+}
+namespace System.Threading.Tasks
+{
+    public static partial class TaskAsyncEnumerableExtensions
+    {
+        public static System.Runtime.CompilerServices.ConfiguredAsyncDisposable ConfigureAwait(this System.IAsyncDisposable source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+}
+namespace System.Threading.Tasks.Sources
+{
+    public partial struct ManualResetValueTaskSourceCore<TResult>
+    {
+        private TResult _result;
+        private object _dummy;
+        private int _dummyPrimitive;
+        public bool RunContinuationsAsynchronously { get { throw null; } set { } }
+        public short Version { get { throw null; } }
+        public TResult GetResult(short token) { throw null; }
+        public System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
+        public void OnCompleted(System.Action<object> continuation, object state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
+        public void Reset() { }
+        public void SetException(System.Exception error) { }
+        public void SetResult(TResult result) { }
+    }
+}

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/netstandard2.0/Microsoft.Bcl.AsyncInterfaces.cs
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/netstandard2.0/Microsoft.Bcl.AsyncInterfaces.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDescription("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDefaultAlias("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.20.21406")]
+[assembly: AssemblyInformationalVersion("4.700.20.21406 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+
+
+
+namespace System
+{
+    public partial interface IAsyncDisposable
+    {
+        System.Threading.Tasks.ValueTask DisposeAsync();
+    }
+}
+namespace System.Collections.Generic
+{
+    public partial interface IAsyncEnumerable<out T>
+    {
+        System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial interface IAsyncEnumerator<out T> : System.IAsyncDisposable
+    {
+        T Current { get; }
+        System.Threading.Tasks.ValueTask<bool> MoveNextAsync();
+    }
+}
+namespace System.Runtime.CompilerServices
+{
+    public partial struct AsyncIteratorMethodBuilder
+    {
+        private object _dummy;
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.INotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+        public void Complete() { }
+        public static System.Runtime.CompilerServices.AsyncIteratorMethodBuilder Create() { throw null; }
+        public void MoveNext<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : System.Runtime.CompilerServices.IAsyncStateMachine { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false, AllowMultiple=false)]
+    public sealed partial class AsyncIteratorStateMachineAttribute : System.Runtime.CompilerServices.StateMachineAttribute
+    {
+        public AsyncIteratorStateMachineAttribute(System.Type stateMachineType) : base (default(System.Type)) { }
+    }
+    public readonly partial struct ConfiguredAsyncDisposable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
+    }
+    public readonly partial struct ConfiguredCancelableAsyncEnumerable<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T>.Enumerator GetAsyncEnumerator() { throw null; }
+        public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public readonly partial struct Enumerator
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public T Current { get { throw null; } }
+            public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
+            public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<bool> MoveNextAsync() { throw null; }
+        }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited=false)]
+    public sealed partial class EnumeratorCancellationAttribute : System.Attribute
+    {
+        public EnumeratorCancellationAttribute() { }
+    }
+}
+namespace System.Threading.Tasks
+{
+    public static partial class TaskAsyncEnumerableExtensions
+    {
+        public static System.Runtime.CompilerServices.ConfiguredAsyncDisposable ConfigureAwait(this System.IAsyncDisposable source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+}
+namespace System.Threading.Tasks.Sources
+{
+    public partial struct ManualResetValueTaskSourceCore<TResult>
+    {
+        private TResult _result;
+        private object _dummy;
+        private int _dummyPrimitive;
+        public bool RunContinuationsAsynchronously { get { throw null; } set { } }
+        public short Version { get { throw null; } }
+        public TResult GetResult(short token) { throw null; }
+        public System.Threading.Tasks.Sources.ValueTaskSourceStatus GetStatus(short token) { throw null; }
+        public void OnCompleted(System.Action<object> continuation, object state, short token, System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags flags) { }
+        public void Reset() { }
+        public void SetException(System.Exception error) { }
+        public void SetResult(TResult result) { }
+    }
+}

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.cs
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.1/ref/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDescription("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyDefaultAlias("Microsoft.Bcl.AsyncInterfaces")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.20.21406")]
+[assembly: AssemblyInformationalVersion("4.700.20.21406 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("1.0.0.0")]
+
+
+
+


### PR DESCRIPTION
I believe this prebuilt is a cycle that can be broken in SBRP. The usages are:

```xml
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/artifacts/obj/Microsoft.AspNetCore.Analyzers/project.assets.json" Project="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/artifacts/obj/Microsoft.AspNetCore.Components.Analyzers/project.assets.json" Project="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/artifacts/obj/Microsoft.AspNetCore.Mvc.Analyzers/project.assets.json" Project="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/artifacts/obj/Microsoft.AspNetCore.Mvc.Api.Analyzers/project.assets.json" Project="src/aspnetcore.ecdcc752d4639061c2c49727ee77a1039bbbca22/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/artifacts/obj/Microsoft.CodeAnalysis.CSharp.Workspaces/project.assets.json" Project="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/artifacts/obj/Microsoft.CodeAnalysis.VisualBasic.Workspaces/project.assets.json" Project="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
  <AnnotatedUsage Id="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" File="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/artifacts/obj/Microsoft.CodeAnalysis.Workspaces/project.assets.json" IsDirectDependency="true" Project="src/roslyn.90e570d763637c4d0d30524674a64b07bb885994/" SourceBuildPackageIdCreator="runtime MicrosoftBclAsyncInterfacesPackageVersion/5.0.0-rc.1.20451.14" />
```

The only direct dependency is `Microsoft.CodeAnalysis.Workspaces` in roslyn.

roslyn (usage) => runtime (no project.assets.json usage) => aspnetcore (usage *due to roslyn nupkg dependency*)

In the SDK, we have a source-built 5.0.0 version of this assembly:

```
#> find . -iname Microsoft.Bcl.AsyncInterfaces.dll -exec pwsh -c 'echo {}; [System.Reflection.Assembly]::LoadFrom("{}").GetName().Version.ToString()' \;
./sdk/5.0.100-rc.1.20452.10/Microsoft.Bcl.AsyncInterfaces.dll
5.0.0.0
```

So the cycle should be broken by it being a ref-only assembly.
