### PR TITLE
Update PrivateSourceBuiltArtifacts to a 5.0 version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-bootstrap.15</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-896680-20201123.1</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
-    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-3.1.100-preview3.dev.19571.3</PrivateSourceBuiltArtifactsPackageVersion>
+    <PrivateSourceBuiltArtifactsPackageVersion>0.1.0-5.0.100-bootstrap.15</PrivateSourceBuiltArtifactsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>

--- a/src/referencePackages/src/dir.props
+++ b/src/referencePackages/src/dir.props
@@ -30,6 +30,6 @@
       NETStandard.Library is no longer built in 5.0, so the version does not exist in
       PackageVersions.props.  Setting to latest version built in sbrp.
     -->
-    <NETStandardLibraryPackageVersion>2.2.0-prerelease.19564.1</NETStandardLibraryPackageVersion>
+    <NETStandardLibraryPackageVersion>2.0.3</NETStandardLibraryPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/referencePackages/src/dir.props
+++ b/src/referencePackages/src/dir.props
@@ -26,5 +26,10 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <WarningsAsErrors></WarningsAsErrors>
+    <!--
+      NETStandard.Library is no longer built in 5.0, so the version does not exist in
+      PackageVersions.props.  Setting to latest version built in sbrp.
+    -->
+    <NETStandardLibraryPackageVersion>2.2.0-prerelease.19564.1</NETStandardLibraryPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="AssembleTargetPack" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
       <!--
         Files that may need the 'constraint' token fixed before they can be assembled. They were
@@ -74,7 +74,7 @@
   </Target>
 
   <Target Name="AssembleTargetPack"
-          Condition="'@(TargetingPackSrcNotRequiringConstraintPatch)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+          Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
 
     <PropertyGroup>
       <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <ItemGroup>
       <!--
         Files that may need the 'constraint' token fixed before they can be assembled. They were
@@ -33,38 +34,29 @@
       <TargetingPackSrc
         Include="$(MSBuildProjectDirectory)\**\*.il"
         Exclude="@(TargetingPackSrcRequiringConstraintPatch)" />
-
   </ItemGroup>
 
-  <Target Name="AssembleTargetPack" Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+  <Target Name="GetProjectSrc"
+          BeforeTargets="PatchIl">
+    <PropertyGroup>
+      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
+    </PropertyGroup>
     <ItemGroup>
       <TargetingPackSrc
+        ILSrcFile="%(FullPath)"
         RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
+      <TargetingPackSrcRequiringConstraintPatch
+        ILSrcFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
+        RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll"
+        DestinationFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)" />
+      <AllSrc
+        Include="@(TargetingPackSrc);@(TargetingPackSrcRequiringConstraintPatch)" />
     </ItemGroup>
