### PR TITLE
Add System.IO.Pipes.AccessControl 5.0.0 reference package

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -30,6 +30,8 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.RegularExpressions.4.3.1.csproj" />
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Diagnostics.DiagnosticSource.5.0.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.IO.Pipes.AccessControl.5.0.0.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(BuildDependencyPackageProjects)' == 'true' ">

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -10,7 +10,7 @@
           BeforeTargets="Execute">
 
     <Exec
-      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:BuildDependencyPackageProjects=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true"
+      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,14 +13,14 @@
       <Sha>75a68216dbce20b32729cbb3c6ad76a9e1623b67</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22171.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22259.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>c8a95297e2622251c125aa5c0ef7c822275a792d</Sha>
+      <Sha>7cd96a6cc743016a432b198135971caff224be89</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22167-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+    <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-22258-01" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>9bf39e621221e1e512bd7966b6b4c78f078ef5aa</Sha>
+      <Sha>7e0f22b377684f55bf2bca45eba46bdcb08edb64</Sha>
       <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.ILAsm" Version="5.0.0-preview.4.20202.18">

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "7.0.100-preview.3.22179.4"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22171.2"
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22259.4"
   }
 }

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/System.IO.Pipes.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/System.IO.Pipes.AccessControl.5.0.0.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.io.pipes.accesscontrol/5.0.0/system.io.pipes.accesscontrol.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.io.pipes.accesscontrol/5.0.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.io.pipes.accesscontrol/5.0.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+    <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.2" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/net46/System.IO.Pipes.AccessControl.cs
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/net46/System.IO.Pipes.AccessControl.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDescription("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDefaultAlias("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.24705.01")]
+[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAccessRights))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAccessRule))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAuditRule))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeSecurity))]
+
+
+
+namespace System.IO.Pipes
+{
+    public static partial class PipesAclExtensions
+    {
+        public static System.IO.Pipes.PipeSecurity GetAccessControl(System.IO.Pipes.PipeStream stream) { throw null; }
+        public static void SetAccessControl(System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
+    }
+}

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/net461/System.IO.Pipes.AccessControl.cs
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/net461/System.IO.Pipes.AccessControl.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDescription("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDefaultAlias("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26606.05")]
+[assembly: AssemblyInformationalVersion("4.6.26606.05 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.0")]
+
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAccessRights))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAccessRule))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeAuditRule))]
+[assembly: TypeForwardedTo(typeof(System.IO.Pipes.PipeSecurity))]
+
+
+
+namespace System.IO.Pipes
+{
+    public static partial class PipesAclExtensions
+    {
+        public static System.IO.Pipes.PipeSecurity GetAccessControl(this System.IO.Pipes.PipeStream stream) { throw null; }
+        public static void SetAccessControl(this System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
+    }
+}

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/netstandard1.3/System.IO.Pipes.AccessControl.cs
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/netstandard1.3/System.IO.Pipes.AccessControl.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDescription("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDefaultAlias("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.24705.01")]
+[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.1.0")]
+
+
+
+
+namespace System.IO.Pipes
+{
+    [System.FlagsAttribute]
+    public enum PipeAccessRights
+    {
+        ReadData = 1,
+        WriteData = 2,
+        CreateNewInstance = 4,
+        ReadExtendedAttributes = 8,
+        WriteExtendedAttributes = 16,
+        ReadAttributes = 128,
+        WriteAttributes = 256,
+        Write = 274,
+        Delete = 65536,
+        ReadPermissions = 131072,
+        Read = 131209,
+        ReadWrite = 131483,
+        ChangePermissions = 262144,
+        TakeOwnership = 524288,
+        Synchronize = 1048576,
+        FullControl = 2032031,
+        AccessSystemSecurity = 16777216,
+    }
+    public sealed partial class PipeAccessRule : System.Security.AccessControl.AccessRule
+    {
+        public PipeAccessRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
+        public PipeAccessRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
+        public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
+    }
+    public sealed partial class PipeAuditRule : System.Security.AccessControl.AuditRule
+    {
+        public PipeAuditRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
+        public PipeAuditRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
+        public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
+    }
+    public static partial class PipesAclExtensions
+    {
+        public static System.IO.Pipes.PipeSecurity GetAccessControl(this System.IO.Pipes.PipeStream stream) { throw null; }
+        public static void SetAccessControl(this System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
+    }
+    public partial class PipeSecurity : System.Security.AccessControl.NativeObjectSecurity
+    {
+        public PipeSecurity() : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        public override System.Type AccessRightType { get { throw null; } }
+        public override System.Type AccessRuleType { get { throw null; } }
+        public override System.Type AuditRuleType { get { throw null; } }
+        public override System.Security.AccessControl.AccessRule AccessRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AccessControlType type) { throw null; }
+        public void AddAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void AddAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
+        public sealed override System.Security.AccessControl.AuditRule AuditRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags) { throw null; }
+        protected internal void Persist(System.Runtime.InteropServices.SafeHandle handle) { }
+        protected internal void Persist(string name) { }
+        public bool RemoveAccessRule(System.IO.Pipes.PipeAccessRule rule) { throw null; }
+        public void RemoveAccessRuleSpecific(System.IO.Pipes.PipeAccessRule rule) { }
+        public bool RemoveAuditRule(System.IO.Pipes.PipeAuditRule rule) { throw null; }
+        public void RemoveAuditRuleAll(System.IO.Pipes.PipeAuditRule rule) { }
+        public void RemoveAuditRuleSpecific(System.IO.Pipes.PipeAuditRule rule) { }
+        public void ResetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void SetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void SetAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
+    }
+}

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/netstandard2.0/System.IO.Pipes.AccessControl.cs
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/ref/netstandard2.0/System.IO.Pipes.AccessControl.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDescription("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyDefaultAlias("System.IO.Pipes.AccessControl")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("4.6.26606.05")]
+[assembly: AssemblyInformationalVersion("4.6.26606.05 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.3.0")]
+
+
+
+
+namespace System.IO.Pipes
+{
+    [System.FlagsAttribute]
+    public enum PipeAccessRights
+    {
+        ReadData = 1,
+        WriteData = 2,
+        CreateNewInstance = 4,
+        ReadExtendedAttributes = 8,
+        WriteExtendedAttributes = 16,
+        ReadAttributes = 128,
+        WriteAttributes = 256,
+        Write = 274,
+        Delete = 65536,
+        ReadPermissions = 131072,
+        Read = 131209,
+        ReadWrite = 131483,
+        ChangePermissions = 262144,
+        TakeOwnership = 524288,
+        Synchronize = 1048576,
+        FullControl = 2032031,
+        AccessSystemSecurity = 16777216,
+    }
+    public sealed partial class PipeAccessRule : System.Security.AccessControl.AccessRule
+    {
+        public PipeAccessRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
+        public PipeAccessRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AccessControlType type) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AccessControlType)) { }
+        public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
+    }
+    public sealed partial class PipeAuditRule : System.Security.AccessControl.AuditRule
+    {
+        public PipeAuditRule(System.Security.Principal.IdentityReference identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
+        public PipeAuditRule(string identity, System.IO.Pipes.PipeAccessRights rights, System.Security.AccessControl.AuditFlags flags) : base (default(System.Security.Principal.IdentityReference), default(int), default(bool), default(System.Security.AccessControl.InheritanceFlags), default(System.Security.AccessControl.PropagationFlags), default(System.Security.AccessControl.AuditFlags)) { }
+        public System.IO.Pipes.PipeAccessRights PipeAccessRights { get { throw null; } }
+    }
+    public static partial class PipesAclExtensions
+    {
+        public static System.IO.Pipes.PipeSecurity GetAccessControl(this System.IO.Pipes.PipeStream stream) { throw null; }
+        public static void SetAccessControl(this System.IO.Pipes.PipeStream stream, System.IO.Pipes.PipeSecurity pipeSecurity) { }
+    }
+    public partial class PipeSecurity : System.Security.AccessControl.NativeObjectSecurity
+    {
+        public PipeSecurity() : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        public override System.Type AccessRightType { get { throw null; } }
+        public override System.Type AccessRuleType { get { throw null; } }
+        public override System.Type AuditRuleType { get { throw null; } }
+        public override System.Security.AccessControl.AccessRule AccessRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AccessControlType type) { throw null; }
+        public void AddAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void AddAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
+        public sealed override System.Security.AccessControl.AuditRule AuditRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags) { throw null; }
+        protected internal void Persist(System.Runtime.InteropServices.SafeHandle handle) { }
+        protected internal void Persist(string name) { }
+        public bool RemoveAccessRule(System.IO.Pipes.PipeAccessRule rule) { throw null; }
+        public void RemoveAccessRuleSpecific(System.IO.Pipes.PipeAccessRule rule) { }
+        public bool RemoveAuditRule(System.IO.Pipes.PipeAuditRule rule) { throw null; }
+        public void RemoveAuditRuleAll(System.IO.Pipes.PipeAuditRule rule) { }
+        public void RemoveAuditRuleSpecific(System.IO.Pipes.PipeAuditRule rule) { }
+        public void ResetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void SetAccessRule(System.IO.Pipes.PipeAccessRule rule) { }
+        public void SetAuditRule(System.IO.Pipes.PipeAuditRule rule) { }
+    }
+}

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/system.io.pipes.accesscontrol.nuspec
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/system.io.pipes.accesscontrol.nuspec
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.IO.Pipes.AccessControl</id>
+    <version>5.0.0</version>
+    <title>System.IO.Pipes.AccessControl</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/runtime</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides types for managing access and audit control lists for pipes.
+
+Commonly Used Types:
+System.IO.Pipes.PipeSecurity
+System.IO.Pipes.PipeAccessRule
+System.IO.Pipes.PipeAuditRule
+System.IO.Pipes.PipeAccessRights
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="git://github.com/dotnet/runtime" commit="cf258a14b70ad9069470a108f13765e0e5988f51" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="System.IO.Pipes" version="4.3.0" />
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework=".NETCoreApp5.0">
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework=".NETCoreApp2.1">
+        <dependency id="Microsoft.NETCore.Platforms" version="5.0.0" />
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.IO.Pipes" version="4.3.0" />
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Security.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.Principal.Windows" version="5.0.0" />
+      </group>
+      <group targetFramework="UAP10.0.16299" />
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6.1" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.6.1" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.accesscontrol/5.0.0/ref/netstandard2.0/System.Security.AccessControl.cs
+++ b/src/referencePackages/src/system.security.accesscontrol/5.0.0/ref/netstandard2.0/System.Security.AccessControl.cs
@@ -157,13 +157,13 @@ namespace System.Security.AccessControl
     public sealed partial class AuthorizationRuleCollection : System.Collections.ReadOnlyCollectionBase
     {
         public AuthorizationRuleCollection() { }
-        public System.Security.AccessControl.AuthorizationRule this[int index] { get { throw null; } }
-        public void AddRule(System.Security.AccessControl.AuthorizationRule rule) { }
+        public System.Security.AccessControl.AuthorizationRule? this[int index] { get { throw null; } }
+        public void AddRule(System.Security.AccessControl.AuthorizationRule? rule) { }
         public void CopyTo(System.Security.AccessControl.AuthorizationRule[] rules, int index) { }
     }
     public sealed partial class CommonAce : System.Security.AccessControl.QualifiedAce
     {
-        public CommonAce(System.Security.AccessControl.AceFlags flags, System.Security.AccessControl.AceQualifier qualifier, int accessMask, System.Security.Principal.SecurityIdentifier sid, bool isCallback, byte[] opaque) { }
+        public CommonAce(System.Security.AccessControl.AceFlags flags, System.Security.AccessControl.AceQualifier qualifier, int accessMask, System.Security.Principal.SecurityIdentifier sid, bool isCallback, byte[]? opaque) { }
         public override int BinaryLength { get { throw null; } }
         public override void GetBinaryForm(byte[] binaryForm, int offset) { }
         public static int MaxOpaqueLength(bool isCallback) { throw null; }
@@ -204,18 +204,18 @@ namespace System.Security.AccessControl
     public sealed partial class CommonSecurityDescriptor : System.Security.AccessControl.GenericSecurityDescriptor
     {
         public CommonSecurityDescriptor(bool isContainer, bool isDS, byte[] binaryForm, int offset) { }
-        public CommonSecurityDescriptor(bool isContainer, bool isDS, System.Security.AccessControl.ControlFlags flags, System.Security.Principal.SecurityIdentifier owner, System.Security.Principal.SecurityIdentifier group, System.Security.AccessControl.SystemAcl systemAcl, System.Security.AccessControl.DiscretionaryAcl discretionaryAcl) { }
+        public CommonSecurityDescriptor(bool isContainer, bool isDS, System.Security.AccessControl.ControlFlags flags, System.Security.Principal.SecurityIdentifier? owner, System.Security.Principal.SecurityIdentifier? group, System.Security.AccessControl.SystemAcl? systemAcl, System.Security.AccessControl.DiscretionaryAcl? discretionaryAcl) { }
         public CommonSecurityDescriptor(bool isContainer, bool isDS, System.Security.AccessControl.RawSecurityDescriptor rawSecurityDescriptor) { }
         public CommonSecurityDescriptor(bool isContainer, bool isDS, string sddlForm) { }
         public override System.Security.AccessControl.ControlFlags ControlFlags { get { throw null; } }
-        public System.Security.AccessControl.DiscretionaryAcl DiscretionaryAcl { get { throw null; } set { } }
-        public override System.Security.Principal.SecurityIdentifier Group { get { throw null; } set { } }
+        public System.Security.AccessControl.DiscretionaryAcl? DiscretionaryAcl { get { throw null; } set { } }
+        public override System.Security.Principal.SecurityIdentifier? Group { get { throw null; } set { } }
         public bool IsContainer { get { throw null; } }
         public bool IsDiscretionaryAclCanonical { get { throw null; } }
         public bool IsDS { get { throw null; } }
         public bool IsSystemAclCanonical { get { throw null; } }
-        public override System.Security.Principal.SecurityIdentifier Owner { get { throw null; } set { } }
-        public System.Security.AccessControl.SystemAcl SystemAcl { get { throw null; } set { } }
+        public override System.Security.Principal.SecurityIdentifier? Owner { get { throw null; } set { } }
+        public System.Security.AccessControl.SystemAcl? SystemAcl { get { throw null; } set { } }
         public void AddDiscretionaryAcl(byte revision, int trusted) { }
         public void AddSystemAcl(byte revision, int trusted) { }
         public void PurgeAccessControl(System.Security.Principal.SecurityIdentifier sid) { }
@@ -258,18 +258,18 @@ namespace System.Security.AccessControl
     public sealed partial class CustomAce : System.Security.AccessControl.GenericAce
     {
         public static readonly int MaxOpaqueLength;
-        public CustomAce(System.Security.AccessControl.AceType type, System.Security.AccessControl.AceFlags flags, byte[] opaque) { }
+        public CustomAce(System.Security.AccessControl.AceType type, System.Security.AccessControl.AceFlags flags, byte[]? opaque) { }
         public override int BinaryLength { get { throw null; } }
         public int OpaqueLength { get { throw null; } }
         public override void GetBinaryForm(byte[] binaryForm, int offset) { }
-        public byte[] GetOpaque() { throw null; }
-        public void SetOpaque(byte[] opaque) { }
+        public byte[]? GetOpaque() { throw null; }
+        public void SetOpaque(byte[]? opaque) { }
     }
     public sealed partial class DiscretionaryAcl : System.Security.AccessControl.CommonAcl
     {
         public DiscretionaryAcl(bool isContainer, bool isDS, byte revision, int capacity) { }
         public DiscretionaryAcl(bool isContainer, bool isDS, int capacity) { }
-        public DiscretionaryAcl(bool isContainer, bool isDS, System.Security.AccessControl.RawAcl rawAcl) { }
+        public DiscretionaryAcl(bool isContainer, bool isDS, System.Security.AccessControl.RawAcl? rawAcl) { }
         public void AddAccess(System.Security.AccessControl.AccessControlType accessType, System.Security.Principal.SecurityIdentifier sid, int accessMask, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags) { }
         public void AddAccess(System.Security.AccessControl.AccessControlType accessType, System.Security.Principal.SecurityIdentifier sid, int accessMask, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.ObjectAceFlags objectFlags, System.Guid objectType, System.Guid inheritedObjectType) { }
         public void AddAccess(System.Security.AccessControl.AccessControlType accessType, System.Security.Principal.SecurityIdentifier sid, System.Security.AccessControl.ObjectAccessRule rule) { }
@@ -295,11 +295,11 @@ namespace System.Security.AccessControl
         public System.Security.AccessControl.PropagationFlags PropagationFlags { get { throw null; } }
         public System.Security.AccessControl.GenericAce Copy() { throw null; }
         public static System.Security.AccessControl.GenericAce CreateFromBinaryForm(byte[] binaryForm, int offset) { throw null; }
-        public sealed override bool Equals(object o) { throw null; }
+        public sealed override bool Equals(object? o) { throw null; }
         public abstract void GetBinaryForm(byte[] binaryForm, int offset);
         public sealed override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Security.AccessControl.GenericAce left, System.Security.AccessControl.GenericAce right) { throw null; }
-        public static bool operator !=(System.Security.AccessControl.GenericAce left, System.Security.AccessControl.GenericAce right) { throw null; }
+        public static bool operator ==(System.Security.AccessControl.GenericAce? left, System.Security.AccessControl.GenericAce? right) { throw null; }
+        public static bool operator !=(System.Security.AccessControl.GenericAce? left, System.Security.AccessControl.GenericAce? right) { throw null; }
     }
     public abstract partial class GenericAcl : System.Collections.ICollection, System.Collections.IEnumerable
     {
@@ -324,8 +324,8 @@ namespace System.Security.AccessControl
         internal GenericSecurityDescriptor() { }
         public int BinaryLength { get { throw null; } }
         public abstract System.Security.AccessControl.ControlFlags ControlFlags { get; }
-        public abstract System.Security.Principal.SecurityIdentifier Group { get; set; }
-        public abstract System.Security.Principal.SecurityIdentifier Owner { get; set; }
+        public abstract System.Security.Principal.SecurityIdentifier? Group { get; set; }
+        public abstract System.Security.Principal.SecurityIdentifier? Owner { get; set; }
         public static byte Revision { get { throw null; } }
         public void GetBinaryForm(byte[] binaryForm, int offset) { }
         public string GetSddlForm(System.Security.AccessControl.AccessControlSections includeSections) { throw null; }
@@ -347,16 +347,16 @@ namespace System.Security.AccessControl
     public abstract partial class NativeObjectSecurity : System.Security.AccessControl.CommonObjectSecurity
     {
         protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType) : base (default(bool)) { }
-        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool)) { }
-        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode exceptionFromErrorCode, object exceptionContext) : base (default(bool)) { }
-        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode exceptionFromErrorCode, object exceptionContext) : base (default(bool)) { }
-        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string name, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool)) { }
-        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string name, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode exceptionFromErrorCode, object exceptionContext) : base (default(bool)) { }
+        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle? handle, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool)) { }
+        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle? handle, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext) : base (default(bool)) { }
+        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext) : base (default(bool)) { }
+        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string? name, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool)) { }
+        protected NativeObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string? name, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext) : base (default(bool)) { }
         protected sealed override void Persist(System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections) { }
