### PR TITLE
Update license url to MIT license for text only package

### DIFF
--- a/src/textOnlyPackages/src/microsoft.dotnet.common.itemtemplates/1.0.2-beta3/microsoft.dotnet.common.itemtemplates.nuspec
+++ b/src/textOnlyPackages/src/microsoft.dotnet.common.itemtemplates/1.0.2-beta3/microsoft.dotnet.common.itemtemplates.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://github.com/dotnet/templating</projectUrl>
     <description>Common File Templates for Microsoft Template Engine</description>
     <language>en-US</language>


### PR DESCRIPTION
Previous text-only packages have been updated to MIT as well.  This one was missed.  See https://github.com/dotnet/source-build-reference-packages/pull/53

Fixes https://github.com/dotnet/source-build/issues/2215