-    <PropertyGroup>
-      <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
-      <ArtifactsTFMPackTemp>$(RepoRoot)artifacts/TFMPack/</ArtifactsTFMPackTemp>
-      <IlasmToolPathSB>$(RepoRoot)/artifacts/source-built/coreclr-tools/</IlasmToolPathSB>
-    </PropertyGroup>
-
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Assemble TargetingPacks src." />
-    <MakeDir Directories="@(TargetingPackSrc->'$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)')" />
-    <!-- Note: Hack below to not fill up build logs.  Ilasm produces warning on validly disassembled il src.  The awk below eats just that warning -->
-    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(TargetingPackSrc.Identity) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(TargetingPackSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done assembling TargetPacks src." />
   </Target>
 
   <Target Name="PatchIl"
           BeforeTargets="AssembleTargetPack"
           Condition="'@(TargetingPackSrcRequiringConstraintPatch)' != ''">
-    <PropertyGroup>
-      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
-    </PropertyGroup>
-    <ItemGroup>
-      <TargetingPackSrcRequiringConstraintPatch
-        DestinationFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
-        RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
-    </ItemGroup>
 
     <!--
       Wrap constraint in single quotes in certain circumstances to avoid using reserved token.
@@ -75,14 +67,26 @@
     -->
     <Exec Command="
       set -e
-      destination=&quot;%(TargetingPackSrcRequiringConstraintPatch.DestinationFile)&quot;
+      destination=&quot;%(TargetingPackSrcRequiringConstraintPatch.ILSrcFile)&quot;
       mkdir -p &quot;${destination%/*}&quot;
       sed -E &quot;s/ constraint(([,)])|%24)/ 'constraint'\2/g&quot; &quot;%(TargetingPackSrcRequiringConstraintPatch.FullPath)&quot; > &quot;$destination&quot;" />
 
-    <ItemGroup>
-      <TargetingPackSrc
-        Include="@(TargetingPackSrcRequiringConstraintPatch->'%(DestinationFile)')" />
-    </ItemGroup>
+  </Target>
+
+  <Target Name="AssembleTargetPack"
+          Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+
+    <PropertyGroup>
+      <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
+      <ArtifactsTFMPackTemp>$(RepoRoot)artifacts/TFMPack/</ArtifactsTFMPackTemp>
+      <IlasmToolPathSB>$(RepoRoot)/artifacts/source-built/coreclr-tools/</IlasmToolPathSB>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Assemble TargetingPacks src." />
+    <MakeDir Directories="@(AllSrc->'$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)')" />
+    <!-- Note: Hack below to not fill up build logs.  Ilasm produces warning on validly disassembled il src.  The awk below eats just that warning -->
+    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(AllSrc.ILSrcFile) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(AllSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done assembling TargetPacks src." />
   </Target>
 
 </Project>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="AssembleTargetPack" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
       <!--
         Files that may need the 'constraint' token fixed before they can be assembled. They were
@@ -30,7 +30,7 @@
           $(MSBuildProjectDirectory)\**\WindowsFormsIntegration.il" />
 
       <!-- Find all IL. Leave out IL that needs to be patched before being built. -->
-      <TargetingPackSrc
+      <TargetingPackSrcNotRequiringConstraintPatch
         Include="$(MSBuildProjectDirectory)\**\*.il"
         Exclude="@(TargetingPackSrcRequiringConstraintPatch)" />
   </ItemGroup>
@@ -38,18 +38,19 @@
   <Target Name="GetProjectSrc"
           BeforeTargets="PatchIl">
     <PropertyGroup>
-      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
+      <PatchedILSrcDir>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcDir>
     </PropertyGroup>
+
     <ItemGroup>
-      <TargetingPackSrc
+      <TargetingPackSrcNotRequiringConstraintPatch
         ILSrcFile="%(FullPath)"
         RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
       <TargetingPackSrcRequiringConstraintPatch
-        ILSrcFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
+        ILSrcFile="$(PatchedILSrcDir)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
         RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll"
-        DestinationFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)" />
-      <AllSrc
-        Include="@(TargetingPackSrc);@(TargetingPackSrcRequiringConstraintPatch)" />
+        DestinationFile="$(PatchedILSrcDir)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)" />
+      <TargetingPackSrc
+        Include="@(TargetingPackSrcNotRequiringConstraintPatch);@(TargetingPackSrcRequiringConstraintPatch)" />
     </ItemGroup>
   </Target>
 
@@ -66,14 +67,14 @@
     -->
     <Exec Command="
       set -e
-      destination=&quot;%(TargetingPackSrcRequiringConstraintPatch.ILSrcFile)&quot;
+      destination=&quot;%(TargetingPackSrcRequiringConstraintPatch.DestinationFile)&quot;
       mkdir -p &quot;${destination%/*}&quot;
       sed -E &quot;s/ constraint(([,)])|%24)/ 'constraint'\2/g&quot; &quot;%(TargetingPackSrcRequiringConstraintPatch.FullPath)&quot; > &quot;$destination&quot;" />
 
   </Target>
 
   <Target Name="AssembleTargetPack"
-          Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+          Condition="'@(TargetingPackSrcNotRequiringConstraintPatch)' != '' and '$(SkipTargetingPacks)' != 'true' ">
 
     <PropertyGroup>
       <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
@@ -82,9 +83,9 @@
     </PropertyGroup>
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Assemble TargetingPacks src." />
-    <MakeDir Directories="@(AllSrc->'$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)')" />
+    <MakeDir Directories="@(TargetingPackSrc->'$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)')" />
     <!-- Note: Hack below to not fill up build logs.  Ilasm produces warning on validly disassembled il src.  The awk below eats just that warning -->
-    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(AllSrc.ILSrcFile) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(AllSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(TargetingPackSrc.ILSrcFile) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(TargetingPackSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done assembling TargetPacks src." />
   </Target>
 </Project>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <ItemGroup>
       <!--
         Files that may need the 'constraint' token fixed before they can be assembled. They were
@@ -88,5 +87,4 @@
     <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(AllSrc.ILSrcFile) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(AllSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done assembling TargetPacks src." />
   </Target>
-
 </Project>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -1,9 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <TargetingPackSrc Include="$(MSBuildProjectDirectory)/**/*.il" />
+      <!--
+        Files that may need the 'constraint' token fixed before they can be assembled. They were
+        decompiled with a 3.1 ildasm not compatible with 5.0 ilasm. In some cases the fix is not
+        necessary for a given IL filename in a certain TFM, but is necessary for a file with the
+        same name in a different TFM. The patch doesn't take a particularly long time, so prefer
+        keeping this list simple.
+      -->
+      <TargetingPackSrcRequiringConstraintPatch
+        Include="
+          $(MSBuildProjectDirectory)\**\Microsoft.AspNetCore.Components.il;
+          $(MSBuildProjectDirectory)\**\Microsoft.AspNetCore.Mvc.Cors.il;
+          $(MSBuildProjectDirectory)\**\Microsoft.AspNetCore.Routing.il;
+          $(MSBuildProjectDirectory)\**\netstandard.il;
+          $(MSBuildProjectDirectory)\**\presentationframework.*.il;
+          $(MSBuildProjectDirectory)\**\PresentationFramework.*.il;
+          $(MSBuildProjectDirectory)\**\PresentationFramework.il;
+          $(MSBuildProjectDirectory)\**\System.Activities.Presentation.il;
+          $(MSBuildProjectDirectory)\**\System.ComponentModel.Composition.il;
+          $(MSBuildProjectDirectory)\**\System.Data.Common.il;
+          $(MSBuildProjectDirectory)\**\System.Data.Entity.il;
+          $(MSBuildProjectDirectory)\**\System.Data.il;
+          $(MSBuildProjectDirectory)\**\System.Design.il;
+          $(MSBuildProjectDirectory)\**\System.Reflection.Metadata.il;
+          $(MSBuildProjectDirectory)\**\System.Web.il;
+          $(MSBuildProjectDirectory)\**\System.Xml.il;
+          $(MSBuildProjectDirectory)\**\System.XML.il;
+          $(MSBuildProjectDirectory)\**\WindowsFormsIntegration.il" />
+
+      <!-- Find all IL. Leave out IL that needs to be patched before being built. -->
+      <TargetingPackSrc
+        Include="$(MSBuildProjectDirectory)\**\*.il"
+        Exclude="@(TargetingPackSrcRequiringConstraintPatch)" />
+
   </ItemGroup>
+
   <Target Name="AssembleTargetPack" Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+    <ItemGroup>
+      <TargetingPackSrc
+        RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
+    </ItemGroup>
     <PropertyGroup>
       <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
       <ArtifactsTFMPackTemp>$(RepoRoot)artifacts/TFMPack/</ArtifactsTFMPackTemp>
@@ -13,7 +50,39 @@
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Assemble TargetingPacks src." />
     <MakeDir Directories="@(TargetingPackSrc->'$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)')" />
     <!-- Note: Hack below to not fill up build logs.  Ilasm produces warning on validly disassembled il src.  The awk below eats just that warning -->
-    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(TargetingPackSrc.Identity) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(RecursiveDir)%(TargetingPackSrc.Filename).dll |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="set -o pipefail;$(IlasmToolPathSB)ilasm %(TargetingPackSrc.Identity) -dll -quiet -nologo -output=$(ArtifactsTFMPackTemp)$(MSBuildProjectName)/%(TargetingPackSrc.RelativeOutputAssemblyFile) |&amp; awk '!/warning : Method has no body/'" IgnoreStandardErrorWarningFormat="true"/>
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Done assembling TargetPacks src." />
   </Target>
+
+  <Target Name="PatchIl"
+          BeforeTargets="AssembleTargetPack"
+          Condition="'@(TargetingPackSrcRequiringConstraintPatch)' != ''">
+    <ItemGroup>
+      <TargetingPackSrcRequiringConstraintPatch
+        DestinationFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
+        RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
+    </PropertyGroup>
+
+    <!--
+      Wrap constraint in single quotes in certain circumstances to avoid using reserved token.
+      Function param:
+        " constraint," => " 'constraint',"
+        " constraint)" => " 'constraint')"
+        " constraint"(eol) => " 'constraint'"(eol) (%24 is $ escaped in hex)
+    -->
+    <Exec Command="
+      set -e
+      destination=&quot;%(TargetingPackSrcRequiringConstraintPatch.DestinationFile)&quot;
+      mkdir -p &quot;${destination%/*}&quot;
+      sed -E &quot;s/ constraint(([,)])|%24)/ 'constraint'\2/g&quot; &quot;%(TargetingPackSrcRequiringConstraintPatch.FullPath)&quot; > &quot;$destination&quot;" />
+
+    <ItemGroup>
+      <TargetingPackSrc
+        Include="@(TargetingPackSrcRequiringConstraintPatch->'%(DestinationFile)')" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -57,14 +57,14 @@
   <Target Name="PatchIl"
           BeforeTargets="AssembleTargetPack"
           Condition="'@(TargetingPackSrcRequiringConstraintPatch)' != ''">
+    <PropertyGroup>
+      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
+    </PropertyGroup>
     <ItemGroup>
       <TargetingPackSrcRequiringConstraintPatch
         DestinationFile="$(PatchedILSrcTemp)$(MSBuildProjectName)/%(RecursiveDir)%(Filename).patched%(Extension)"
         RelativeOutputAssemblyFile="%(RecursiveDir)%(Filename).dll" />
     </ItemGroup>
-    <PropertyGroup>
-      <PatchedILSrcTemp>$(RepoRoot)artifacts/patchedILSrc/</PatchedILSrcTemp>
-    </PropertyGroup>
 
     <!--
       Wrap constraint in single quotes in certain circumstances to avoid using reserved token.

--- a/src/targetPacks/assemble.targets
+++ b/src/targetPacks/assemble.targets
@@ -74,7 +74,9 @@
   </Target>
 
   <Target Name="AssembleTargetPack"
-          Condition="'@(TargetingPackSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
+          Condition="'@(TargetingPackSrcNotRequiringConstraintPatch)' != '' 
+                      and '@(TargetingPackSrcRequiringConstraintPatch)' != '' 
+                      and '$(SkipTargetingPacks)' != 'true' ">
 
     <PropertyGroup>
       <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>

--- a/src/targetPacks/buildTargettingPackages.proj
+++ b/src/targetPacks/buildTargettingPackages.proj
@@ -32,7 +32,7 @@
   </Target>
 
   <Target Name="AssembleTargetPacks" BeforeTargets="Build" AfterTargets="BuildTFMDLLStructure" Condition="'@(TargetingPacksSrc)' != '' and '$(SkipTargetingPacks)' != 'true' ">
-    <MSBuild Projects="@(ProjFiles)" BuildInParallel="true"/>
+    <MSBuild Projects="@(ProjFiles)" Targets="AssembleTargetPack" BuildInParallel="true"/>
   </Target>
 
   <Target Name="Build" AfterTargets="AssembleTargetPacks" Condition=" '$(SkipTargetingPacks)' != 'true'" >


### PR DESCRIPTION
Update PrivateSourceBuiltArtifacts to a recent 5.0 version.  Update IL src to include the same fixup that is present in the master branch to make 'constraint' a keyword.  This allows it to be built with 5.0 ilasm.  

Also, since NETStandard.Library is no longer built in 5.0, the package version is not available in PackageVersions.props, so it needs to be included in dir.props for reference packages.