-        protected void Persist(System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections, object exceptionContext) { }
+        protected void Persist(System.Runtime.InteropServices.SafeHandle handle, System.Security.AccessControl.AccessControlSections includeSections, object? exceptionContext) { }
         protected sealed override void Persist(string name, System.Security.AccessControl.AccessControlSections includeSections) { }
-        protected void Persist(string name, System.Security.AccessControl.AccessControlSections includeSections, object exceptionContext) { }
-        protected internal delegate System.Exception ExceptionFromErrorCode(int errorCode, string name, System.Runtime.InteropServices.SafeHandle handle, object context);
+        protected void Persist(string name, System.Security.AccessControl.AccessControlSections includeSections, object? exceptionContext) { }
+        protected internal delegate System.Exception? ExceptionFromErrorCode(int errorCode, string? name, System.Runtime.InteropServices.SafeHandle? handle, object? context);
     }
     public abstract partial class ObjectAccessRule : System.Security.AccessControl.AccessRule
     {
@@ -367,7 +367,7 @@ namespace System.Security.AccessControl
     }
     public sealed partial class ObjectAce : System.Security.AccessControl.QualifiedAce
     {
-        public ObjectAce(System.Security.AccessControl.AceFlags aceFlags, System.Security.AccessControl.AceQualifier qualifier, int accessMask, System.Security.Principal.SecurityIdentifier sid, System.Security.AccessControl.ObjectAceFlags flags, System.Guid type, System.Guid inheritedType, bool isCallback, byte[] opaque) { }
+        public ObjectAce(System.Security.AccessControl.AceFlags aceFlags, System.Security.AccessControl.AceQualifier qualifier, int accessMask, System.Security.Principal.SecurityIdentifier sid, System.Security.AccessControl.ObjectAceFlags flags, System.Guid type, System.Guid inheritedType, bool isCallback, byte[]? opaque) { }
         public override int BinaryLength { get { throw null; } }
         public System.Guid InheritedObjectAceType { get { throw null; } set { } }
         public System.Security.AccessControl.ObjectAceFlags ObjectAceFlags { get { throw null; } set { } }
@@ -410,8 +410,8 @@ namespace System.Security.AccessControl
         protected System.Security.AccessControl.CommonSecurityDescriptor SecurityDescriptor { get { throw null; } }
         public abstract System.Security.AccessControl.AccessRule AccessRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AccessControlType type);
         public abstract System.Security.AccessControl.AuditRule AuditRuleFactory(System.Security.Principal.IdentityReference identityReference, int accessMask, bool isInherited, System.Security.AccessControl.InheritanceFlags inheritanceFlags, System.Security.AccessControl.PropagationFlags propagationFlags, System.Security.AccessControl.AuditFlags flags);
