### PR TITLE
Update System.Threading.Tasks.Dataflow version

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -14,11 +14,5 @@
 
     <UsagePattern IdentityGlob="runtime.*/*" />
   </IgnorePatterns>
-  <Usages>
-    <!--
-      The following prebuilts are being tracked in the 6.0 prebuilt burndown effort.
-      They are tracked by https://github.com/dotnet/source-build/issues/2423
-    -->
-    <Usage Id="System.Threading.Tasks.Dataflow" Version="4.5.24" IsDirectDependency="true" />
-  </Usages>
+  <Usages/>
 </UsageData>

--- a/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
@@ -39,7 +39,7 @@
         <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
         <PackageReference Include="System.IO.Compression" Version="4.3.0" />
         <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.2" />
         <Reference Include="System.Configuration" />
         <Reference Include="System.Xml" />


### PR DESCRIPTION
The System.Threading.Tasks.Dataflow version in the csproj for Microsoft.Build.15.7.179 was different than the version referenced in the nuspec file.  Correcting that issue.