### PR TITLE
Add Microsoft.Build.Framework.16.5.0 dependency

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -10,6 +10,7 @@
       Format:
       <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Options.5.0.0.csproj" />
     -->
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Build.Framework.16.5.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Build.Utilities.Core.16.5.0.csproj" />
 
 


### PR DESCRIPTION
Adding back this dependency that was removed in https://github.com/dotnet/source-build-reference-packages/pull/282.  It is needed in source-build because previous source-built doesn't contain it yet.