-        public System.Security.Principal.IdentityReference GetGroup(System.Type targetType) { throw null; }
-        public System.Security.Principal.IdentityReference GetOwner(System.Type targetType) { throw null; }
+        public System.Security.Principal.IdentityReference? GetGroup(System.Type targetType) { throw null; }
+        public System.Security.Principal.IdentityReference? GetOwner(System.Type targetType) { throw null; }
         public byte[] GetSecurityDescriptorBinaryForm() { throw null; }
         public string GetSecurityDescriptorSddlForm(System.Security.AccessControl.AccessControlSections includeSections) { throw null; }
         public static bool IsSddlConversionSupported() { throw null; }
@@ -440,10 +440,10 @@ namespace System.Security.AccessControl
     public abstract partial class ObjectSecurity<T> : System.Security.AccessControl.NativeObjectSecurity where T : struct
     {
         protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
-        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle safeHandle, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
-        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle safeHandle, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode exceptionFromErrorCode, object exceptionContext) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
-        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string name, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
-        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string name, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode exceptionFromErrorCode, object exceptionContext) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle? safeHandle, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, System.Runtime.InteropServices.SafeHandle? safeHandle, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string? name, System.Security.AccessControl.AccessControlSections includeSections) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
+        protected ObjectSecurity(bool isContainer, System.Security.AccessControl.ResourceType resourceType, string? name, System.Security.AccessControl.AccessControlSections includeSections, System.Security.AccessControl.NativeObjectSecurity.ExceptionFromErrorCode? exceptionFromErrorCode, object? exceptionContext) : base (default(bool), default(System.Security.AccessControl.ResourceType)) { }
         public override System.Type AccessRightType { get { throw null; } }
         public override System.Type AccessRuleType { get { throw null; } }
         public override System.Type AuditRuleType { get { throw null; } }
