### PR TITLE
Change ReferenceAssemblies version to 1.0.2

### DIFF
--- a/src/referencePackages/src/microsoft.build.framework/16.6.0/Microsoft.Build.Framework.16.6.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/16.6.0/Microsoft.Build.Framework.16.6.0.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <PackageReference Include="System.Runtime" Version="4.3.0" />
         <Reference Include="System.Xaml" />
     </ItemGroup>

--- a/src/referencePackages/src/microsoft.build.utilities.core/16.6.0/Microsoft.Build.Utilities.Core.16.6.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/16.6.0/Microsoft.Build.Utilities.Core.16.6.0.csproj
@@ -32,7 +32,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="Microsoft.Build.Framework" Version="16.6.0" />
         <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <PackageReference Include="System.Runtime" Version="4.3.0" />
         <Reference Include="System.Configuration" />
     </ItemGroup>

--- a/src/referencePackages/src/microsoft.build/16.6.0/Microsoft.Build.16.6.0.csproj
+++ b/src/referencePackages/src/microsoft.build/16.6.0/Microsoft.Build.16.6.0.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
         <PackageReference Include="System.Memory" Version="4.5.3" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="System.Configuration" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System" />

--- a/src/referencePackages/src/microsoft.win32.registry/4.7.0/Microsoft.Win32.Registry.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.7.0/Microsoft.Win32.Registry.4.7.0.csproj
@@ -41,7 +41,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/microsoft.win32.systemevents/4.7.0/Microsoft.Win32.SystemEvents.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.systemevents/4.7.0/Microsoft.Win32.SystemEvents.4.7.0.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
     <Reference Include="System" />
   </ItemGroup>
 

--- a/src/referencePackages/src/nuget.build.tasks/5.1.0/NuGet.Build.Tasks.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.build.tasks/5.1.0/NuGet.Build.Tasks.5.1.0.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Commands" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="Microsoft.Build.Framework" />
         <Reference Include="Microsoft.Build.Utilities.v4.0" />
     </ItemGroup>

--- a/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.commands/5.1.0/NuGet.Commands.5.1.0.csproj
@@ -30,7 +30,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Credentials" Version="5.1.0" />
         <PackageReference Include="NuGet.ProjectModel" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.Security" />
         <Reference Include="System.Xml" />

--- a/src/referencePackages/src/nuget.common/5.1.0/NuGet.Common.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.common/5.1.0/NuGet.Common.5.1.0.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Frameworks" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <PackageReference Include="System.Runtime" Version="4.3.0" />
         <Reference Include="System.Core" />
         <Reference Include="System.IO.Compression" />

--- a/src/referencePackages/src/nuget.configuration/5.1.0/NuGet.Configuration.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.configuration/5.1.0/NuGet.Configuration.5.1.0.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Common" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <PackageReference Include="System.Runtime" Version="4.3.0" />
         <Reference Include="System.Security" />
         <Reference Include="System.Xml" />

--- a/src/referencePackages/src/nuget.credentials/5.1.0/NuGet.Credentials.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.credentials/5.1.0/NuGet.Credentials.5.1.0.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Protocol" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="Microsoft.CSharp" />
         <Reference Include="System" />
         <Reference Include="System.Core" />

--- a/src/referencePackages/src/nuget.dependencyresolver.core/5.1.0/NuGet.DependencyResolver.Core.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/5.1.0/NuGet.DependencyResolver.Core.5.1.0.csproj
@@ -30,7 +30,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.LibraryModel" Version="5.1.0" />
         <PackageReference Include="NuGet.Protocol" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
     </ItemGroup>
 
   

--- a/src/referencePackages/src/nuget.frameworks/5.1.0/NuGet.Frameworks.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.frameworks/5.1.0/NuGet.Frameworks.5.1.0.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
     </ItemGroup>
 
   

--- a/src/referencePackages/src/nuget.librarymodel/5.1.0/NuGet.LibraryModel.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/5.1.0/NuGet.LibraryModel.5.1.0.csproj
@@ -30,7 +30,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Common" Version="5.1.0" />
         <PackageReference Include="NuGet.Versioning" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
     </ItemGroup>
 
   

--- a/src/referencePackages/src/nuget.packaging/5.1.0/NuGet.Packaging.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.packaging/5.1.0/NuGet.Packaging.5.1.0.csproj
@@ -33,7 +33,7 @@
         <PackageReference Include="NuGet.Configuration" Version="5.1.0" />
         <PackageReference Include="NuGet.Versioning" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.Security" />
         <Reference Include="System.Xml" />

--- a/src/referencePackages/src/nuget.projectmodel/5.1.0/NuGet.ProjectModel.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/5.1.0/NuGet.ProjectModel.5.1.0.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.DependencyResolver.Core" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="System" />
     </ItemGroup>
 

--- a/src/referencePackages/src/nuget.protocol/5.1.0/NuGet.Protocol.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.protocol/5.1.0/NuGet.Protocol.5.1.0.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <PackageReference Include="NuGet.Packaging" Version="5.1.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
         <Reference Include="System.IdentityModel" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.Net.Http" />

--- a/src/referencePackages/src/nuget.versioning/5.1.0/NuGet.Versioning.5.1.0.csproj
+++ b/src/referencePackages/src/nuget.versioning/5.1.0/NuGet.Versioning.5.1.0.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0-alpha-5" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" />
     </ItemGroup>
 
   


### PR DESCRIPTION
This is in preparation of removing the 1.0.0-alpha-5 versions of ReferenceAssemblies, so no new prebuilts will be added.