### PR TITLE
Port 4th set of reference packages from pre-arcade to main

### DIFF
--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/System.Security.Cryptography.Algorithms.4.3.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/System.Security.Cryptography.Algorithms.4.3.1.csproj
@@ -1,0 +1,67 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.algorithms/4.3.1/system.security.cryptography.algorithms.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.algorithms/4.3.1/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.algorithms/4.3.1</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.IO" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net46/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net46/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.25815.03")]
+[assembly: AssemblyInformationalVersion("4.6.25815.03 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Aes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACMD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.MD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RandomNumberGenerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Rfc2898DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSA))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAParameters))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.TripleDES))]
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net461/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net461/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.25815.03")]
+[assembly: AssemblyInformationalVersion("4.6.25815.03 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.1.0.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Aes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.ECDsa))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACMD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.MD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RandomNumberGenerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Rfc2898DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSA))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAParameters))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.TripleDES))]
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net462/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/net462/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.25815.03")]
+[assembly: AssemblyInformationalVersion("4.6.25815.03 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.2.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Aes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.ECDsa))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACMD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.HMACSHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.MD5))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RandomNumberGenerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Rfc2898DeriveBytes))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSA))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAEncryptionPaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSAParameters))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePadding))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.RSASignaturePaddingMode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA1))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA256))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA384))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.SHA512))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.TripleDES))]
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.3/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.3/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,241 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected Aes() { }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.Aes Create() { throw null; }
+    }
+    public abstract partial class DeriveBytes : System.IDisposable
+    {
+        protected DeriveBytes() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract byte[] GetBytes(int cb);
+        public abstract void Reset();
+    }
+    public partial class HMACMD5 : System.Security.Cryptography.HMAC
+    {
+        public HMACMD5() { }
+        public HMACMD5(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA1 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA1() { }
+        public HMACSHA1(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA256 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA256() { }
+        public HMACSHA256(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA384 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA384() { }
+        public HMACSHA384(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA512 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA512() { }
+        public HMACSHA512(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+    public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected MD5() { }
+        public static System.Security.Cryptography.MD5 Create() { throw null; }
+    }
+    public abstract partial class RandomNumberGenerator : System.IDisposable
+    {
+        protected RandomNumberGenerator() { }
+        public static System.Security.Cryptography.RandomNumberGenerator Create() { throw null; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract void GetBytes(byte[] data);
+    }
+    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
+    {
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, int saltSize) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
+        public int IterationCount { get { throw null; } set { } }
+        public byte[] Salt { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] GetBytes(int cb) { throw null; }
+        public override void Reset() { }
+    }
+    public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected RSA() { }
+        public static System.Security.Cryptography.RSA Create() { throw null; }
+        public abstract byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+    }
+    public sealed partial class RSAEncryptionPadding : System.IEquatable<System.Security.Cryptography.RSAEncryptionPadding>
+    {
+        internal RSAEncryptionPadding() { }
+        public System.Security.Cryptography.RSAEncryptionPaddingMode Mode { get { throw null; } }
+        public System.Security.Cryptography.HashAlgorithmName OaepHashAlgorithm { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA256 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA384 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA512 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding CreateOaep(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSAEncryptionPadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSAEncryptionPaddingMode
+    {
+        Pkcs1 = 0,
+        Oaep = 1,
+    }
+    public partial struct RSAParameters
+    {
+        public byte[] D;
+        public byte[] DP;
+        public byte[] DQ;
+        public byte[] Exponent;
+        public byte[] InverseQ;
+        public byte[] Modulus;
+        public byte[] P;
+        public byte[] Q;
+    }
+    public sealed partial class RSASignaturePadding : System.IEquatable<System.Security.Cryptography.RSASignaturePadding>
+    {
+        internal RSASignaturePadding() { }
+        public System.Security.Cryptography.RSASignaturePaddingMode Mode { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pss { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSASignaturePadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSASignaturePaddingMode
+    {
+        Pkcs1 = 0,
+        Pss = 1,
+    }
+    public abstract partial class SHA1 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA1() { }
+        public static System.Security.Cryptography.SHA1 Create() { throw null; }
+    }
+    public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA256() { }
+        public static System.Security.Cryptography.SHA256 Create() { throw null; }
+    }
+    public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA384() { }
+        public static System.Security.Cryptography.SHA384 Create() { throw null; }
+    }
+    public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA512() { }
+        public static System.Security.Cryptography.SHA512 Create() { throw null; }
+    }
+    public abstract partial class TripleDES : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected TripleDES() { }
+        public override byte[] Key { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.TripleDES Create() { throw null; }
+        public static bool IsWeakKey(byte[] rgbKey) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.4/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.4/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.1.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected Aes() { }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.Aes Create() { throw null; }
+    }
+    public abstract partial class DeriveBytes : System.IDisposable
+    {
+        protected DeriveBytes() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract byte[] GetBytes(int cb);
+        public abstract void Reset();
+    }
+    public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected ECDsa() { }
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public abstract byte[] SignHash(byte[] hash);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature);
+    }
+    public partial class HMACMD5 : System.Security.Cryptography.HMAC
+    {
+        public HMACMD5() { }
+        public HMACMD5(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA1 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA1() { }
+        public HMACSHA1(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA256 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA256() { }
+        public HMACSHA256(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA384 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA384() { }
+        public HMACSHA384(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA512 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA512() { }
+        public HMACSHA512(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+    public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected MD5() { }
+        public static System.Security.Cryptography.MD5 Create() { throw null; }
+    }
+    public abstract partial class RandomNumberGenerator : System.IDisposable
+    {
+        protected RandomNumberGenerator() { }
+        public static System.Security.Cryptography.RandomNumberGenerator Create() { throw null; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract void GetBytes(byte[] data);
+    }
+    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
+    {
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, int saltSize) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
+        public int IterationCount { get { throw null; } set { } }
+        public byte[] Salt { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] GetBytes(int cb) { throw null; }
+        public override void Reset() { }
+    }
+    public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected RSA() { }
+        public static System.Security.Cryptography.RSA Create() { throw null; }
+        public abstract byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+    }
+    public sealed partial class RSAEncryptionPadding : System.IEquatable<System.Security.Cryptography.RSAEncryptionPadding>
+    {
+        internal RSAEncryptionPadding() { }
+        public System.Security.Cryptography.RSAEncryptionPaddingMode Mode { get { throw null; } }
+        public System.Security.Cryptography.HashAlgorithmName OaepHashAlgorithm { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA256 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA384 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA512 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding CreateOaep(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSAEncryptionPadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSAEncryptionPaddingMode
+    {
+        Pkcs1 = 0,
+        Oaep = 1,
+    }
+    public partial struct RSAParameters
+    {
+        public byte[] D;
+        public byte[] DP;
+        public byte[] DQ;
+        public byte[] Exponent;
+        public byte[] InverseQ;
+        public byte[] Modulus;
+        public byte[] P;
+        public byte[] Q;
+    }
+    public sealed partial class RSASignaturePadding : System.IEquatable<System.Security.Cryptography.RSASignaturePadding>
+    {
+        internal RSASignaturePadding() { }
+        public System.Security.Cryptography.RSASignaturePaddingMode Mode { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pss { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSASignaturePadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSASignaturePaddingMode
+    {
+        Pkcs1 = 0,
+        Pss = 1,
+    }
+    public abstract partial class SHA1 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA1() { }
+        public static System.Security.Cryptography.SHA1 Create() { throw null; }
+    }
+    public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA256() { }
+        public static System.Security.Cryptography.SHA256 Create() { throw null; }
+    }
+    public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA384() { }
+        public static System.Security.Cryptography.SHA384 Create() { throw null; }
+    }
+    public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA512() { }
+        public static System.Security.Cryptography.SHA512 Create() { throw null; }
+    }
+    public abstract partial class TripleDES : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected TripleDES() { }
+        public override byte[] Key { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.TripleDES Create() { throw null; }
+        public static bool IsWeakKey(byte[] rgbKey) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.6/System.Security.Cryptography.Algorithms.cs
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/ref/netstandard1.6/System.Security.Cryptography.Algorithms.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Algorithms")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.2.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class Aes : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected Aes() { }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.Aes Create() { throw null; }
+    }
+    public abstract partial class DeriveBytes : System.IDisposable
+    {
+        protected DeriveBytes() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract byte[] GetBytes(int cb);
+        public abstract void Reset();
+    }
+    public partial struct ECCurve
+    {
+        public byte[] A;
+        public byte[] B;
+        public byte[] Cofactor;
+        public System.Security.Cryptography.ECCurve.ECCurveType CurveType;
+        public System.Security.Cryptography.ECPoint G;
+        public System.Security.Cryptography.HashAlgorithmName? Hash;
+        public byte[] Order;
+        public byte[] Polynomial;
+        public byte[] Prime;
+        public byte[] Seed;
+        public bool IsCharacteristic2 { get { throw null; } }
+        public bool IsExplicit { get { throw null; } }
+        public bool IsNamed { get { throw null; } }
+        public bool IsPrime { get { throw null; } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public static System.Security.Cryptography.ECCurve CreateFromFriendlyName(string oidFriendlyName) { throw null; }
+        public static System.Security.Cryptography.ECCurve CreateFromOid(System.Security.Cryptography.Oid curveOid) { throw null; }
+        public static System.Security.Cryptography.ECCurve CreateFromValue(string oidValue) { throw null; }
+        public void Validate() { }
+        public enum ECCurveType
+        {
+            Implicit = 0,
+            PrimeShortWeierstrass = 1,
+            PrimeTwistedEdwards = 2,
+            PrimeMontgomery = 3,
+            Characteristic2 = 4,
+            Named = 5,
+        }
+        public static partial class NamedCurves
+        {
+            public static System.Security.Cryptography.ECCurve brainpoolP160r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP160t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP192r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP192t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP224r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP224t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP256r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP256t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP320r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP320t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP384r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP384t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP512r1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve brainpoolP512t1 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve nistP256 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve nistP384 { get { throw null; } }
+            public static System.Security.Cryptography.ECCurve nistP521 { get { throw null; } }
+        }
+    }
+    public abstract partial class ECDsa : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected ECDsa() { }
+        public static System.Security.Cryptography.ECDsa Create() { throw null; }
+        public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECCurve curve) { throw null; }
+        public static System.Security.Cryptography.ECDsa Create(System.Security.Cryptography.ECParameters parameters) { throw null; }
+        public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
+        public virtual System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        public virtual void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public virtual void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public abstract byte[] SignHash(byte[] hash);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature);
+    }
+    public partial struct ECParameters
+    {
+        public System.Security.Cryptography.ECCurve Curve;
+        public byte[] D;
+        public System.Security.Cryptography.ECPoint Q;
+        public void Validate() { }
+    }
+    public partial struct ECPoint
+    {
+        public byte[] X;
+        public byte[] Y;
+    }
+    public partial class HMACMD5 : System.Security.Cryptography.HMAC
+    {
+        public HMACMD5() { }
+        public HMACMD5(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA1 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA1() { }
+        public HMACSHA1(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA256 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA256() { }
+        public HMACSHA256(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA384 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA384() { }
+        public HMACSHA384(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public partial class HMACSHA512 : System.Security.Cryptography.HMAC
+    {
+        public HMACSHA512() { }
+        public HMACSHA512(byte[] key) { }
+        public override int HashSize { get { throw null; } }
+        public override byte[] Key { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        protected override void HashCore(byte[] rgb, int ib, int cb) { }
+        protected override byte[] HashFinal() { throw null; }
+        public override void Initialize() { }
+    }
+    public sealed partial class IncrementalHash : System.IDisposable
+    {
+        internal IncrementalHash() { }
+        public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public void AppendData(byte[] data) { }
+        public void AppendData(byte[] data, int offset, int count) { }
+        public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
+        public void Dispose() { }
+        public byte[] GetHashAndReset() { throw null; }
+    }
+    public abstract partial class MD5 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected MD5() { }
+        public static System.Security.Cryptography.MD5 Create() { throw null; }
+    }
+    public abstract partial class RandomNumberGenerator : System.IDisposable
+    {
+        protected RandomNumberGenerator() { }
+        public static System.Security.Cryptography.RandomNumberGenerator Create() { throw null; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public abstract void GetBytes(byte[] data);
+    }
+    public partial class Rfc2898DeriveBytes : System.Security.Cryptography.DeriveBytes
+    {
+        public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt) { }
+        public Rfc2898DeriveBytes(string password, byte[] salt, int iterations) { }
+        public Rfc2898DeriveBytes(string password, int saltSize) { }
+        public Rfc2898DeriveBytes(string password, int saltSize, int iterations) { }
+        public int IterationCount { get { throw null; } set { } }
+        public byte[] Salt { get { throw null; } set { } }
+        protected override void Dispose(bool disposing) { }
+        public override byte[] GetBytes(int cb) { throw null; }
+        public override void Reset() { }
+    }
+    public abstract partial class RSA : System.Security.Cryptography.AsymmetricAlgorithm
+    {
+        protected RSA() { }
+        public static System.Security.Cryptography.RSA Create() { throw null; }
+        public abstract byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding);
+        public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
+        protected abstract byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        protected abstract byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm);
+        public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
+        public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+        public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public bool VerifyData(System.IO.Stream data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public abstract bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding);
+    }
+    public sealed partial class RSAEncryptionPadding : System.IEquatable<System.Security.Cryptography.RSAEncryptionPadding>
+    {
+        internal RSAEncryptionPadding() { }
+        public System.Security.Cryptography.RSAEncryptionPaddingMode Mode { get { throw null; } }
+        public System.Security.Cryptography.HashAlgorithmName OaepHashAlgorithm { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA256 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA384 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding OaepSHA512 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSAEncryptionPadding CreateOaep(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSAEncryptionPadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSAEncryptionPadding left, System.Security.Cryptography.RSAEncryptionPadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSAEncryptionPaddingMode
+    {
+        Pkcs1 = 0,
+        Oaep = 1,
+    }
+    public partial struct RSAParameters
+    {
+        public byte[] D;
+        public byte[] DP;
+        public byte[] DQ;
+        public byte[] Exponent;
+        public byte[] InverseQ;
+        public byte[] Modulus;
+        public byte[] P;
+        public byte[] Q;
+    }
+    public sealed partial class RSASignaturePadding : System.IEquatable<System.Security.Cryptography.RSASignaturePadding>
+    {
+        internal RSASignaturePadding() { }
+        public System.Security.Cryptography.RSASignaturePaddingMode Mode { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pkcs1 { get { throw null; } }
+        public static System.Security.Cryptography.RSASignaturePadding Pss { get { throw null; } }
+        public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Security.Cryptography.RSASignaturePadding other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public static bool operator !=(System.Security.Cryptography.RSASignaturePadding left, System.Security.Cryptography.RSASignaturePadding right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public enum RSASignaturePaddingMode
+    {
+        Pkcs1 = 0,
+        Pss = 1,
+    }
+    public abstract partial class SHA1 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA1() { }
+        public static System.Security.Cryptography.SHA1 Create() { throw null; }
+    }
+    public abstract partial class SHA256 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA256() { }
+        public static System.Security.Cryptography.SHA256 Create() { throw null; }
+    }
+    public abstract partial class SHA384 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA384() { }
+        public static System.Security.Cryptography.SHA384 Create() { throw null; }
+    }
+    public abstract partial class SHA512 : System.Security.Cryptography.HashAlgorithm
+    {
+        protected SHA512() { }
+        public static System.Security.Cryptography.SHA512 Create() { throw null; }
+    }
+    public abstract partial class TripleDES : System.Security.Cryptography.SymmetricAlgorithm
+    {
+        protected TripleDES() { }
+        public override byte[] Key { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalBlockSizes { get { throw null; } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public static System.Security.Cryptography.TripleDES Create() { throw null; }
+        public static bool IsWeakKey(byte[] rgbKey) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/system.security.cryptography.algorithms.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/system.security.cryptography.algorithms.nuspec
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.Algorithms</id>
+    <version>4.3.1</version>
+    <title>System.Security.Cryptography.Algorithms</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides base types for cryptographic algorithms, including hashing, encryption, and signing operations.
+
+Commonly Used Types:
+System.Security.Cryptography.Aes
+System.Security.Cryptography.RSA
+System.Security.Cryptography.RSAParameters
+System.Security.Cryptography.HMACSHA1
+System.Security.Cryptography.SHA256
+System.Security.Cryptography.SHA1
+System.Security.Cryptography.SHA512
+System.Security.Cryptography.SHA384
+System.Security.Cryptography.HMACSHA256
+System.Security.Cryptography.MD5
+System.Security.Cryptography.HMACSHA384
+System.Security.Cryptography.HMACSHA512
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0" />
+      <group targetFramework="MonoTouch1.0" />
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.3">
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETCore5.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.IO" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.4">
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.6">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Collections" version="4.3.0" exclude="Compile" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.iOS1.0" />
+      <group targetFramework="Xamarin.Mac2.0" />
+      <group targetFramework="Xamarin.TVOS1.0" />
+      <group targetFramework="Xamarin.WatchOS1.0" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.3" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6.3" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/System.Security.Cryptography.Pkcs.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/System.Security.Cryptography.Pkcs.4.7.0.csproj
@@ -1,0 +1,64 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;net46;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.pkcs/4.7.0/system.security.cryptography.pkcs.nuspec</NuspecFile>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.pkcs/4.7.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.pkcs/4.7.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+    <Reference Include="System" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/net46/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/net46/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.Xml;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.24705.01")]
+[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.AlgorithmIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipient))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.ContentInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.EnvelopedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyAgreeRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyTransRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9AttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9ContentType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentName))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9MessageDigest))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9SigningTime))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.PublicKeyInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.X509IssuerSerial))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/net461/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/net461/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.Xml;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.56404")]
+[assembly: AssemblyInformationalVersion("4.700.19.56404 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.1.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.X509IssuerSerial))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.AlgorithmIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipient))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsSigner))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.ContentInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.EnvelopedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyAgreeRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyTransRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9AttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9ContentType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentName))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9MessageDigest))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9SigningTime))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.PublicKeyInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierType))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netcoreapp2.1/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netcoreapp2.1/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,404 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.27129.04")]
+[assembly: AssemblyInformationalVersion("4.6.27129.04 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.2")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netcoreapp3.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netcoreapp3.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,537 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.56404")]
+[assembly: AssemblyInformationalVersion("4.700.19.56404 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.1.1.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+        public System.Security.Cryptography.RSAEncryptionPadding RSAEncryptionPadding { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class Pkcs12Builder
+    {
+        public Pkcs12Builder() { }
+        public bool IsSealed { get { throw null; } }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, string password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsUnencrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { }
+        public byte[] Encode() { throw null; }
+        public void SealWithMac(System.ReadOnlySpan<char> password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithMac(string password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithoutIntegrity() { }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12CertBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(System.Security.Cryptography.Oid certificateType, System.ReadOnlyMemory<byte> encodedCertificate) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+        public bool IsX509Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+        public System.Security.Cryptography.Oid GetCertificateType() { throw null; }
+    }
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+        public bool VerifyMac(System.ReadOnlySpan<char> password) { throw null; }
+        public bool VerifyMac(string password) { throw null; }
+    }
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12KeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(System.ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, System.ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.Oid GetBagId() { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12SafeContents() { }
+        public System.Security.Cryptography.Pkcs.Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12CertBag AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12KeyBag AddKeyUnencrypted(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContentsBag AddNestedContents(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { throw null; }
+        public void AddSafeBag(System.Security.Cryptography.Pkcs.Pkcs12SafeBag safeBag) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SecretBag AddSecret(System.Security.Cryptography.Oid secretType, System.ReadOnlyMemory<byte> secretValue) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public void Decrypt(byte[] passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<byte> passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<char> password) { }
+        public void Decrypt(string password) { }
+        public System.Collections.Generic.IEnumerable<System.Security.Cryptography.Pkcs.Pkcs12SafeBag> GetBags() { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContents SafeContents { get { throw null; } }
+    }
+    public sealed partial class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+        public System.Security.Cryptography.Oid GetSecretType() { throw null; }
+    }
+    public sealed partial class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(System.ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(System.Security.Cryptography.Oid algorithmId, System.ReadOnlyMemory<byte>? algorithmParameters, System.ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+        public System.Security.Cryptography.Oid AlgorithmId { get { throw null; } }
+        public System.ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Create(System.Security.Cryptography.AsymmetricAlgorithm privateKey) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Decode(System.ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<char> password, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public byte[] Encode() { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9LocalKeyId : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+        public Pkcs9LocalKeyId(System.ReadOnlySpan<byte> keyId) { }
+        public System.ReadOnlyMemory<byte> KeyId { get { throw null; } }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard1.3/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard1.3/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard2.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard2.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.27129.04")]
+[assembly: AssemblyInformationalVersion("4.6.27129.04 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.2")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard2.1/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/ref/netstandard2.1/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,537 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.56404")]
+[assembly: AssemblyInformationalVersion("4.700.19.56404 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.4.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+        public System.Security.Cryptography.RSAEncryptionPadding RSAEncryptionPadding { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class Pkcs12Builder
+    {
+        public Pkcs12Builder() { }
+        public bool IsSealed { get { throw null; } }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, string password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsUnencrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { }
+        public byte[] Encode() { throw null; }
+        public void SealWithMac(System.ReadOnlySpan<char> password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithMac(string password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithoutIntegrity() { }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12CertBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(System.Security.Cryptography.Oid certificateType, System.ReadOnlyMemory<byte> encodedCertificate) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+        public bool IsX509Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+        public System.Security.Cryptography.Oid GetCertificateType() { throw null; }
+    }
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+        public bool VerifyMac(System.ReadOnlySpan<char> password) { throw null; }
+        public bool VerifyMac(string password) { throw null; }
+    }
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12KeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(System.ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, System.ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.Oid GetBagId() { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12SafeContents() { }
+        public System.Security.Cryptography.Pkcs.Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12CertBag AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12KeyBag AddKeyUnencrypted(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContentsBag AddNestedContents(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { throw null; }
+        public void AddSafeBag(System.Security.Cryptography.Pkcs.Pkcs12SafeBag safeBag) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SecretBag AddSecret(System.Security.Cryptography.Oid secretType, System.ReadOnlyMemory<byte> secretValue) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public void Decrypt(byte[] passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<byte> passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<char> password) { }
+        public void Decrypt(string password) { }
+        public System.Collections.Generic.IEnumerable<System.Security.Cryptography.Pkcs.Pkcs12SafeBag> GetBags() { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContents SafeContents { get { throw null; } }
+    }
+    public sealed partial class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+        public System.Security.Cryptography.Oid GetSecretType() { throw null; }
+    }
+    public sealed partial class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(System.ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(System.Security.Cryptography.Oid algorithmId, System.ReadOnlyMemory<byte>? algorithmParameters, System.ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+        public System.Security.Cryptography.Oid AlgorithmId { get { throw null; } }
+        public System.ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Create(System.Security.Cryptography.AsymmetricAlgorithm privateKey) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Decode(System.ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<char> password, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public byte[] Encode() { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9LocalKeyId : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+        public Pkcs9LocalKeyId(System.ReadOnlySpan<byte> keyId) { }
+        public System.ReadOnlyMemory<byte> KeyId { get { throw null; } }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/system.security.cryptography.pkcs.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/system.security.cryptography.pkcs.nuspec
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.Pkcs</id>
+    <version>4.7.0</version>
+    <title>System.Security.Cryptography.Pkcs</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides support for PKCS and CMS algorithms.
+
+Commonly Used Types:
+System.Security.Cryptography.Pkcs.EnvelopedCms
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0" />
+      <group targetFramework="MonoTouch1.0" />
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETCoreApp2.0">
+        <dependency id="System.Memory" version="4.5.3" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETCoreApp2.1">
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="System.Collections" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.5.0" exclude="Compile" />
+        <dependency id="System.Memory" version="4.5.3" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Security.Cryptography.Cng" version="4.7.0" exclude="Compile" />
+      </group>
+      <group targetFramework="UAP10.0.16299">
+        <dependency id="System.Memory" version="4.5.3" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.iOS1.0" />
+      <group targetFramework="Xamarin.Mac2.0" />
+      <group targetFramework="Xamarin.TVOS1.0" />
+      <group targetFramework="Xamarin.WatchOS1.0" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/System.Security.Cryptography.Pkcs.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/System.Security.Cryptography.Pkcs.5.0.0.csproj
@@ -1,0 +1,67 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;net46;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.pkcs/5.0.0/system.security.cryptography.pkcs.nuspec</NuspecFile>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.pkcs/5.0.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.pkcs/5.0.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="System.Formats.Asn1" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+    <Reference Include="System" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/net46/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/net46/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.Xml;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.24705.01")]
+[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.AlgorithmIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipient))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.ContentInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.EnvelopedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyAgreeRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyTransRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9AttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9ContentType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentName))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9MessageDigest))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9SigningTime))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.PublicKeyInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.X509IssuerSerial))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/net461/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/net461/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.Xml;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("5.0.20.51904")]
+[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("5.0.0.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.CryptographicAttributeObjectEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.X509IssuerSerial))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.AlgorithmIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipient))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsRecipientEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.CmsSigner))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.ContentInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.EnvelopedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyAgreeRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.KeyTransRecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9AttributeObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9ContentType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentDescription))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9DocumentName))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9MessageDigest))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.Pkcs9SigningTime))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.PublicKeyInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.RecipientInfoType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignedCms))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfoCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SignerInfoEnumerator))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifier))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Pkcs.SubjectIdentifierType))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netcoreapp2.1/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netcoreapp2.1/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,404 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.27129.04")]
+[assembly: AssemblyInformationalVersion("4.6.27129.04 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.2")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netcoreapp3.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netcoreapp3.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,541 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("5.0.20.51904")]
+[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("5.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+        public System.Security.Cryptography.RSAEncryptionPadding RSAEncryptionPadding { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+        public static System.Security.Cryptography.Oid GetContentType(System.ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decode(System.ReadOnlySpan<byte> encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class Pkcs12Builder
+    {
+        public Pkcs12Builder() { }
+        public bool IsSealed { get { throw null; } }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, string password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsUnencrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { }
+        public byte[] Encode() { throw null; }
+        public void SealWithMac(System.ReadOnlySpan<char> password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithMac(string password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithoutIntegrity() { }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12CertBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(System.Security.Cryptography.Oid certificateType, System.ReadOnlyMemory<byte> encodedCertificate) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+        public bool IsX509Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+        public System.Security.Cryptography.Oid GetCertificateType() { throw null; }
+    }
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+        public bool VerifyMac(System.ReadOnlySpan<char> password) { throw null; }
+        public bool VerifyMac(string password) { throw null; }
+    }
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12KeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(System.ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, System.ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.Oid GetBagId() { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12SafeContents() { }
+        public System.Security.Cryptography.Pkcs.Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12CertBag AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12KeyBag AddKeyUnencrypted(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContentsBag AddNestedContents(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { throw null; }
+        public void AddSafeBag(System.Security.Cryptography.Pkcs.Pkcs12SafeBag safeBag) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SecretBag AddSecret(System.Security.Cryptography.Oid secretType, System.ReadOnlyMemory<byte> secretValue) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public void Decrypt(byte[] passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<byte> passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<char> password) { }
+        public void Decrypt(string password) { }
+        public System.Collections.Generic.IEnumerable<System.Security.Cryptography.Pkcs.Pkcs12SafeBag> GetBags() { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContents SafeContents { get { throw null; } }
+    }
+    public sealed partial class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+        public System.Security.Cryptography.Oid GetSecretType() { throw null; }
+    }
+    public sealed partial class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(System.ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(System.Security.Cryptography.Oid algorithmId, System.ReadOnlyMemory<byte>? algorithmParameters, System.ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+        public System.Security.Cryptography.Oid AlgorithmId { get { throw null; } }
+        public System.ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Create(System.Security.Cryptography.AsymmetricAlgorithm privateKey) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Decode(System.ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<char> password, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public byte[] Encode() { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9LocalKeyId : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+        public Pkcs9LocalKeyId(System.ReadOnlySpan<byte> keyId) { }
+        public System.ReadOnlyMemory<byte> KeyId { get { throw null; } }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)]out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)]out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decode(System.ReadOnlySpan<byte> encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard1.3/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard1.3/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,274 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard2.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard2.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.27129.04")]
+[assembly: AssemblyInformationalVersion("4.6.27129.04 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.2")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
+        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard2.1/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/ref/netstandard2.1/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,541 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("5.0.20.51904")]
+[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.4.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid) { }
+        public CryptographicAttributeObject(System.Security.Cryptography.Oid oid, System.Security.Cryptography.AsnEncodedDataCollection values) { }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public System.Security.Cryptography.AsnEncodedDataCollection Values { get { throw null; } }
+    }
+    public sealed partial class CryptographicAttributeObjectCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+        public CryptographicAttributeObjectCollection(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.AsnEncodedData asnEncodedData) { throw null; }
+        public int Add(System.Security.Cryptography.CryptographicAttributeObject attribute) { throw null; }
+        public void CopyTo(System.Security.Cryptography.CryptographicAttributeObject[] array, int index) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.CryptographicAttributeObject attribute) { }
+        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CryptographicAttributeObjectEnumerator : System.Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+        public System.Security.Cryptography.CryptographicAttributeObject Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+}
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid) { }
+        public AlgorithmIdentifier(System.Security.Cryptography.Oid oid, int keyLength) { }
+        public int KeyLength { get { throw null; } set { } }
+        public System.Security.Cryptography.Oid Oid { get { throw null; } set { } }
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsRecipient(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.RSAEncryptionPadding rsaEncryptionPadding) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+        public System.Security.Cryptography.RSAEncryptionPadding RSAEncryptionPadding { get { throw null; } }
+    }
+    public sealed partial class CmsRecipientCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public CmsRecipientCollection(System.Security.Cryptography.Pkcs.SubjectIdentifierType recipientIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.CmsRecipient this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public int Add(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.CmsRecipient[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.CmsRecipientEnumerator GetEnumerator() { throw null; }
+        public void Remove(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class CmsRecipientEnumerator : System.Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+        public System.Security.Cryptography.Pkcs.CmsRecipient Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+        public CmsSigner(System.Security.Cryptography.CspParameters parameters) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public CmsSigner(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public CmsSigner(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } set { } }
+        public System.Security.Cryptography.X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+        public System.Security.Cryptography.AsymmetricAlgorithm PrivateKey { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+        public ContentInfo(System.Security.Cryptography.Oid contentType, byte[] content) { }
+        public byte[] Content { get { throw null; } }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public static System.Security.Cryptography.Oid GetContentType(byte[] encodedMessage) { throw null; }
+        public static System.Security.Cryptography.Oid GetContentType(System.ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public EnvelopedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, System.Security.Cryptography.Pkcs.AlgorithmIdentifier encryptionAlgorithm) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfoCollection RecipientInfos { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decode(System.ReadOnlySpan<byte> encodedMessage) { }
+        public void Decrypt() { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.AsymmetricAlgorithm privateKey) { }
+        public void Decrypt(System.Security.Cryptography.Pkcs.RecipientInfo recipientInfo, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public void Decrypt(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore) { }
+        public byte[] Encode() { throw null; }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipient recipient) { }
+        public void Encrypt(System.Security.Cryptography.Pkcs.CmsRecipientCollection recipients) { }
+    }
+    public sealed partial class KeyAgreeRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+        public System.DateTime Date { get { throw null; } }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObject OtherKeyAttribute { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class KeyTransRecipientInfo : System.Security.Cryptography.Pkcs.RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+        public override byte[] EncryptedKey { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+        public override System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get { throw null; } }
+        public override int Version { get { throw null; } }
+    }
+    public sealed partial class Pkcs12Builder
+    {
+        public Pkcs12Builder() { }
+        public bool IsSealed { get { throw null; } }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsEncrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents, string password, System.Security.Cryptography.PbeParameters pbeParameters) { }
+        public void AddSafeContentsUnencrypted(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { }
+        public byte[] Encode() { throw null; }
+        public void SealWithMac(System.ReadOnlySpan<char> password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithMac(string password, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public void SealWithoutIntegrity() { }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12CertBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(System.Security.Cryptography.Oid certificateType, System.ReadOnlyMemory<byte> encodedCertificate) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+        public bool IsX509Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+        public System.Security.Cryptography.Oid GetCertificateType() { throw null; }
+    }
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+        public System.Collections.ObjectModel.ReadOnlyCollection<System.Security.Cryptography.Pkcs.Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs12Info Decode(System.ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+        public bool VerifyMac(System.ReadOnlySpan<char> password) { throw null; }
+        public bool VerifyMac(string password) { throw null; }
+    }
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3,
+    }
+    public sealed partial class Pkcs12KeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(System.ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, System.ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.Oid GetBagId() { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12SafeContents() { }
+        public System.Security.Cryptography.Pkcs.Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.Pkcs12CertBag AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12KeyBag AddKeyUnencrypted(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContentsBag AddNestedContents(System.Security.Cryptography.Pkcs.Pkcs12SafeContents safeContents) { throw null; }
+        public void AddSafeBag(System.Security.Cryptography.Pkcs.Pkcs12SafeBag safeBag) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SecretBag AddSecret(System.Security.Cryptography.Oid secretType, System.ReadOnlyMemory<byte> secretValue) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, byte[] passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public System.Security.Cryptography.Pkcs.Pkcs12ShroudedKeyBag AddShroudedKey(System.Security.Cryptography.AsymmetricAlgorithm key, string password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public void Decrypt(byte[] passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<byte> passwordBytes) { }
+        public void Decrypt(System.ReadOnlySpan<char> password) { }
+        public void Decrypt(string password) { }
+        public System.Collections.Generic.IEnumerable<System.Security.Cryptography.Pkcs.Pkcs12SafeBag> GetBags() { throw null; }
+    }
+    public sealed partial class Pkcs12SafeContentsBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.Security.Cryptography.Pkcs.Pkcs12SafeContents SafeContents { get { throw null; } }
+    }
+    public sealed partial class Pkcs12SecretBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+        public System.Security.Cryptography.Oid GetSecretType() { throw null; }
+    }
+    public sealed partial class Pkcs12ShroudedKeyBag : System.Security.Cryptography.Pkcs.Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(System.ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base (default(string), default(System.ReadOnlyMemory<byte>), default(bool)) { }
+        public System.ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(System.Security.Cryptography.Oid algorithmId, System.ReadOnlyMemory<byte>? algorithmParameters, System.ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+        public System.Security.Cryptography.Oid AlgorithmId { get { throw null; } }
+        public System.ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+        public System.ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Create(System.Security.Cryptography.AsymmetricAlgorithm privateKey) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo Decode(System.ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Pkcs8PrivateKeyInfo DecryptAndDecode(System.ReadOnlySpan<char> password, System.ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+        public byte[] Encode() { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public byte[] Encrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryEncrypt(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public partial class Pkcs9AttributeObject : System.Security.Cryptography.AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public Pkcs9AttributeObject(System.Security.Cryptography.Oid oid, byte[] encodedData) { }
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+        public new System.Security.Cryptography.Oid Oid { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9ContentType() { }
+        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+        public Pkcs9DocumentDescription(string documentDescription) { }
+        public string DocumentDescription { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+        public Pkcs9DocumentName(string documentName) { }
+        public string DocumentName { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9LocalKeyId : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+        public Pkcs9LocalKeyId(System.ReadOnlySpan<byte> keyId) { }
+        public System.ReadOnlyMemory<byte> KeyId { get { throw null; } }
+    }
+    public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9MessageDigest() { }
+        public byte[] MessageDigest { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+        public Pkcs9SigningTime(System.DateTime signingTime) { }
+        public System.DateTime SigningTime { get { throw null; } }
+        public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+        public System.Security.Cryptography.Pkcs.AlgorithmIdentifier Algorithm { get { throw null; } }
+        public byte[] KeyValue { get { throw null; } }
+    }
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+        public abstract byte[] EncryptedKey { get; }
+        public abstract System.Security.Cryptography.Pkcs.AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract System.Security.Cryptography.Pkcs.SubjectIdentifier RecipientIdentifier { get; }
+        public System.Security.Cryptography.Pkcs.RecipientInfoType Type { get { throw null; } }
+        public abstract int Version { get; }
+    }
+    public sealed partial class RecipientInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.RecipientInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.RecipientInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.RecipientInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class RecipientInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.RecipientInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2,
+    }
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public System.Security.Cryptography.Oid RequestedPolicyId { get { throw null; } }
+        public bool RequestSignerCertificate { get { throw null; } }
+        public int Version { get { throw null; } }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromData(System.ReadOnlySpan<byte> data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromHash(System.ReadOnlyMemory<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public static System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest CreateFromSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.Oid requestedPolicyId = null, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), bool requestSignerCertificates = false, System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { throw null; }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampToken ProcessResponse(System.ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, out System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest request, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+        public System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignedCms AsSignedCms() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)]out System.Security.Cryptography.Pkcs.Rfc3161TimestampToken token, out int bytesConsumed) { throw null; }
+        public bool VerifySignatureForData(System.ReadOnlySpan<byte> data, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForHash(System.ReadOnlySpan<byte> hash, System.Security.Cryptography.Oid hashAlgorithmId, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+        public bool VerifySignatureForSignerInfo(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, out System.Security.Cryptography.X509Certificates.X509Certificate2 signerCertificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraCandidates = null) { throw null; }
+    }
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(System.Security.Cryptography.Oid policyId, System.Security.Cryptography.Oid hashAlgorithmId, System.ReadOnlyMemory<byte> messageHash, System.ReadOnlyMemory<byte> serialNumber, System.DateTimeOffset timestamp, long? accuracyInMicroseconds = default(long?), bool isOrdering = false, System.ReadOnlyMemory<byte>? nonce = default(System.ReadOnlyMemory<byte>?), System.ReadOnlyMemory<byte>? timestampAuthorityName = default(System.ReadOnlyMemory<byte>?), System.Security.Cryptography.X509Certificates.X509ExtensionCollection extensions = null) { }
+        public long? AccuracyInMicroseconds { get { throw null; } }
+        public bool HasExtensions { get { throw null; } }
+        public System.Security.Cryptography.Oid HashAlgorithmId { get { throw null; } }
+        public bool IsOrdering { get { throw null; } }
+        public System.Security.Cryptography.Oid PolicyId { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public int Version { get { throw null; } }
+        public byte[] Encode() { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+        public System.ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetNonce() { throw null; }
+        public System.ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+        public System.ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+        public static bool TryDecode(System.ReadOnlyMemory<byte> encodedBytes, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)]out System.Security.Cryptography.Pkcs.Rfc3161TimestampTokenInfo timestampTokenInfo, out int bytesConsumed) { throw null; }
+        public bool TryEncode(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo) { }
+        public SignedCms(System.Security.Cryptography.Pkcs.SubjectIdentifierType signerIdentifierType, System.Security.Cryptography.Pkcs.ContentInfo contentInfo, bool detached) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.ContentInfo ContentInfo { get { throw null; } }
+        public bool Detached { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection SignerInfos { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public void ComputeSignature(System.Security.Cryptography.Pkcs.CmsSigner signer, bool silent) { }
+        public void Decode(byte[] encodedMessage) { }
+        public void Decode(System.ReadOnlySpan<byte> encodedMessage) { }
+        public byte[] Encode() { throw null; }
+        public void RemoveCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { }
+        public void RemoveSignature(int index) { }
+        public void RemoveSignature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo) { }
+    }
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfoCollection CounterSignerInfos { get { throw null; } }
+        public System.Security.Cryptography.Oid DigestAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.Oid SignatureAlgorithm { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifier SignerIdentifier { get { throw null; } }
+        public System.Security.Cryptography.CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+        public int Version { get { throw null; } }
+        public void AddUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+        public void CheckHash() { }
+        public void CheckSignature(bool verifySignatureOnly) { }
+        public void CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+        public void ComputeCounterSignature() { }
+        public void ComputeCounterSignature(System.Security.Cryptography.Pkcs.CmsSigner signer) { }
+        public byte[] GetSignature() { throw null; }
+        public void RemoveCounterSignature(int index) { }
+        public void RemoveCounterSignature(System.Security.Cryptography.Pkcs.SignerInfo counterSignerInfo) { }
+        public void RemoveUnsignedAttribute(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
+    }
+    public sealed partial class SignerInfoCollection : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Security.Cryptography.Pkcs.SignerInfo this[int index] { get { throw null; } }
+        public object SyncRoot { get { throw null; } }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Pkcs.SignerInfo[] array, int index) { }
+        public System.Security.Cryptography.Pkcs.SignerInfoEnumerator GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class SignerInfoEnumerator : System.Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+        public System.Security.Cryptography.Pkcs.SignerInfo Current { get { throw null; } }
+        object System.Collections.IEnumerator.Current { get { throw null; } }
+        public bool MoveNext() { throw null; }
+        public void Reset() { }
+    }
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+        public bool MatchesCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+        public System.Security.Cryptography.Pkcs.SubjectIdentifierOrKeyType Type { get { throw null; } }
+        public object Value { get { throw null; } }
+    }
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3,
+    }
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3,
+    }
+}
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/system.security.cryptography.pkcs.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/system.security.cryptography.pkcs.nuspec
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.Pkcs</id>
+    <version>5.0.0</version>
+    <title>System.Security.Cryptography.Pkcs</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/runtime</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides support for PKCS and CMS algorithms.
+
+Commonly Used Types:
+System.Security.Cryptography.Pkcs.EnvelopedCms
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="git://github.com/dotnet/runtime" commit="cf258a14b70ad9069470a108f13765e0e5988f51" />
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="MonoTouch1.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETCoreApp2.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Memory" version="4.5.4" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETCoreApp2.1">
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="System.Collections" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.5.1" exclude="Compile" />
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Memory" version="4.5.4" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="UAP10.0.16299">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Memory" version="4.5.4" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.iOS1.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.Mac2.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.TVOS1.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.WatchOS1.0">
+        <dependency id="System.Formats.Asn1" version="5.0.0" exclude="Compile" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.protecteddata/4.4.0/system.security.cryptography.protecteddata.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.protecteddata/4.4.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.protecteddata/4.4.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+    <Reference Include="System.Security" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/net46/System.Security.Cryptography.ProtectedData.cs
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/net46/System.Security.Cryptography.ProtectedData.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDescription("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.24705.01")]
+[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.DataProtectionScope))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.ProtectedData))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/net461/System.Security.Cryptography.ProtectedData.cs
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/net461/System.Security.Cryptography.ProtectedData.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDescription("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.25519.03")]
+[assembly: AssemblyInformationalVersion("4.6.25519.03 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.2.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.DataProtectionScope))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.ProtectedData))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/netstandard1.3/System.Security.Cryptography.ProtectedData.cs
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/netstandard1.3/System.Security.Cryptography.ProtectedData.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDescription("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public enum DataProtectionScope
+    {
+        CurrentUser = 0,
+        LocalMachine = 1,
+    }
+    public static partial class ProtectedData
+    {
+        public static byte[] Protect(byte[] userData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+        public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/netstandard2.0/System.Security.Cryptography.ProtectedData.cs
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/ref/netstandard2.0/System.Security.Cryptography.ProtectedData.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDescription("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.ProtectedData")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.25519.03")]
+[assembly: AssemblyInformationalVersion("4.6.25519.03 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.2.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public enum DataProtectionScope
+    {
+        CurrentUser = 0,
+        LocalMachine = 1,
+    }
+    public static partial class ProtectedData
+    {
+        public static byte[] Protect(byte[] userData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+        public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/system.security.cryptography.protecteddata.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/system.security.cryptography.protecteddata.nuspec
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.ProtectedData</id>
+    <version>4.4.0</version>
+    <title>System.Security.Cryptography.ProtectedData</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides access to Windows Data Protection Api.
+
+Commonly Used Types:
+System.Security.Cryptography.DataProtectionScope
+System.Security.Cryptography.ProtectedData
+ 
+8321c729934c0f8be754953439b88e6e1c120c24 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0" />
+      <group targetFramework="MonoTouch1.0" />
+      <group targetFramework=".NETFramework4.6" />
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework=".NETCoreApp2.0" />
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework="Xamarin.iOS1.0" />
+      <group targetFramework="Xamarin.Mac2.0" />
+      <group targetFramework="Xamarin.TVOS1.0" />
+      <group targetFramework="Xamarin.WatchOS1.0" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.xml/4.7.0/System.Security.Cryptography.Xml.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/4.7.0/System.Security.Cryptography.Xml.4.7.0.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.xml/4.7.0/system.security.cryptography.xml.nuspec</NuspecFile>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.xml/4.7.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.xml/4.7.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
+    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0-alpha-5" />
+    <Reference Include="System" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.xml/4.7.0/ref/net461/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/4.7.0/ref/net461/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Cryptography.Xml;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Xml")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.56404")]
+[assembly: AssemblyInformationalVersion("4.700.19.56404 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.0")]
+
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.CipherData))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.CipherReference))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.DataObject))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.DataReference))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.DSAKeyValue))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptedData))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptedKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptedReference))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptedType))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptedXml))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptionMethod))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptionProperty))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.EncryptionPropertyCollection))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.IRelDecryptor))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoClause))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoEncryptedKey))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoName))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoNode))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoRetrievalMethod))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyInfoX509Data))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.KeyReference))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.Reference))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.ReferenceList))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.RSAKeyValue))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.Signature))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.SignedInfo))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.SignedXml))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.Transform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.TransformChain))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDecryptionTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigBase64Transform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigC14NTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigExcC14NTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigXPathTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlDsigXsltTransform))]
+[assembly: TypeForwardedTo(typeof(System.Security.Cryptography.Xml.XmlLicenseTransform))]
+
+
+

