### PR TITLE
Update framework/library references

### DIFF
--- a/src/referencePackages/src/microsoft.extensions.primitives/5.0.0/Microsoft.Extensions.Primitives.5.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.primitives/5.0.0/Microsoft.Extensions.Primitives.5.0.0.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.extensions.primitives/5.0.0/microsoft.extensions.primitives.nuspec</NuspecFile>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,6 +18,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <OutputPath>$(ArtifactsBinDir)microsoft.extensions.primitives/5.0.0/lib/</OutputPath>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -34,6 +34,7 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/referencePackages/src/system.data.sqlclient/4.8.2/System.Data.SqlClient.4.8.2.csproj
+++ b/src/referencePackages/src/system.data.sqlclient/4.8.2/System.Data.SqlClient.4.8.2.csproj
@@ -4,12 +4,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard1.3;netstandard2.0;netcoreapp2.1;net451;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.data.sqlclient/4.8.2/system.data.sqlclient.nuspec</NuspecFile>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
     <OutputPath>$(ArtifactsBinDir)system.data.sqlclient/4.8.2/ref/</OutputPath>
     <IntermediateOutputPath>$(ArtifactsObjDir)system.data.sqlclient/4.8.2</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +21,12 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.2' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
@@ -36,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />

--- a/src/referencePackages/src/system.data.sqlclient/4.8.3/System.Data.SqlClient.4.8.3.csproj
+++ b/src/referencePackages/src/system.data.sqlclient/4.8.3/System.Data.SqlClient.4.8.3.csproj
@@ -4,12 +4,15 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard1.3;netstandard2.0;netcoreapp2.1;net451;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.data.sqlclient/4.8.3/system.data.sqlclient.nuspec</NuspecFile>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
     <OutputPath>$(ArtifactsBinDir)system.data.sqlclient/4.8.3/ref/</OutputPath>
     <IntermediateOutputPath>$(ArtifactsObjDir)system.data.sqlclient/4.8.3</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +21,12 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.2' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
@@ -36,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.0/System.Runtime.CompilerServices.Unsafe.4.5.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.0/System.Runtime.CompilerServices.Unsafe.4.5.0.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.0/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,6 +13,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <OutputPath>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.0/lib/</OutputPath>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +23,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,6 +13,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <OutputPath>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.7.0/lib/</OutputPath>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +23,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.security.permissions/4.7.0/System.Security.Permissions.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.permissions/4.7.0/System.Security.Permissions.4.7.0.csproj
@@ -10,6 +10,9 @@
   <PropertyGroup>
     <OutputPath>$(ArtifactsBinDir)system.security.permissions/4.7.0/ref/</OutputPath>
     <IntermediateOutputPath>$(ArtifactsObjDir)system.security.permissions/4.7.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
@@ -20,8 +23,9 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.Windows.Extensions" Version="4.7.0" />


### PR DESCRIPTION
The `DisableImplicitFrameworkReferences` flag is incorrectly being set to false for all TFMs.  It should just be for netcoreapp TFMs while netstandard TFMs reference `NETStandard.Library`.

While investigating another issue in SBRP, I realized that the edits made to the .csproj files for these projects were incorrectly applying the flag to all TFMs.  We want to build netstandard TFMs in SBRP using a version of `NETStandard.Libaray` that was built from source.