### PR TITLE
Add basic devcontainer configuration

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "Source-Build",
+	"image": "mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2"
+}


### PR DESCRIPTION
This will allow devs to work on SBRP using Codespaces, which will make it simpler to add packages to SBRP in the future.