--- a/src/referencePackages/src/system.security.cryptography.xml/4.7.0/ref/netstandard2.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/4.7.0/ref/netstandard2.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,565 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: AssemblyDescription("System.Security.Cryptography.Xml")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.700.19.56404")]
+[assembly: AssemblyInformationalVersion("4.700.19.56404 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.0")]
+
+
+
+
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+        public CipherData(byte[] cipherValue) { }
+        public CipherData(System.Security.Cryptography.Xml.CipherReference cipherReference) { }
+        public System.Security.Cryptography.Xml.CipherReference CipherReference { get { throw null; } set { } }
+        public byte[] CipherValue { get { throw null; } set { } }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class CipherReference : System.Security.Cryptography.Xml.EncryptedReference
+    {
+        public CipherReference() { }
+        public CipherReference(string uri) { }
+        public CipherReference(string uri, System.Security.Cryptography.Xml.TransformChain transformChain) { }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class DataObject
+    {
+        public DataObject() { }
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+        public string Encoding { get { throw null; } set { } }
+        public string Id { get { throw null; } set { } }
+        public string MimeType { get { throw null; } set { } }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class DataReference : System.Security.Cryptography.Xml.EncryptedReference
+    {
+        public DataReference() { }
+        public DataReference(string uri) { }
+        public DataReference(string uri, System.Security.Cryptography.Xml.TransformChain transformChain) { }
+    }
+    public partial class DSAKeyValue : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public DSAKeyValue() { }
+        public DSAKeyValue(System.Security.Cryptography.DSA key) { }
+        public System.Security.Cryptography.DSA Key { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class EncryptedData : System.Security.Cryptography.Xml.EncryptedType
+    {
+        public EncryptedData() { }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class EncryptedKey : System.Security.Cryptography.Xml.EncryptedType
+    {
+        public EncryptedKey() { }
+        public string CarriedKeyName { get { throw null; } set { } }
+        public string Recipient { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.ReferenceList ReferenceList { get { throw null; } }
+        public void AddReference(System.Security.Cryptography.Xml.DataReference dataReference) { }
+        public void AddReference(System.Security.Cryptography.Xml.KeyReference keyReference) { }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+        protected EncryptedReference(string uri) { }
+        protected EncryptedReference(string uri, System.Security.Cryptography.Xml.TransformChain transformChain) { }
+        protected internal bool CacheValid { get { throw null; } }
+        protected string ReferenceType { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.TransformChain TransformChain { get { throw null; } set { } }
+        public string Uri { get { throw null; } set { } }
+        public void AddTransform(System.Security.Cryptography.Xml.Transform transform) { }
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public abstract partial class EncryptedType
+    {
+        protected EncryptedType() { }
+        public virtual System.Security.Cryptography.Xml.CipherData CipherData { get { throw null; } set { } }
+        public virtual string Encoding { get { throw null; } set { } }
+        public virtual System.Security.Cryptography.Xml.EncryptionMethod EncryptionMethod { get { throw null; } set { } }
+        public virtual System.Security.Cryptography.Xml.EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+        public virtual string Id { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.KeyInfo KeyInfo { get { throw null; } set { } }
+        public virtual string MimeType { get { throw null; } set { } }
+        public virtual string Type { get { throw null; } set { } }
+        public void AddProperty(System.Security.Cryptography.Xml.EncryptionProperty ep) { }
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        public EncryptedXml() { }
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+        public EncryptedXml(System.Xml.XmlDocument document, System.Security.Policy.Evidence evidence) { }
+        public System.Security.Policy.Evidence DocumentEvidence { get { throw null; } set { } }
+        public System.Text.Encoding Encoding { get { throw null; } set { } }
+        public System.Security.Cryptography.CipherMode Mode { get { throw null; } set { } }
+        public System.Security.Cryptography.PaddingMode Padding { get { throw null; } set { } }
+        public string Recipient { get { throw null; } set { } }
+        public System.Xml.XmlResolver Resolver { get { throw null; } set { } }
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+        public void ClearKeyNameMappings() { }
+        public byte[] DecryptData(System.Security.Cryptography.Xml.EncryptedData encryptedData, System.Security.Cryptography.SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+        public void DecryptDocument() { }
+        public virtual byte[] DecryptEncryptedKey(System.Security.Cryptography.Xml.EncryptedKey encryptedKey) { throw null; }
+        public static byte[] DecryptKey(byte[] keyData, System.Security.Cryptography.RSA rsa, bool useOAEP) { throw null; }
+        public static byte[] DecryptKey(byte[] keyData, System.Security.Cryptography.SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+        public System.Security.Cryptography.Xml.EncryptedData Encrypt(System.Xml.XmlElement inputElement, System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+        public System.Security.Cryptography.Xml.EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+        public byte[] EncryptData(byte[] plaintext, System.Security.Cryptography.SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, System.Security.Cryptography.SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+        public static byte[] EncryptKey(byte[] keyData, System.Security.Cryptography.RSA rsa, bool useOAEP) { throw null; }
+        public static byte[] EncryptKey(byte[] keyData, System.Security.Cryptography.SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+        public virtual byte[] GetDecryptionIV(System.Security.Cryptography.Xml.EncryptedData encryptedData, string symmetricAlgorithmUri) { throw null; }
+        public virtual System.Security.Cryptography.SymmetricAlgorithm GetDecryptionKey(System.Security.Cryptography.Xml.EncryptedData encryptedData, string symmetricAlgorithmUri) { throw null; }
+        public virtual System.Xml.XmlElement GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, System.Security.Cryptography.Xml.EncryptedData encryptedData, bool content) { }
+    }
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+        public EncryptionMethod(string algorithm) { }
+        public string KeyAlgorithm { get { throw null; } set { } }
+        public int KeySize { get { throw null; } set { } }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+        public string Id { get { throw null; } }
+        public System.Xml.XmlElement PropertyElement { get { throw null; } set { } }
+        public string Target { get { throw null; } }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class EncryptionPropertyCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+    {
+        public EncryptionPropertyCollection() { }
+        public int Count { get { throw null; } }
+        public bool IsFixedSize { get { throw null; } }
+        public bool IsReadOnly { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public System.Security.Cryptography.Xml.EncryptionProperty this[int index] { get { throw null; } set { } }
+        public object SyncRoot { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        public int Add(System.Security.Cryptography.Xml.EncryptionProperty value) { throw null; }
+        public void Clear() { }
+        public bool Contains(System.Security.Cryptography.Xml.EncryptionProperty value) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Security.Cryptography.Xml.EncryptionProperty[] array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public int IndexOf(System.Security.Cryptography.Xml.EncryptionProperty value) { throw null; }
+        public void Insert(int index, System.Security.Cryptography.Xml.EncryptionProperty value) { }
+        public System.Security.Cryptography.Xml.EncryptionProperty Item(int index) { throw null; }
+        public void Remove(System.Security.Cryptography.Xml.EncryptionProperty value) { }
+        public void RemoveAt(int index) { }
+        int System.Collections.IList.Add(object value) { throw null; }
+        bool System.Collections.IList.Contains(object value) { throw null; }
+        int System.Collections.IList.IndexOf(object value) { throw null; }
+        void System.Collections.IList.Insert(int index, object value) { }
+        void System.Collections.IList.Remove(object value) { }
+    }
+    public partial interface IRelDecryptor
+    {
+        System.IO.Stream Decrypt(System.Security.Cryptography.Xml.EncryptionMethod encryptionMethod, System.Security.Cryptography.Xml.KeyInfo keyInfo, System.IO.Stream toDecrypt);
+    }
+    public partial class KeyInfo : System.Collections.IEnumerable
+    {
+        public KeyInfo() { }
+        public int Count { get { throw null; } }
+        public string Id { get { throw null; } set { } }
+        public void AddClause(System.Security.Cryptography.Xml.KeyInfoClause clause) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public System.Collections.IEnumerator GetEnumerator(System.Type requestedObjectType) { throw null; }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public abstract partial class KeyInfoClause
+    {
+        protected KeyInfoClause() { }
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+    public partial class KeyInfoEncryptedKey : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+        public KeyInfoEncryptedKey(System.Security.Cryptography.Xml.EncryptedKey encryptedKey) { }
+        public System.Security.Cryptography.Xml.EncryptedKey EncryptedKey { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class KeyInfoName : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public KeyInfoName() { }
+        public KeyInfoName(string keyName) { }
+        public string Value { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class KeyInfoNode : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public KeyInfoNode() { }
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+        public System.Xml.XmlElement Value { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class KeyInfoRetrievalMethod : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+        public KeyInfoRetrievalMethod(string strUri) { }
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+        public string Type { get { throw null; } set { } }
+        public string Uri { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class KeyInfoX509Data : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+        public KeyInfoX509Data(byte[] rgbCert) { }
+        public KeyInfoX509Data(System.Security.Cryptography.X509Certificates.X509Certificate cert) { }
+        public KeyInfoX509Data(System.Security.Cryptography.X509Certificates.X509Certificate cert, System.Security.Cryptography.X509Certificates.X509IncludeOption includeOption) { }
+        public System.Collections.ArrayList Certificates { get { throw null; } }
+        public byte[] CRL { get { throw null; } set { } }
+        public System.Collections.ArrayList IssuerSerials { get { throw null; } }
+        public System.Collections.ArrayList SubjectKeyIds { get { throw null; } }
+        public System.Collections.ArrayList SubjectNames { get { throw null; } }
+        public void AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate certificate) { }
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+        public void AddSubjectKeyId(string subjectKeyId) { }
+        public void AddSubjectName(string subjectName) { }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+    public sealed partial class KeyReference : System.Security.Cryptography.Xml.EncryptedReference
+    {
+        public KeyReference() { }
+        public KeyReference(string uri) { }
+        public KeyReference(string uri, System.Security.Cryptography.Xml.TransformChain transformChain) { }
+    }
+    public partial class Reference
+    {
+        public Reference() { }
+        public Reference(System.IO.Stream stream) { }
+        public Reference(string uri) { }
+        public string DigestMethod { get { throw null; } set { } }
+        public byte[] DigestValue { get { throw null; } set { } }
+        public string Id { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.TransformChain TransformChain { get { throw null; } set { } }
+        public string Type { get { throw null; } set { } }
+        public string Uri { get { throw null; } set { } }
+        public void AddTransform(System.Security.Cryptography.Xml.Transform transform) { }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public sealed partial class ReferenceList : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+    {
+        public ReferenceList() { }
+        public int Count { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public System.Security.Cryptography.Xml.EncryptedReference this[int index] { get { throw null; } set { } }
+        public object SyncRoot { get { throw null; } }
+        bool System.Collections.IList.IsFixedSize { get { throw null; } }
+        bool System.Collections.IList.IsReadOnly { get { throw null; } }
+        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+        public int Add(object value) { throw null; }
+        public void Clear() { }
+        public bool Contains(object value) { throw null; }
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public int IndexOf(object value) { throw null; }
+        public void Insert(int index, object value) { }
+        public System.Security.Cryptography.Xml.EncryptedReference Item(int index) { throw null; }
+        public void Remove(object value) { }
+        public void RemoveAt(int index) { }
+    }
+    public partial class RSAKeyValue : System.Security.Cryptography.Xml.KeyInfoClause
+    {
+        public RSAKeyValue() { }
+        public RSAKeyValue(System.Security.Cryptography.RSA key) { }
+        public System.Security.Cryptography.RSA Key { get { throw null; } set { } }
+        public override System.Xml.XmlElement GetXml() { throw null; }
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class Signature
+    {
+        public Signature() { }
+        public string Id { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.KeyInfo KeyInfo { get { throw null; } set { } }
+        public System.Collections.IList ObjectList { get { throw null; } set { } }
+        public byte[] SignatureValue { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.SignedInfo SignedInfo { get { throw null; } set { } }
+        public void AddObject(System.Security.Cryptography.Xml.DataObject dataObject) { }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class SignedInfo : System.Collections.ICollection, System.Collections.IEnumerable
+    {
+        public SignedInfo() { }
+        public string CanonicalizationMethod { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.Transform CanonicalizationMethodObject { get { throw null; } }
+        public int Count { get { throw null; } }
+        public string Id { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
+        public bool IsSynchronized { get { throw null; } }
+        public System.Collections.ArrayList References { get { throw null; } }
+        public string SignatureLength { get { throw null; } set { } }
+        public string SignatureMethod { get { throw null; } set { } }
+        public object SyncRoot { get { throw null; } }
+        public void AddReference(System.Security.Cryptography.Xml.Reference reference) { }
+        public void CopyTo(System.Array array, int index) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public partial class SignedXml
+    {
+        protected System.Security.Cryptography.Xml.Signature m_signature;
+        protected string m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        public SignedXml() { }
+        public SignedXml(System.Xml.XmlDocument document) { }
+        public SignedXml(System.Xml.XmlElement elem) { }
+        public System.Security.Cryptography.Xml.EncryptedXml EncryptedXml { get { throw null; } set { } }
+        public System.Security.Cryptography.Xml.KeyInfo KeyInfo { get { throw null; } set { } }
+        public System.Xml.XmlResolver Resolver { set { } }
+        public System.Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+        public System.Security.Cryptography.Xml.Signature Signature { get { throw null; } }
+        public System.Func<System.Security.Cryptography.Xml.SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+        public string SignatureLength { get { throw null; } }
+        public string SignatureMethod { get { throw null; } }
+        public byte[] SignatureValue { get { throw null; } }
+        public System.Security.Cryptography.Xml.SignedInfo SignedInfo { get { throw null; } }
+        public System.Security.Cryptography.AsymmetricAlgorithm SigningKey { get { throw null; } set { } }
+        public string SigningKeyName { get { throw null; } set { } }
+        public void AddObject(System.Security.Cryptography.Xml.DataObject dataObject) { }
+        public void AddReference(System.Security.Cryptography.Xml.Reference reference) { }
+        public bool CheckSignature() { throw null; }
+        public bool CheckSignature(System.Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+        public bool CheckSignature(System.Security.Cryptography.KeyedHashAlgorithm macAlg) { throw null; }
+        public bool CheckSignature(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+        public bool CheckSignatureReturningKey(out System.Security.Cryptography.AsymmetricAlgorithm signingKey) { throw null; }
+        public void ComputeSignature() { }
+        public void ComputeSignature(System.Security.Cryptography.KeyedHashAlgorithm macAlg) { }
+        public virtual System.Xml.XmlElement GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+        protected virtual System.Security.Cryptography.AsymmetricAlgorithm GetPublicKey() { throw null; }
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+    public abstract partial class Transform
+    {
+        protected Transform() { }
+        public string Algorithm { get { throw null; } set { } }
+        public System.Xml.XmlElement Context { get { throw null; } set { } }
+        public abstract System.Type[] InputTypes { get; }
+        public abstract System.Type[] OutputTypes { get; }
+        public System.Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+        public System.Xml.XmlResolver Resolver { set { } }
+        public virtual byte[] GetDigestedOutput(System.Security.Cryptography.HashAlgorithm hash) { throw null; }
+        protected abstract System.Xml.XmlNodeList GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(System.Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+    public partial class TransformChain
+    {
+        public TransformChain() { }
+        public int Count { get { throw null; } }
+        public System.Security.Cryptography.Xml.Transform this[int index] { get { throw null; } }
+        public void Add(System.Security.Cryptography.Xml.Transform transform) { }
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+    public partial class XmlDecryptionTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDecryptionTransform() { }
+        public System.Security.Cryptography.Xml.EncryptedXml EncryptedXml { get { throw null; } set { } }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        public void AddExceptUri(string uri) { }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        protected virtual bool IsTargetElement(System.Xml.XmlElement inputElement, string idValue) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigBase64Transform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigBase64Transform() { }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigC14NTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigC14NTransform() { }
+        public XmlDsigC14NTransform(bool includeComments) { }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        public override byte[] GetDigestedOutput(System.Security.Cryptography.HashAlgorithm hash) { throw null; }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigC14NWithCommentsTransform : System.Security.Cryptography.Xml.XmlDsigC14NTransform
+    {
+        public XmlDsigC14NWithCommentsTransform() { }
+    }
+    public partial class XmlDsigEnvelopedSignatureTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigExcC14NTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+        public XmlDsigExcC14NTransform(bool includeComments, string inclusiveNamespacesPrefixList) { }
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+        public string InclusiveNamespacesPrefixList { get { throw null; } set { } }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        public override byte[] GetDigestedOutput(System.Security.Cryptography.HashAlgorithm hash) { throw null; }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigExcC14NWithCommentsTransform : System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+    public partial class XmlDsigXPathTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigXPathTransform() { }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlDsigXsltTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlDsigXsltTransform() { }
+        public XmlDsigXsltTransform(bool includeComments) { }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+    public partial class XmlLicenseTransform : System.Security.Cryptography.Xml.Transform
+    {
+        public XmlLicenseTransform() { }
+        public System.Security.Cryptography.Xml.IRelDecryptor Decryptor { get { throw null; } set { } }
+        public override System.Type[] InputTypes { get { throw null; } }
+        public override System.Type[] OutputTypes { get { throw null; } }
+        protected override System.Xml.XmlNodeList GetInnerXml() { throw null; }
+        public override object GetOutput() { throw null; }
+        public override object GetOutput(System.Type type) { throw null; }
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/4.7.0/system.security.cryptography.xml.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.xml/4.7.0/system.security.cryptography.xml.nuspec
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.Xml</id>
+    <version>4.7.0</version>
+    <title>System.Security.Cryptography.Xml</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/corefx</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.
+
+Commonly Used Types:
+System.Security.Cryptography.Xml.CipherData
+System.Security.Cryptography.Xml.CipherReference
+System.Security.Cryptography.Xml.DataObject
+System.Security.Cryptography.Xml.DataReference
+System.Security.Cryptography.Xml.DSAKeyValue
+System.Security.Cryptography.Xml.EncryptedData
+System.Security.Cryptography.Xml.EncryptedKey
+System.Security.Cryptography.Xml.EncryptedReference
+System.Security.Cryptography.Xml.EncryptedType
+System.Security.Cryptography.Xml.EncryptedXml
+System.Security.Cryptography.Xml.EncryptionMethod
+System.Security.Cryptography.Xml.EncryptionProperty
+System.Security.Cryptography.Xml.EncryptionPropertyCollection
+System.Security.Cryptography.Xml.KeyInfo
+System.Security.Cryptography.Xml.KeyInfoClause
+System.Security.Cryptography.Xml.KeyInfoEncryptedKey
+System.Security.Cryptography.Xml.KeyInfoName
+System.Security.Cryptography.Xml.KeyInfoNode
+System.Security.Cryptography.Xml.KeyInfoRetrievalMethod
+System.Security.Cryptography.Xml.KeyInfoX509Data
+System.Security.Cryptography.Xml.KeyReference
+System.Security.Cryptography.Xml.Reference
+System.Security.Cryptography.Xml.ReferenceList
+System.Security.Cryptography.Xml.RSAKeyValue
+System.Security.Cryptography.Xml.Signature
+System.Security.Cryptography.Xml.SignedInfo
+System.Security.Cryptography.Xml.SignedXml
+System.Security.Cryptography.Xml.Transform
+System.Security.Cryptography.Xml.TransformChain
+System.Security.Cryptography.Xml.XmlDecryptionTransform
+System.Security.Cryptography.Xml.XmlDsigBase64Transform
+System.Security.Cryptography.Xml.XmlDsigC14NTransform
+System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigXPathTransform
+System.Security.Cryptography.Xml.XmlDsigXsltTransform
+System.Security.Cryptography.Xml.XmlLicenseTransform
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Security.Permissions" version="4.7.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="4.7.0" exclude="Compile" />
+        <dependency id="System.Security.Permissions" version="4.7.0" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.6.1" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.xml/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.xml/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Port the following packages from pre-arcade to main:

- System.Security.Cryptography.Algorithms,4.3.1
- System.Security.Cryptography.Pkcs,4.7.0
- System.Security.Cryptography.Pkcs,5.0.0
- System.Security.Cryptography.ProtectedData,4.4.0
- System.Security.Cryptography.Xml,4.7.0