### PR TITLE
Fix concurrency issue in the referencePackageSourceGenerator

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 #set -x
+
+# Stop script if command returns non-zero exit code.
+set -e
+
 source="${BASH_SOURCE[0]}"
 
 DEFAULT_TFM=net6.0

--- a/src/referencePackageSourceGenerator/GenerateProjects/GenerateProjects.proj
+++ b/src/referencePackageSourceGenerator/GenerateProjects/GenerateProjects.proj
@@ -18,7 +18,7 @@
   <UsingTask AssemblyFile="$(GenerateProjectsTaskPath)" TaskName="GenerateProjects" />
 
   <Target Name="CoreCompile" DependsOnTargets="GetGenApiDlls" >
-    <!-- Ensure source is generated first.  GenerateProjects modifies updates the assembly version attribute placeholder -->
+    <!-- Ensure source is generated first.  GenerateProjects requires the source to replace the assembly version attribute placeholder -->
     <MSBuild Projects="@(ProjectReference)" Targets="Build" />
 
     <Message Importance="High" Text="==> Generating projects for all target packages" />

--- a/src/referencePackageSourceGenerator/GenerateProjects/GenerateProjects.proj
+++ b/src/referencePackageSourceGenerator/GenerateProjects/GenerateProjects.proj
@@ -18,6 +18,9 @@
   <UsingTask AssemblyFile="$(GenerateProjectsTaskPath)" TaskName="GenerateProjects" />
 
   <Target Name="CoreCompile" DependsOnTargets="GetGenApiDlls" >
+    <!-- Ensure source is generated first.  GenerateProjects modifies updates the assembly version attribute placeholder -->
+    <MSBuild Projects="@(ProjectReference)" Targets="Build" />
+
     <Message Importance="High" Text="==> Generating projects for all target packages" />
     <GenerateProjects 
         PackageDlls="@(GenApiDlls)"

--- a/src/referencePackageSourceGenerator/Tasks/GenerateProjects.cs
+++ b/src/referencePackageSourceGenerator/Tasks/GenerateProjects.cs
@@ -210,8 +210,14 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     Directory.Delete(Path.GetDirectoryName(pd.SourceFileName));
                 }
 
-                if (updateSrcText && File.Exists(outputFilename))
+                if (updateSrcText)
                 {
+                    if (!File.Exists(outputFilename))
+                    {
+                        Log.LogError($"Source file '{outputFilename}' not found");
+                        return false;
+                    }
+
                     Log.LogMessage(MessageImportance.Low, $"Updating {outputFilename} with assembly version attributes");
                     Directory.CreateDirectory(codeArtifactsPath);
                     string srcText = File.ReadAllText(outputFilename);


### PR DESCRIPTION
The logic that replaces the assembly attributes placeholder in GenerateProjects was running before GenerateSource completed.  This causes the generated source to be incorrect.

This was encountered with https://github.com/dotnet/source-build-reference-packages/pull/357.