@@ -466,9 +466,9 @@ namespace System.Security.AccessControl
     public sealed partial class PrivilegeNotHeldException : System.UnauthorizedAccessException, System.Runtime.Serialization.ISerializable
     {
         public PrivilegeNotHeldException() { }
-        public PrivilegeNotHeldException(string privilege) { }
-        public PrivilegeNotHeldException(string privilege, System.Exception inner) { }
-        public string PrivilegeName { get { throw null; } }
+        public PrivilegeNotHeldException(string? privilege) { }
+        public PrivilegeNotHeldException(string? privilege, System.Exception? inner) { }
+        public string? PrivilegeName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.FlagsAttribute]
@@ -484,8 +484,8 @@ namespace System.Security.AccessControl
         public System.Security.AccessControl.AceQualifier AceQualifier { get { throw null; } }
         public bool IsCallback { get { throw null; } }
         public int OpaqueLength { get { throw null; } }
-        public byte[] GetOpaque() { throw null; }
-        public void SetOpaque(byte[] opaque) { }
+        public byte[]? GetOpaque() { throw null; }
+        public void SetOpaque(byte[]? opaque) { }
     }
     public sealed partial class RawAcl : System.Security.AccessControl.GenericAcl
     {
@@ -502,14 +502,14 @@ namespace System.Security.AccessControl
     public sealed partial class RawSecurityDescriptor : System.Security.AccessControl.GenericSecurityDescriptor
     {
         public RawSecurityDescriptor(byte[] binaryForm, int offset) { }
-        public RawSecurityDescriptor(System.Security.AccessControl.ControlFlags flags, System.Security.Principal.SecurityIdentifier owner, System.Security.Principal.SecurityIdentifier group, System.Security.AccessControl.RawAcl systemAcl, System.Security.AccessControl.RawAcl discretionaryAcl) { }
+        public RawSecurityDescriptor(System.Security.AccessControl.ControlFlags flags, System.Security.Principal.SecurityIdentifier? owner, System.Security.Principal.SecurityIdentifier? group, System.Security.AccessControl.RawAcl? systemAcl, System.Security.AccessControl.RawAcl? discretionaryAcl) { }
         public RawSecurityDescriptor(string sddlForm) { }
         public override System.Security.AccessControl.ControlFlags ControlFlags { get { throw null; } }
-        public System.Security.AccessControl.RawAcl DiscretionaryAcl { get { throw null; } set { } }
-        public override System.Security.Principal.SecurityIdentifier Group { get { throw null; } set { } }
-        public override System.Security.Principal.SecurityIdentifier Owner { get { throw null; } set { } }
+        public System.Security.AccessControl.RawAcl? DiscretionaryAcl { get { throw null; } set { } }
+        public override System.Security.Principal.SecurityIdentifier? Group { get { throw null; } set { } }
+        public override System.Security.Principal.SecurityIdentifier? Owner { get { throw null; } set { } }
         public byte ResourceManagerControl { get { throw null; } set { } }
-        public System.Security.AccessControl.RawAcl SystemAcl { get { throw null; } set { } }
+        public System.Security.AccessControl.RawAcl? SystemAcl { get { throw null; } set { } }
         public void SetFlags(System.Security.AccessControl.ControlFlags flags) { }
     }
     public enum ResourceType

--- a/src/referencePackages/src/system.security.principal.windows/5.0.0/ref/netcoreapp3.0/System.Security.Principal.Windows.cs
+++ b/src/referencePackages/src/system.security.principal.windows/5.0.0/ref/netcoreapp3.0/System.Security.Principal.Windows.cs
@@ -44,8 +44,8 @@ namespace System.Security.Principal
     public sealed partial class IdentityNotMappedException : System.SystemException
     {
         public IdentityNotMappedException() { }
-        public IdentityNotMappedException(string message) { }
-        public IdentityNotMappedException(string message, System.Exception inner) { }
+        public IdentityNotMappedException(string? message) { }
+        public IdentityNotMappedException(string? message, System.Exception? inner) { }
         public System.Security.Principal.IdentityReferenceCollection UnmappedIdentities { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
@@ -53,11 +53,11 @@ namespace System.Security.Principal
     {
         internal IdentityReference() { }
         public abstract string Value { get; }
-        public abstract override bool Equals(object o);
+        public abstract override bool Equals(object? o);
         public abstract override int GetHashCode();
         public abstract bool IsValidTargetType(System.Type targetType);
-        public static bool operator ==(System.Security.Principal.IdentityReference left, System.Security.Principal.IdentityReference right) { throw null; }
-        public static bool operator !=(System.Security.Principal.IdentityReference left, System.Security.Principal.IdentityReference right) { throw null; }
+        public static bool operator ==(System.Security.Principal.IdentityReference? left, System.Security.Principal.IdentityReference? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.IdentityReference? left, System.Security.Principal.IdentityReference? right) { throw null; }
         public abstract override string ToString();
         public abstract System.Security.Principal.IdentityReference Translate(System.Type targetType);
     }
@@ -83,11 +83,11 @@ namespace System.Security.Principal
         public NTAccount(string name) { }
         public NTAccount(string domainName, string accountName) { }
         public override string Value { get { throw null; } }
-        public override bool Equals(object o) { throw null; }
+        public override bool Equals(object? o) { throw null; }
         public override int GetHashCode() { throw null; }
         public override bool IsValidTargetType(System.Type targetType) { throw null; }
-        public static bool operator ==(System.Security.Principal.NTAccount left, System.Security.Principal.NTAccount right) { throw null; }
-        public static bool operator !=(System.Security.Principal.NTAccount left, System.Security.Principal.NTAccount right) { throw null; }
+        public static bool operator ==(System.Security.Principal.NTAccount? left, System.Security.Principal.NTAccount? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.NTAccount? left, System.Security.Principal.NTAccount? right) { throw null; }
         public override string ToString() { throw null; }
         public override System.Security.Principal.IdentityReference Translate(System.Type targetType) { throw null; }
     }
@@ -97,13 +97,13 @@ namespace System.Security.Principal
         public static readonly int MinBinaryLength;
         public SecurityIdentifier(byte[] binaryForm, int offset) { }
         public SecurityIdentifier(System.IntPtr binaryForm) { }
-        public SecurityIdentifier(System.Security.Principal.WellKnownSidType sidType, System.Security.Principal.SecurityIdentifier domainSid) { }
+        public SecurityIdentifier(System.Security.Principal.WellKnownSidType sidType, System.Security.Principal.SecurityIdentifier? domainSid) { }
         public SecurityIdentifier(string sddlForm) { }
-        public System.Security.Principal.SecurityIdentifier AccountDomainSid { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? AccountDomainSid { get { throw null; } }
         public int BinaryLength { get { throw null; } }
         public override string Value { get { throw null; } }
-        public int CompareTo(System.Security.Principal.SecurityIdentifier sid) { throw null; }
-        public override bool Equals(object o) { throw null; }
+        public int CompareTo(System.Security.Principal.SecurityIdentifier? sid) { throw null; }
+        public override bool Equals(object? o) { throw null; }
         public bool Equals(System.Security.Principal.SecurityIdentifier sid) { throw null; }
         public void GetBinaryForm(byte[] binaryForm, int offset) { }
         public override int GetHashCode() { throw null; }
@@ -111,8 +111,8 @@ namespace System.Security.Principal
         public bool IsEqualDomainSid(System.Security.Principal.SecurityIdentifier sid) { throw null; }
         public override bool IsValidTargetType(System.Type targetType) { throw null; }
         public bool IsWellKnown(System.Security.Principal.WellKnownSidType type) { throw null; }
-        public static bool operator ==(System.Security.Principal.SecurityIdentifier left, System.Security.Principal.SecurityIdentifier right) { throw null; }
-        public static bool operator !=(System.Security.Principal.SecurityIdentifier left, System.Security.Principal.SecurityIdentifier right) { throw null; }
+        public static bool operator ==(System.Security.Principal.SecurityIdentifier? left, System.Security.Principal.SecurityIdentifier? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.SecurityIdentifier? left, System.Security.Principal.SecurityIdentifier? right) { throw null; }
         public override string ToString() { throw null; }
         public override System.Security.Principal.IdentityReference Translate(System.Type targetType) { throw null; }
     }
@@ -263,26 +263,26 @@ namespace System.Security.Principal
         protected WindowsIdentity(System.Security.Principal.WindowsIdentity identity) { }
         public WindowsIdentity(string sUserPrincipalName) { }
         public Microsoft.Win32.SafeHandles.SafeAccessTokenHandle AccessToken { get { throw null; } }
-        public sealed override string AuthenticationType { get { throw null; } }
+        public sealed override string? AuthenticationType { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> DeviceClaims { get { throw null; } }
-        public System.Security.Principal.IdentityReferenceCollection Groups { get { throw null; } }
+        public System.Security.Principal.IdentityReferenceCollection? Groups { get { throw null; } }
         public System.Security.Principal.TokenImpersonationLevel ImpersonationLevel { get { throw null; } }
         public virtual bool IsAnonymous { get { throw null; } }
         public override bool IsAuthenticated { get { throw null; } }
         public virtual bool IsGuest { get { throw null; } }
         public virtual bool IsSystem { get { throw null; } }
         public override string Name { get { throw null; } }
-        public System.Security.Principal.SecurityIdentifier Owner { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? Owner { get { throw null; } }
         public virtual System.IntPtr Token { get { throw null; } }
-        public System.Security.Principal.SecurityIdentifier User { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? User { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> UserClaims { get { throw null; } }
         public override System.Security.Claims.ClaimsIdentity Clone() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public static System.Security.Principal.WindowsIdentity GetAnonymous() { throw null; }
         public static System.Security.Principal.WindowsIdentity GetCurrent() { throw null; }
-        public static System.Security.Principal.WindowsIdentity GetCurrent(bool ifImpersonating) { throw null; }
+        public static System.Security.Principal.WindowsIdentity? GetCurrent(bool ifImpersonating) { throw null; }
         public static System.Security.Principal.WindowsIdentity GetCurrent(System.Security.Principal.TokenAccessLevels desiredAccess) { throw null; }
         public static void RunImpersonated(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle safeAccessTokenHandle, System.Action action) { }
         public static System.Threading.Tasks.Task RunImpersonatedAsync(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle safeAccessTokenHandle, System.Func<System.Threading.Tasks.Task> func) { throw null; }

--- a/src/referencePackages/src/system.security.principal.windows/5.0.0/ref/netstandard2.0/System.Security.Principal.Windows.cs
+++ b/src/referencePackages/src/system.security.principal.windows/5.0.0/ref/netstandard2.0/System.Security.Principal.Windows.cs
@@ -44,8 +44,8 @@ namespace System.Security.Principal
     public sealed partial class IdentityNotMappedException : System.SystemException
     {
         public IdentityNotMappedException() { }
-        public IdentityNotMappedException(string message) { }
-        public IdentityNotMappedException(string message, System.Exception inner) { }
+        public IdentityNotMappedException(string? message) { }
+        public IdentityNotMappedException(string? message, System.Exception? inner) { }
         public System.Security.Principal.IdentityReferenceCollection UnmappedIdentities { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
@@ -53,11 +53,11 @@ namespace System.Security.Principal
     {
         internal IdentityReference() { }
         public abstract string Value { get; }
-        public abstract override bool Equals(object o);
+        public abstract override bool Equals(object? o);
         public abstract override int GetHashCode();
         public abstract bool IsValidTargetType(System.Type targetType);
-        public static bool operator ==(System.Security.Principal.IdentityReference left, System.Security.Principal.IdentityReference right) { throw null; }
-        public static bool operator !=(System.Security.Principal.IdentityReference left, System.Security.Principal.IdentityReference right) { throw null; }
+        public static bool operator ==(System.Security.Principal.IdentityReference? left, System.Security.Principal.IdentityReference? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.IdentityReference? left, System.Security.Principal.IdentityReference? right) { throw null; }
         public abstract override string ToString();
         public abstract System.Security.Principal.IdentityReference Translate(System.Type targetType);
     }
@@ -83,11 +83,11 @@ namespace System.Security.Principal
         public NTAccount(string name) { }
         public NTAccount(string domainName, string accountName) { }
         public override string Value { get { throw null; } }
-        public override bool Equals(object o) { throw null; }
+        public override bool Equals(object? o) { throw null; }
         public override int GetHashCode() { throw null; }
         public override bool IsValidTargetType(System.Type targetType) { throw null; }
-        public static bool operator ==(System.Security.Principal.NTAccount left, System.Security.Principal.NTAccount right) { throw null; }
-        public static bool operator !=(System.Security.Principal.NTAccount left, System.Security.Principal.NTAccount right) { throw null; }
+        public static bool operator ==(System.Security.Principal.NTAccount? left, System.Security.Principal.NTAccount? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.NTAccount? left, System.Security.Principal.NTAccount? right) { throw null; }
         public override string ToString() { throw null; }
         public override System.Security.Principal.IdentityReference Translate(System.Type targetType) { throw null; }
     }
@@ -97,13 +97,13 @@ namespace System.Security.Principal
         public static readonly int MinBinaryLength;
         public SecurityIdentifier(byte[] binaryForm, int offset) { }
         public SecurityIdentifier(System.IntPtr binaryForm) { }
-        public SecurityIdentifier(System.Security.Principal.WellKnownSidType sidType, System.Security.Principal.SecurityIdentifier domainSid) { }
+        public SecurityIdentifier(System.Security.Principal.WellKnownSidType sidType, System.Security.Principal.SecurityIdentifier? domainSid) { }
         public SecurityIdentifier(string sddlForm) { }
-        public System.Security.Principal.SecurityIdentifier AccountDomainSid { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? AccountDomainSid { get { throw null; } }
         public int BinaryLength { get { throw null; } }
         public override string Value { get { throw null; } }
-        public int CompareTo(System.Security.Principal.SecurityIdentifier sid) { throw null; }
-        public override bool Equals(object o) { throw null; }
+        public int CompareTo(System.Security.Principal.SecurityIdentifier? sid) { throw null; }
+        public override bool Equals(object? o) { throw null; }
         public bool Equals(System.Security.Principal.SecurityIdentifier sid) { throw null; }
         public void GetBinaryForm(byte[] binaryForm, int offset) { }
         public override int GetHashCode() { throw null; }
@@ -111,8 +111,8 @@ namespace System.Security.Principal
         public bool IsEqualDomainSid(System.Security.Principal.SecurityIdentifier sid) { throw null; }
         public override bool IsValidTargetType(System.Type targetType) { throw null; }
         public bool IsWellKnown(System.Security.Principal.WellKnownSidType type) { throw null; }
-        public static bool operator ==(System.Security.Principal.SecurityIdentifier left, System.Security.Principal.SecurityIdentifier right) { throw null; }
-        public static bool operator !=(System.Security.Principal.SecurityIdentifier left, System.Security.Principal.SecurityIdentifier right) { throw null; }
+        public static bool operator ==(System.Security.Principal.SecurityIdentifier? left, System.Security.Principal.SecurityIdentifier? right) { throw null; }
+        public static bool operator !=(System.Security.Principal.SecurityIdentifier? left, System.Security.Principal.SecurityIdentifier? right) { throw null; }
         public override string ToString() { throw null; }
         public override System.Security.Principal.IdentityReference Translate(System.Type targetType) { throw null; }
     }
@@ -263,26 +263,26 @@ namespace System.Security.Principal
         protected WindowsIdentity(System.Security.Principal.WindowsIdentity identity) { }
         public WindowsIdentity(string sUserPrincipalName) { }
         public Microsoft.Win32.SafeHandles.SafeAccessTokenHandle AccessToken { get { throw null; } }
-        public sealed override string AuthenticationType { get { throw null; } }
+        public sealed override string? AuthenticationType { get { throw null; } }
         public override System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> DeviceClaims { get { throw null; } }
-        public System.Security.Principal.IdentityReferenceCollection Groups { get { throw null; } }
+        public System.Security.Principal.IdentityReferenceCollection? Groups { get { throw null; } }
         public System.Security.Principal.TokenImpersonationLevel ImpersonationLevel { get { throw null; } }
         public virtual bool IsAnonymous { get { throw null; } }
         public override bool IsAuthenticated { get { throw null; } }
         public virtual bool IsGuest { get { throw null; } }
         public virtual bool IsSystem { get { throw null; } }
         public override string Name { get { throw null; } }
-        public System.Security.Principal.SecurityIdentifier Owner { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? Owner { get { throw null; } }
         public virtual System.IntPtr Token { get { throw null; } }
-        public System.Security.Principal.SecurityIdentifier User { get { throw null; } }
+        public System.Security.Principal.SecurityIdentifier? User { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> UserClaims { get { throw null; } }
         public override System.Security.Claims.ClaimsIdentity Clone() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public static System.Security.Principal.WindowsIdentity GetAnonymous() { throw null; }
         public static System.Security.Principal.WindowsIdentity GetCurrent() { throw null; }
-        public static System.Security.Principal.WindowsIdentity GetCurrent(bool ifImpersonating) { throw null; }
+        public static System.Security.Principal.WindowsIdentity? GetCurrent(bool ifImpersonating) { throw null; }
         public static System.Security.Principal.WindowsIdentity GetCurrent(System.Security.Principal.TokenAccessLevels desiredAccess) { throw null; }
         public static void RunImpersonated(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle safeAccessTokenHandle, System.Action action) { }
         public static System.Threading.Tasks.Task RunImpersonatedAsync(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle safeAccessTokenHandle, System.Func<System.Threading.Tasks.Task> func) { throw null; }


### PR DESCRIPTION
This removes prebuilts from roslyn.

This  pulling in a new Arcade version to fix an issue with the dependency DependencyPackageProjects.