### PR TITLE
Remove source csproj from text-only packages

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -53,7 +53,12 @@
           @(PotentialCompileSrc);
           **\*.csproj;
           @(NuGetGeneratedMetadataFile);
-          "/>
+          "
+        Condition="'$(TextOnlyPackage)' != 'true'" />
+      <StructureFile
+        Include="**\*"
+        Exclude="$(MSBuildProjectFullPath)"
+        Condition="'$(TextOnlyPackage)' == 'true'"/>
 
       <StaticAssetFile
         Include="@(StructureFile)"
@@ -109,7 +114,6 @@
 
     <PropertyGroup>
       <NuspecFile>$(TFMPackTempOutputDir)@(NuspecFile)</NuspecFile>
-      <NuspecFile Condition="'$(PackNuspecInPlace)' == 'true'">@(NuspecFile)</NuspecFile>
     </PropertyGroup>
   </Target>
 

--- a/src/textOnlyPackages/Directory.Build.props
+++ b/src/textOnlyPackages/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <PackNuspecInPlace>true</PackNuspecInPlace>
+    <TextOnlyPackage>true</TextOnlyPackage>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/1906

Infra exists to copy assets to package to a special artifacts location specific to each package.  Text-only packages weren't utilizing this and instead packaged the source-location which ends up packaging the source csproj.  I modified text-only packages to pack from the artifacts location and to have special logic to copy all content except the source proj to the special artifacts location.