### PR TITLE
Refactor BuildDependencyPackageProjects to run after tools.proj

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup>
+    <BuildInParallel Condition=" '$(BuildInParallel)' == '' and '$(BuildDependencyPackageProjects)' == 'true' ">false</BuildInParallel>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(GeneratePackageSource)' == 'true' ">
     <ProjectToBuild Include="$(RepoRoot)src/referencePackageSourceGenerator/Tasks/GenerateProjectsTask.csproj" />
     <ProjectToBuild Include="$(RepoRoot)src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj" />
@@ -28,7 +32,7 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Diagnostics.DiagnosticSource.5.0.0.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(GeneratePackageSource)' != 'true' and '$(BuildDependencyPackageProjects)' == 'true' ">
+  <ItemGroup Condition=" '$(BuildDependencyPackageProjects)' == 'true' ">
     <ProjectToBuild Include="@(DependencyPackageProjects)" />
   </ItemGroup>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,18 +1,18 @@
 <Project>
 
-  <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SourceBuild.AddSourceToNuGetConfig" AssemblyFile="$(MSBuildProjectDirectory)/netcoreapp3.1/Microsoft.DotNet.Arcade.Sdk.dll" />
-
   <ItemGroup Condition=" '$(GeneratePackageSource)' == 'true' ">
     <ProjectToBuild Include="$(RepoRoot)src/referencePackageSourceGenerator/Tasks/GenerateProjectsTask.csproj" />
     <ProjectToBuild Include="$(RepoRoot)src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj" />
     <ProjectToBuild Include="$(Reporoot)src/referencePackageSourceGenerator/GenerateProjects/GenerateProjects.proj" />
   </ItemGroup>
+
   <ItemGroup Condition=" '$(GeneratePackageSource)' != 'true' ">
     <!--
-      The following DependencyPackageProjects are ones on which other packages depend.  Adding them
-      to this ItemGroup will ensure that they get built first and in order of inclusion.  Also,
-      packages included here will be added to the source-build package cache when building with
-      source-build to allow them to be considered in prebuilt reporting.
+      The following DependencyPackageProjects are ones on which other packages depend on that do
+      not exist in the source-build package cache.  Adding them to this ItemGroup will ensure that
+      they get built first and in order of inclusion.  Also, packages included here will be added
+      to the source-build package cache when building with source-build to allow them to be
+      considered in prebuilt reporting.
 
       Format:
       <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Options.5.0.0.csproj" />
@@ -24,7 +24,13 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.Extensions.4.3.1.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.4.3.1.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.RegularExpressions.4.3.1.csproj" />
+  </ItemGroup>
 
+  <ItemGroup Condition=" '$(GeneratePackageSource)' != 'true' and '$(BuildDependencyPackageProjects)' == 'true' ">
+    <ProjectToBuild Include="@(DependencyPackageProjects)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(GeneratePackageSource)' != 'true' and '$(BuildDependencyPackageProjects)' != 'true'">
     <TargetingPackageProject Include="$(RepoRoot)src\targetPacks\ILsrc\**\*.csproj" />
     <ProjectToBuild Include="@(TargetingPackageProject)" />
 
@@ -36,44 +42,6 @@
 
     <ProjectToBuild Remove="@(DependencyPackageProjects)" />
   </ItemGroup>
-
-  <!--
-    Build each dependency project one at a time and then copy it's nupkg to the package feed so that dependent projects will reference
-    the SBRP packages vs online packages. Specifing `Outputs` is what enables this vs building all projects at once.
-  -->
-  <Target Name="BuildDependencyPackageProjects"
-          BeforeTargets="Execute"
-          Condition="'$(GeneratePackageSource)' != 'true' and ('$(ArcadeBuildFromSource)' != 'true' or '$(ArcadeInnerBuildFromSource)' == 'true')"
-          Outputs="%(DependencyPackageProjects.Identity)">
-
-    <MSBuild
-      Condition="'@(DependencyPackageProjects)' != ''"
-      Projects="@(DependencyPackageProjects)"
-      Targets="Restore;Build;Pack" />
-
-    <!-- Copy packages into package cache if building with source-build -->
-    <Copy
-      Condition="'$(CurrentRepoSourceBuiltNupkgCacheDir)' != ''"
-      SourceFiles="@(DependencyPackageProjects->'$(ArtifactsShippingPackagesDir)%(FileName).nupkg')"
-      DestinationFolder="$(CurrentRepoSourceBuiltNupkgCacheDir)" />
-  </Target>
-
-  <!--
-    Adding the local package cache to the NuGet.config must be done explicitly before BuildDependencyPackageProjects.
-    This normally gets done by the Arcade tool.proj which doesn't have a mechanism for BuildDependencyPackageProjects
-    to hook into.
-  -->
-  <Target Name="InitializeNuGetConfig"
-          BeforeTargets="BuildDependencyPackageProjects"
-          Condition="'$(GeneratePackageSource)' != 'true' and '$(ArcadeInnerBuildFromSource)' == 'true'">
-
-      <AddSourceToNuGetConfig
-        NuGetConfigFile="$(CurrentRepoSourceBuildSourceDir)NuGet.config"
-        SourceName="source-build-int-nupkg-cache"
-        SourcePath="$(CurrentRepoSourceBuiltNupkgCacheDir)" />
-
-      <MakeDir Directories="$(CurrentRepoSourceBuiltNupkgCacheDir)"/>
-  </Target>
 
   <!--
     Adding new projects is somewhat copy-paste heavy and may result in project name overlaps. Catch

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,4 +5,20 @@
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
   </PropertyGroup>
 
+  <Target Name="BuildDependencyPackageProjects"
+          Condition="'$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="Execute">
+
+    <Exec
+      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:BuildDependencyPackageProjects=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true"
+      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
+      EnvironmentVariables="@(InnerBuildEnv)" />
+
+    <!-- Copy dependency packages into package cache -->
+    <Copy
+      Condition="'$(CurrentRepoSourceBuiltNupkgCacheDir)' != ''"
+      SourceFiles="@(DependencyPackageProjects->'$(ArtifactsShippingPackagesDir)%(FileName).nupkg')"
+      DestinationFolder="$(CurrentRepoSourceBuiltNupkgCacheDir)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This change is necessary as the tool.proj is what restores the source-build intermediates.  This is needed so that DependencyPackageProjects can utilize the package cache without having to explicitly define the entire dependency graph.

This solution also removes the need for the workaround that was implemented to initialize the nuget.config before building the DependencyPackageProjects.