### PR TITLE
Fix build against musl libc

### DIFF
--- a/src/targetPacks/Directory.Build.targets
+++ b/src/targetPacks/Directory.Build.targets
@@ -59,9 +59,19 @@
   </Target>
 
   <Target Name="GetILToolPackageReferences">
+    <Exec IgnoreExitCode="true" Command="ldd --version 2&gt;&amp;1 | grep -q musl">
+      <Output TaskParameter="ExitCode" PropertyName="OSPlatformIsMuslCheck" />
+    </Exec>
+
+    <PropertyGroup>
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMuslCheck) == '0'">true</OSPlatformIsMusl>
+      <OSPlatformIsMusl Condition="$(OSPlatformIsMusl) == ''">false</OSPlatformIsMusl>
+    </PropertyGroup>
+
     <PropertyGroup>
       <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</_OSPlatform>
       <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</_OSPlatform>
+      <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('linux')) and '$(OSPlatformIsMusl)' == 'true'">linux-musl</_OSPlatform>
       <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</_OSPlatform>
       <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('freebsd'))">freebsd</_OSPlatform>
       <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('netbsd'))">netbsd</_OSPlatform>


### PR DESCRIPTION
Originally reported at https://github.com/dotnet/installer/issues/12859

Use the same logic as dotnet-isntall.sh to identify whether a system is musl-based or not. For musl-based Linux systems, use `linux-musl` as the platform name, which leads to better RID names.

Otherwise, we end up trying to use artifacts with an incorrect RID on musl based systems.

In particular, we look for `runtime.linux-x64.microsoft.netcore.ildasm` which doesn't work on musl-based systems. It's also not produced by source-build builds, which makes building using a previous build of source-build impossible.

cc @ayakael