### PR TITLE
Add netstandard.library 2.0.1 targeting pack

### DIFF
--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/LICENSE.TXT
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/LICENSE.TXT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/THIRD-PARTY-NOTICES.TXT
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,31 @@
+This Microsoft .NET Library may incorporate components from the projects listed
+below. Microsoft licenses these components under the Microsoft .NET Library
+software license terms. The original copyright notices and the licenses under
+which Microsoft received such components are set forth below for informational
+purposes only. Microsoft reserves all rights not expressly granted herein,
+whether by implication, estoppel or otherwise.
+
+1.	.NET Core (https://github.com/dotnet/core/)
+
+.NET Core
+Copyright (c) .NET Foundation and Contributors
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/NETStandard.Library.targets
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/NETStandard.Library.targets
@@ -1,0 +1,23 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NETStandardLibraryPackageVersion>2.0.1</NETStandardLibraryPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_NetStandardLibraryRefPath)' != ''">
+    <Reference Include="$(_NetStandardLibraryRefPath)*.dll">
+      <!-- Private = false to make these reference only -->
+      <Private>false</Private>
+      <!-- hide these from Assemblies view in Solution Explorer, they will be shown under packages -->
+      <Visible>false</Visible>
+      <Facade Condition="'%(FileName)' != 'netstandard'">true</Facade>
+      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+    </Reference>
+    <ReferenceCopyLocalPaths Condition="'$(_NetStandardLibraryLibPath)' != ''" Include="$(_NetStandardLibraryLibPath)*.dll">
+      <Private>false</Private>
+      <Facade Condition="'%(FileName)' != 'netstandard'">true</Facade>
+      <NuGetPackageId>NETStandard.Library</NuGetPackageId>
+      <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+    </ReferenceCopyLocalPaths>
+  </ItemGroup>
+</Project>

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/NETStandard.Library.targets
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/NETStandard.Library.targets
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Only add references if we're actually targeting .NETStandard.
+       If the project is targeting some other TFM that is compatible with NETStandard we expect
+       that framework to provide all references for NETStandard, mscorlib, System.* in their own
+       targeting pack / SDK. -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <_NetStandardLibraryRefPath>$(MSBuildThisFileDirectory)\ref\</_NetStandardLibraryRefPath>
+  </PropertyGroup>
+
+  <!-- import the TFM-agnostic targets -->
+  <Import Project="..\$(MSBuildThisFile)"/>
+</Project>

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/Microsoft.Win32.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/Microsoft.Win32.Primitives.il
@@ -1,0 +1,316 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028a6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000fccb
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002854 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000271c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008ac Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008a8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002896 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000064c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000269c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x0000023c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000424 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000428 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000438 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17623             (83.06%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1612               ( 7.60%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -779              (-3.67%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1612
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   570 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ Microsoft.Win32.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 2E 57 69 6E   // ...Microsoft.Win
+                                                                                                                                                              33 32 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )    // 32.Primitives..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 2E 57 69 6E   // ...Microsoft.Win
+                                                                                                                                                                    33 32 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )    // 32.Primitives..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 2E 57 69 6E   // ...Microsoft.Win
+                                                                                                                                                                     33 32 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )    // 32.Primitives..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.ComponentModel.Win32Exception
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module Microsoft.Win32.Primitives.dll
+// MVID: {4bdda669-7ba1-46b2-9334-a36ba93a756b}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FEBABBC1000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.AppContext.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.AppContext.il
@@ -1,0 +1,316 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002866
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000595a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002814 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004e0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003eb8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000026dc [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000086c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004e0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000868
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002856 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000060c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000265c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x00000204 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000003ec Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000003f0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000400 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21176
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17503             (82.65%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1548               ( 7.31%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -635              (-3.00%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1548
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   515 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.AppContext
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 11 53 79 73 74 65 6D 2E 41 70 70 43 6F 6E   // ...System.AppCon
+                                                                                                                                                              74 65 78 74 00 00 )                               // text..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 11 53 79 73 74 65 6D 2E 41 70 70 43 6F 6E   // ...System.AppCon
+                                                                                                                                                                    74 65 78 74 00 00 )                               // text..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 11 53 79 73 74 65 6D 2E 41 70 70 43 6F 6E   // ...System.AppCon
+                                                                                                                                                                     74 65 78 74 00 00 )                               // text..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.AppContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.AppContext.dll
+// MVID: {2d36bec8-9c81-4588-9483-87c14ee0535d}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F445C9B1000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.Concurrent.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.Concurrent.il
@@ -1,0 +1,355 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029c6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000ba58
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002974 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000544] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000283c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009cc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000544 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009c8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029b6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000076c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027bc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001f8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000264 Offset
+//              0x000002dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000540 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000544 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000554 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17651             (83.17%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1900               ( 8.95%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1087             (-5.12%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1900
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   10 (140 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   729 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Collections.Concurrent
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                              74 69 6F 6E 73 2E 43 6F 6E 63 75 72 72 65 6E 74   // tions.Concurrent
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                    74 69 6F 6E 73 2E 43 6F 6E 63 75 72 72 65 6E 74   // tions.Concurrent
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                     74 69 6F 6E 73 2E 43 6F 6E 63 75 72 72 65 6E 74   // tions.Concurrent
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Collections.Concurrent.BlockingCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Collections.Concurrent.ConcurrentBag`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.Concurrent.ConcurrentDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Collections.Concurrent.ConcurrentQueue`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Collections.Concurrent.ConcurrentStack`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Collections.Concurrent.EnumerablePartitionerOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Collections.Concurrent.IProducerConsumerCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Collections.Concurrent.OrderablePartitioner`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Collections.Concurrent.Partitioner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Collections.Concurrent.Partitioner`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Collections.Concurrent.dll
+// MVID: {cd64df5c-55c5-4eb8-b45a-d6e2f79dc4e6}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F15DFB46000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.NonGeneric.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.NonGeneric.il
@@ -1,0 +1,359 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029c2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00013ef2
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002970 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002838 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009c8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009c4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029b2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000768] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027b8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000208 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000274 Offset
+//              0x000002c8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000053c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000540 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000550 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1896               ( 8.93%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1079             (-5.08%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1896
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   11 (154 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   710 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Collections.NonGeneric
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                              74 69 6F 6E 73 2E 4E 6F 6E 47 65 6E 65 72 69 63   // tions.NonGeneric
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                    74 69 6F 6E 73 2E 4E 6F 6E 47 65 6E 65 72 69 63   // tions.NonGeneric
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                     74 69 6F 6E 73 2E 4E 6F 6E 47 65 6E 65 72 69 63   // tions.NonGeneric
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Collections.ArrayList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Collections.CaseInsensitiveComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.CollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Collections.Comparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Collections.DictionaryBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Collections.Hashtable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Collections.Queue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Collections.ReadOnlyCollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Collections.SortedList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Collections.Stack
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Collections.Specialized.CollectionsUtil
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Collections.NonGeneric.dll
+// MVID: {a034a278-c2a4-4465-a6bd-0912ca816f0f}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F8EE48D2000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.Specialized.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.Specialized.il
@@ -1,0 +1,363 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029da
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000100ac
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002988 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002850 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009e0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009dc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029ca Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000780] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027d0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000214 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000280 Offset
+//              0x000002d4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000554 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000558 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000568 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17663             (83.22%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1920               ( 9.05%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1119             (-5.27%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1920
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   12 (168 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   723 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Collections.Specialized
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                              74 69 6F 6E 73 2E 53 70 65 63 69 61 6C 69 7A 65   // tions.Specialize
+                                                                                                                                                              64 00 00 )                                        // d..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                    74 69 6F 6E 73 2E 53 70 65 63 69 61 6C 69 7A 65   // tions.Specialize
+                                                                                                                                                                    64 00 00 )                                        // d..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                     74 69 6F 6E 73 2E 53 70 65 63 69 61 6C 69 7A 65   // tions.Specialize
+                                                                                                                                                                     64 00 00 )                                        // d..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Collections.Specialized.BitVector32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ Section
+{
+  .class extern System.Collections.Specialized.BitVector32 /*27000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.Specialized.HybridDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Collections.Specialized.IOrderedDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Collections.Specialized.ListDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Collections.Specialized.NameObjectCollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ KeysCollection
+{
+  .class extern System.Collections.Specialized.NameObjectCollectionBase /*27000006*/ 
+}
+.class extern /*27000008*/ forwarder System.Collections.Specialized.NameValueCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Collections.Specialized.OrderedDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Collections.Specialized.StringCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Collections.Specialized.StringDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Collections.Specialized.StringEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Collections.Specialized.dll
+// MVID: {98329995-6f8a-447a-9c38-ff2c2b806e1f}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F9797EAA000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Collections.il
@@ -1,0 +1,432 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002ad6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000a44a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a84 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f4] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000294c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000adc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f4 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ad8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002ac6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000087c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028cc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000310 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000037c Offset
+//              0x000002e0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000065c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000660 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000670 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17531             (80.80%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2172               (10.01%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -767              (-3.54%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2172
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   30 (420 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   735 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Collections
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 12 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                              74 69 6F 6E 73 00 00 )                            // tions..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 12 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                    74 69 6F 6E 73 00 00 )                            // tions..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 12 53 79 73 74 65 6D 2E 43 6F 6C 6C 65 63   // ...System.Collec
+                                                                                                                                                                     74 69 6F 6E 73 00 00 )                            // tions..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Collections.BitArray
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Collections.StructuralComparisons
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.Generic.Comparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Collections.Generic.Dictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*27000004*/ 
+}
+.class extern /*27000006*/ KeyCollection
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*27000004*/ 
+}
+.class extern /*27000007*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2/KeyCollection /*27000006*/ 
+}
+.class extern /*27000008*/ ValueCollection
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*27000004*/ 
+}
+.class extern /*27000009*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2/ValueCollection /*27000008*/ 
+}
+.class extern /*2700000A*/ forwarder System.Collections.Generic.EqualityComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Collections.Generic.HashSet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ Enumerator
+{
+  .class extern System.Collections.Generic.HashSet`1 /*2700000B*/ 
+}
+.class extern /*2700000D*/ forwarder System.Collections.Generic.LinkedListNode`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Collections.Generic.LinkedList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ Enumerator
+{
+  .class extern System.Collections.Generic.LinkedList`1 /*2700000E*/ 
+}
+.class extern /*27000010*/ forwarder System.Collections.Generic.List`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ Enumerator
+{
+  .class extern System.Collections.Generic.List`1 /*27000010*/ 
+}
+.class extern /*27000012*/ forwarder System.Collections.Generic.Queue`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ Enumerator
+{
+  .class extern System.Collections.Generic.Queue`1 /*27000012*/ 
+}
+.class extern /*27000014*/ forwarder System.Collections.Generic.SortedDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*27000014*/ 
+}
+.class extern /*27000016*/ KeyCollection
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*27000014*/ 
+}
+.class extern /*27000017*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2/KeyCollection /*27000016*/ 
+}
+.class extern /*27000018*/ ValueCollection
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*27000014*/ 
+}
+.class extern /*27000019*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2/ValueCollection /*27000018*/ 
+}
+.class extern /*2700001A*/ forwarder System.Collections.Generic.SortedList`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Collections.Generic.SortedSet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedSet`1 /*2700001B*/ 
+}
+.class extern /*2700001D*/ forwarder System.Collections.Generic.Stack`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ Enumerator
+{
+  .class extern System.Collections.Generic.Stack`1 /*2700001D*/ 
+}
+.module System.Collections.dll
+// MVID: {a4ea7691-bf5d-44b2-bfac-41061ba1a3ad}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F98EF26C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.Composition.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.Composition.il
@@ -1,0 +1,310 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000280a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000120f0
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000027b8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002680 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000810 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000080c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000027fa Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000005b0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002600 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x0000022c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000414 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000418 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000428 Offset
+//              0x00000188 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21240
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17695             (83.31%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1456               ( 6.85%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.64%)
+// Unaccounted          : -671              (-3.16%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1456
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   554 bytes
+//   Blobs         -   392 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ComponentModel.Composition
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 21 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..!System.Compon
+                                                                                                                                                              65 6E 74 4D 6F 64 65 6C 2E 43 6F 6D 70 6F 73 69   // entModel.Composi
+                                                                                                                                                              74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 21 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..!System.Compon
+                                                                                                                                                                    65 6E 74 4D 6F 64 65 6C 2E 43 6F 6D 70 6F 73 69   // entModel.Composi
+                                                                                                                                                                    74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 21 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..!System.Compon
+                                                                                                                                                                     65 6E 74 4D 6F 64 65 6C 2E 43 6F 6D 70 6F 73 69   // entModel.Composi
+                                                                                                                                                                     74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Lazy`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ComponentModel.Composition.dll
+// MVID: {22ce3ca8-c0ba-4fbc-8ad6-153613765ba1}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FC046D7D000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.EventBasedAsync.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.EventBasedAsync.il
@@ -1,0 +1,359 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a42
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000104b3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029f0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000584] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003f08] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028b8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a48 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000584 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a44
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a32 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007e8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002838 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000208 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000274 Offset
+//              0x00000340 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005b4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005b8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005c8 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21768
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17747             (81.53%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2024               ( 9.30%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.41%)
+// Unaccounted          : -763              (-3.51%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2024
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   11 (154 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   829 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ComponentModel.EventBasedAsync
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 25 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..%System.Compon
+                                                                                                                                                              65 6E 74 4D 6F 64 65 6C 2E 45 76 65 6E 74 42 61   // entModel.EventBa
+                                                                                                                                                              73 65 64 41 73 79 6E 63 00 00 )                   // sedAsync..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 25 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..%System.Compon
+                                                                                                                                                                    65 6E 74 4D 6F 64 65 6C 2E 45 76 65 6E 74 42 61   // entModel.EventBa
+                                                                                                                                                                    73 65 64 41 73 79 6E 63 00 00 )                   // sedAsync..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 25 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..%System.Compon
+                                                                                                                                                                     65 6E 74 4D 6F 64 65 6C 2E 45 76 65 6E 74 42 61   // entModel.EventBa
+                                                                                                                                                                     73 65 64 41 73 79 6E 63 00 00 )                   // sedAsync..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.ComponentModel.AsyncCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ComponentModel.AsyncCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ComponentModel.AsyncOperation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ComponentModel.AsyncOperationManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ComponentModel.BackgroundWorker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.ComponentModel.DoWorkEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ComponentModel.DoWorkEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ComponentModel.ProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.ComponentModel.ProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.ComponentModel.RunWorkerCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.ComponentModel.RunWorkerCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ComponentModel.EventBasedAsync.dll
+// MVID: {0903d0b4-ca36-4ec8-8dd2-86f36c3cb42c}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6E4B221000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.Primitives.il
@@ -1,0 +1,403 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b8e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000b6f3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b3c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ef8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a04 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b94 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b90
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b7e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000934] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002984 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002a0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000030c Offset
+//              0x000003fc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000708 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000070c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000071c Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21752
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17695             (81.35%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2356               (10.83%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -1059             (-4.87%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2356
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   22 (308 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1019 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ComponentModel.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 20 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // .. System.Compon
+                                                                                                                                                              65 6E 74 4D 6F 64 65 6C 2E 50 72 69 6D 69 74 69   // entModel.Primiti
+                                                                                                                                                              76 65 73 00 00 )                                  // ves..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 20 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // .. System.Compon
+                                                                                                                                                                    65 6E 74 4D 6F 64 65 6C 2E 50 72 69 6D 69 74 69   // entModel.Primiti
+                                                                                                                                                                    76 65 73 00 00 )                                  // ves..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 20 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // .. System.Compon
+                                                                                                                                                                     65 6E 74 4D 6F 64 65 6C 2E 50 72 69 6D 69 74 69   // entModel.Primiti
+                                                                                                                                                                     76 65 73 00 00 )                                  // ves..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.ComponentModel.BrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ComponentModel.CategoryAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ComponentModel.ComponentCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ComponentModel.DescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ComponentModel.DesignerCategoryAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.ComponentModel.DesignerSerializationVisibility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ComponentModel.DesignerSerializationVisibilityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ComponentModel.DesignOnlyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.ComponentModel.DisplayNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.ComponentModel.EventHandlerList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.ComponentModel.IComponent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.ComponentModel.IContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.ComponentModel.ImmutableObjectAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.ComponentModel.InitializationEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.ComponentModel.ISite
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.ComponentModel.LocalizableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.ComponentModel.MergablePropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.ComponentModel.NotifyParentPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.ComponentModel.ParenthesizePropertyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.ComponentModel.ReadOnlyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.ComponentModel.RefreshProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.ComponentModel.RefreshPropertiesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ComponentModel.Primitives.dll
+// MVID: {0ac1d73c-c037-49b5-b5af-11774baa1ea6}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FED08AC0000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.TypeConverter.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.TypeConverter.il
@@ -1,0 +1,551 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001000
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002fde
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000d83a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002f8c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000570] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001a00 [0x00003f00] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002e54 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000fe4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001000 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000570 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000fe0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002fce Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000d84] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002dd4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000004a8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000514 Offset
+//              0x00000640 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000b54 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000b58 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000b68 Offset
+//              0x0000021c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22784
+// PE header size       : 512 (496 used)    ( 2.25%)
+// PE additional info   : 17719             (77.77%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 3460               (15.19%)
+// CLR additional info : 128                ( 0.56%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 8.99%)
+// Unaccounted          : -1155             (-5.07%)
+
+// Num.of PE sections   : 3
+//   .text    - 4096
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 3460
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   59 (826 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1599 bytes
+//   Blobs         -   540 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ComponentModel.TypeConverter
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 23 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..#System.Compon
+                                                                                                                                                              65 6E 74 4D 6F 64 65 6C 2E 54 79 70 65 43 6F 6E   // entModel.TypeCon
+                                                                                                                                                              76 65 72 74 65 72 00 00 )                         // verter..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 23 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..#System.Compon
+                                                                                                                                                                    65 6E 74 4D 6F 64 65 6C 2E 54 79 70 65 43 6F 6E   // entModel.TypeCon
+                                                                                                                                                                    76 65 72 74 65 72 00 00 )                         // verter..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 23 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ..#System.Compon
+                                                                                                                                                                     65 6E 74 4D 6F 64 65 6C 2E 54 79 70 65 43 6F 6E   // entModel.TypeCon
+                                                                                                                                                                     76 65 72 74 65 72 00 00 )                         // verter..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.UriTypeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ComponentModel.ArrayConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ComponentModel.AttributeCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ComponentModel.AttributeProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ComponentModel.BaseNumberConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.ComponentModel.BooleanConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ComponentModel.ByteConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ComponentModel.CancelEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.ComponentModel.CharConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.ComponentModel.CollectionChangeAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.ComponentModel.CollectionChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.ComponentModel.CollectionChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.ComponentModel.CollectionConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.ComponentModel.CustomTypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.ComponentModel.DateTimeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.ComponentModel.DateTimeOffsetConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.ComponentModel.DecimalConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.ComponentModel.DefaultEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.ComponentModel.DefaultPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.ComponentModel.DoubleConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.ComponentModel.EnumConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.ComponentModel.EventDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.ComponentModel.EventDescriptorCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.ComponentModel.ExtenderProvidedPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.ComponentModel.GuidConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.ComponentModel.HandledEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.ComponentModel.HandledEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.ComponentModel.ICustomTypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.ComponentModel.IExtenderProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.ComponentModel.IListSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.ComponentModel.Int16Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.ComponentModel.Int32Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.ComponentModel.Int64Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.ComponentModel.InvalidAsynchronousStateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.ComponentModel.ITypeDescriptorContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.ComponentModel.ITypedList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.ComponentModel.MemberDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.ComponentModel.MultilineStringConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.ComponentModel.NullableConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.ComponentModel.PropertyDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.ComponentModel.PropertyDescriptorCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.ComponentModel.ProvidePropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.ComponentModel.RefreshEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.ComponentModel.RefreshEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.ComponentModel.SByteConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.ComponentModel.SingleConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.ComponentModel.StringConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.ComponentModel.TimeSpanConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.ComponentModel.TypeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ SimplePropertyDescriptor
+{
+  .class extern System.ComponentModel.TypeConverter /*27000031*/ 
+}
+.class extern /*27000033*/ StandardValuesCollection
+{
+  .class extern System.ComponentModel.TypeConverter /*27000031*/ 
+}
+.class extern /*27000034*/ forwarder System.ComponentModel.TypeConverterAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.ComponentModel.TypeDescriptionProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.ComponentModel.TypeDescriptionProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.ComponentModel.TypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.ComponentModel.TypeListConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.ComponentModel.UInt16Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.ComponentModel.UInt32Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.ComponentModel.UInt64Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ComponentModel.TypeConverter.dll
+// MVID: {a2890f0a-ef91-4af7-b7d5-e6f4e876237d}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F59CA7D4000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ComponentModel.il
@@ -1,0 +1,332 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002906
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001158f
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028b4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000277c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000090c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000908
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028f6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006ac] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026fc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x00000268 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000488 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000048c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000049c Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1708               ( 8.06%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -827              (-3.90%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1708
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   614 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ComponentModel
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 15 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ...System.Compon
+                                                                                                                                                              65 6E 74 4D 6F 64 65 6C 00 00 )                   // entModel..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 15 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ...System.Compon
+                                                                                                                                                                    65 6E 74 4D 6F 64 65 6C 00 00 )                   // entModel..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 15 53 79 73 74 65 6D 2E 43 6F 6D 70 6F 6E   // ...System.Compon
+                                                                                                                                                                     65 6E 74 4D 6F 64 65 6C 00 00 )                   // entModel..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.IServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ComponentModel.CancelEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ComponentModel.IChangeTracking
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ComponentModel.IEditableObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ComponentModel.IRevertibleChangeTracking
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ComponentModel.dll
+// MVID: {10193847-1b42-4367-87f8-1048e4ff3f1a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FF7B50E1000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Console.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Console.il
@@ -1,0 +1,344 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002936
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000055f3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028e4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ea8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027ac [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000093c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000938
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002926 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006dc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000272c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001dc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000248 Offset
+//              0x00000278 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004c0 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004c4 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004d4 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21160
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17471             (82.57%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1756               ( 8.30%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.68%)
+// Unaccounted          : -827              (-3.91%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1756
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    8 (112 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   632 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Console
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 43 6F 6E 73 6F 6C   // ...System.Consol
+                                                                                                                                                              65 00 00 )                                        // e..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 43 6F 6E 73 6F 6C   // ...System.Consol
+                                                                                                                                                                    65 00 00 )                                        // e..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 43 6F 6E 73 6F 6C   // ...System.Consol
+                                                                                                                                                                     65 00 00 )                                        // e..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Console
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ConsoleCancelEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ConsoleCancelEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ConsoleColor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ConsoleKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.ConsoleKeyInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ConsoleModifiers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ConsoleSpecialKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Console.dll
+// MVID: {31f4d46a-c515-4f83-a9a6-095313e2cba4}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F708E3A4000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Core.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Core.il
@@ -1,0 +1,976 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00003c62
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000134d8
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00003c10 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00002800 [0x00003ea0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00003ad8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00001c68 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00002000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00002600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00003000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c64
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00003c52 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00001a08] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00003a58 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000aac Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000b18 Offset
+//              0x00000d68 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00001880 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00001884 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00001894 Offset
+//              0x00000174 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 26272
+// PE header size       : 512 (496 used)    ( 1.95%)
+// PE additional info   : 17431             (66.35%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.27%)
+// CLR meta-data size  : 6664               (25.37%)
+// CLR additional info : 128                ( 0.49%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 7.80%)
+// Unaccounted          : -583              (-2.22%)
+
+// Num.of PE sections   : 3
+//   .text    - 7680
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 6664
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -  169 (2366 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  3432 bytes
+//   Blobs         -   372 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Core
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 43 6F 72 65 00 00 ) // ...System.Core..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 43 6F 72 65 00 00 ) // ...System.Core..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 43 6F 72 65 00 00 ) // ...System.Core..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder Microsoft.Win32.SafeHandles.SafePipeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Action
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Action`10
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Action`11
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Action`12
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Action`13
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Action`14
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Action`15
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Action`16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Action`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Action`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Action`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Action`9
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Func`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Func`10
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Func`11
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Func`12
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Func`13
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Func`14
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Func`15
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Func`16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Func`17
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Func`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Func`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Func`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Func`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.InvalidTimeZoneException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Lazy`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.TimeZoneInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ AdjustmentRule
+{
+  .class extern System.TimeZoneInfo /*2700001F*/ 
+}
+.class extern /*27000021*/ TransitionTime
+{
+  .class extern System.TimeZoneInfo /*2700001F*/ 
+}
+.class extern /*27000022*/ forwarder System.TimeZoneNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Collections.Generic.HashSet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ Enumerator
+{
+  .class extern System.Collections.Generic.HashSet`1 /*27000023*/ 
+}
+.class extern /*27000025*/ forwarder System.Dynamic.BinaryOperationBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Dynamic.BindingRestrictions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Dynamic.CallInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Dynamic.ConvertBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Dynamic.CreateInstanceBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Dynamic.DeleteIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Dynamic.DeleteMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Dynamic.DynamicMetaObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Dynamic.DynamicMetaObjectBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Dynamic.DynamicObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.Dynamic.ExpandoObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.Dynamic.GetIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.Dynamic.GetMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.Dynamic.IDynamicMetaObjectProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.Dynamic.IInvokeOnGetBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.Dynamic.InvokeBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.Dynamic.InvokeMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Dynamic.SetIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.Dynamic.SetMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.Dynamic.UnaryOperationBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.IO.HandleInheritability
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileRights
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedViewAccessor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedViewStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.IO.Pipes.AnonymousPipeClientStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.IO.Pipes.AnonymousPipeServerStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.IO.Pipes.NamedPipeClientStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.IO.Pipes.NamedPipeServerStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ forwarder System.IO.Pipes.PipeDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000045*/ forwarder System.IO.Pipes.PipeOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.IO.Pipes.PipeStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.IO.Pipes.PipeStreamImpersonationWorker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.IO.Pipes.PipeTransmissionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.Linq.Enumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.Linq.EnumerableExecutor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.Linq.EnumerableExecutor`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.Linq.EnumerableQuery
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.Linq.EnumerableQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.Linq.IGrouping`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.Linq.ILookup`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.Linq.IOrderedEnumerable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.Linq.IOrderedQueryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.Linq.IOrderedQueryable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.Linq.IQueryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.Linq.IQueryable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Linq.IQueryProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ forwarder System.Linq.Lookup`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000057*/ forwarder System.Linq.OrderedParallelQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000058*/ forwarder System.Linq.ParallelEnumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.Linq.ParallelExecutionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.Linq.ParallelMergeOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.Linq.ParallelQuery
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.Linq.ParallelQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.Linq.Queryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.Linq.Expressions.BinaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.Linq.Expressions.BlockExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.Linq.Expressions.CatchBlock
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.Linq.Expressions.ConditionalExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.Linq.Expressions.ConstantExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.Linq.Expressions.DebugInfoExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.Linq.Expressions.DefaultExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.Linq.Expressions.DynamicExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.Linq.Expressions.DynamicExpressionVisitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.Linq.Expressions.ElementInit
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.Linq.Expressions.Expression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.Linq.Expressions.ExpressionType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.Linq.Expressions.ExpressionVisitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.Linq.Expressions.Expression`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.Linq.Expressions.GotoExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.Linq.Expressions.GotoExpressionKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ forwarder System.Linq.Expressions.IArgumentProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006F*/ forwarder System.Linq.Expressions.IDynamicExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ forwarder System.Linq.Expressions.IndexExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000071*/ forwarder System.Linq.Expressions.InvocationExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.Linq.Expressions.LabelExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000073*/ forwarder System.Linq.Expressions.LabelTarget
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000074*/ forwarder System.Linq.Expressions.LambdaExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000075*/ forwarder System.Linq.Expressions.ListInitExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000076*/ forwarder System.Linq.Expressions.LoopExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000077*/ forwarder System.Linq.Expressions.MemberAssignment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000078*/ forwarder System.Linq.Expressions.MemberBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000079*/ forwarder System.Linq.Expressions.MemberBindingType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007A*/ forwarder System.Linq.Expressions.MemberExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.Linq.Expressions.MemberInitExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007C*/ forwarder System.Linq.Expressions.MemberListBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007D*/ forwarder System.Linq.Expressions.MemberMemberBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007E*/ forwarder System.Linq.Expressions.MethodCallExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007F*/ forwarder System.Linq.Expressions.NewArrayExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.Linq.Expressions.NewExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000081*/ forwarder System.Linq.Expressions.ParameterExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000082*/ forwarder System.Linq.Expressions.RuntimeVariablesExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.Linq.Expressions.SwitchCase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ forwarder System.Linq.Expressions.SwitchExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000085*/ forwarder System.Linq.Expressions.SymbolDocumentInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000086*/ forwarder System.Linq.Expressions.TryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ forwarder System.Linq.Expressions.TypeBinaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000088*/ forwarder System.Linq.Expressions.UnaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ forwarder System.Runtime.CompilerServices.CallSite
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008A*/ forwarder System.Runtime.CompilerServices.CallSiteBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ forwarder System.Runtime.CompilerServices.CallSiteHelpers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008C*/ forwarder System.Runtime.CompilerServices.CallSite`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008D*/ forwarder System.Runtime.CompilerServices.DebugInfoGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008E*/ forwarder System.Runtime.CompilerServices.DynamicAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008F*/ forwarder System.Runtime.CompilerServices.ExtensionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000090*/ forwarder System.Runtime.CompilerServices.IRuntimeVariables
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.Runtime.CompilerServices.IStrongBox
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ forwarder System.Runtime.CompilerServices.ReadOnlyCollectionBuilder`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000093*/ forwarder System.Runtime.CompilerServices.RuleCache`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ forwarder System.Runtime.CompilerServices.StrongBox`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000095*/ forwarder System.Runtime.InteropServices.ComAwareEventInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.Security.Cryptography.Aes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.Security.Cryptography.AesCryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000098*/ forwarder System.Security.Cryptography.AesManaged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000099*/ forwarder System.Security.Cryptography.ECCurve
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009A*/ ECCurveType
+{
+  .class extern System.Security.Cryptography.ECCurve /*27000099*/ 
+}
+.class extern /*2700009B*/ NamedCurves
+{
+  .class extern System.Security.Cryptography.ECCurve /*27000099*/ 
+}
+.class extern /*2700009C*/ forwarder System.Security.Cryptography.ECDiffieHellmanPublicKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009D*/ forwarder System.Security.Cryptography.ECDsa
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009E*/ forwarder System.Security.Cryptography.ECParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009F*/ forwarder System.Security.Cryptography.ECPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A0*/ forwarder System.Security.Cryptography.SHA256CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A1*/ forwarder System.Security.Cryptography.SHA384CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A2*/ forwarder System.Security.Cryptography.SHA512CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A3*/ forwarder System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A4*/ forwarder System.Security.Cryptography.X509Certificates.RSACertificateExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A5*/ forwarder System.Threading.LazyThreadSafetyMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A6*/ forwarder System.Threading.LockRecursionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A7*/ forwarder System.Threading.LockRecursionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A8*/ forwarder System.Threading.ReaderWriterLockSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A9*/ forwarder System.Threading.Tasks.TaskExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Core.dll
+// MVID: {3f3f875d-1b8d-4e51-97b2-a9cae4603fa8}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB00A0D0000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Data.Common.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Data.Common.il
@@ -1,0 +1,448 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002c26
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008381
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002bd4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003eb8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a9c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000c2c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c28
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c16 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000009cc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002a1c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000348 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003b4 Offset
+//              0x000003f8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000007ac Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000007b0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000007c0 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22200
+// PE header size       : 512 (496 used)    ( 2.31%)
+// PE additional info   : 17519             (78.91%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2508               (11.30%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.23%)
+// Unaccounted          : -587              (-2.64%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2508
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   34 (476 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1014 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Data.Common
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 12 53 79 73 74 65 6D 2E 44 61 74 61 2E 43   // ...System.Data.C
+                                                                                                                                                              6F 6D 6D 6F 6E 00 00 )                            // ommon..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 12 53 79 73 74 65 6D 2E 44 61 74 61 2E 43   // ...System.Data.C
+                                                                                                                                                                    6F 6D 6D 6F 6E 00 00 )                            // ommon..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 12 53 79 73 74 65 6D 2E 44 61 74 61 2E 43   // ...System.Data.C
+                                                                                                                                                                     6F 6D 6D 6F 6E 00 00 )                            // ommon..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.DBNull
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Data.CommandBehavior
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Data.CommandType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Data.ConnectionState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Data.DataRowVersion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Data.DataTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Data.DbType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Data.IDataParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Data.IDataParameterCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Data.IDataReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Data.IDataRecord
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Data.IDbCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Data.IDbConnection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Data.IDbDataParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Data.IDbTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Data.IsolationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Data.ParameterDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Data.StateChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Data.StateChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Data.UpdateRowSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Data.Common.DbColumn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Data.Common.DbCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Data.Common.DbConnection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Data.Common.DbConnectionStringBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Data.Common.DbDataReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Data.Common.DbDataReaderExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Data.Common.DbDataRecord
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Data.Common.DbEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Data.Common.DbException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Data.Common.DbParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Data.Common.DbParameterCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Data.Common.DbProviderFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Data.Common.DbTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Data.Common.IDbColumnSchemaGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Data.Common.dll
+// MVID: {91bbf54a-f8b8-430d-b6a3-614d4e644a11}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F74DE403000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Data.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Data.il
@@ -1,0 +1,904 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00003a1e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008889
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000039cc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00002600 [0x00003ea0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00003894 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00001a24 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00002400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00003000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a20
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00003a0e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000017c4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00003814 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000009b0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000a1c Offset
+//              0x00000c20 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000163c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00001640 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00001650 Offset
+//              0x00000174 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 25760
+// PE header size       : 512 (496 used)    ( 1.99%)
+// PE additional info   : 17431             (67.67%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.28%)
+// CLR meta-data size  : 6084               (23.62%)
+// CLR additional info : 128                ( 0.50%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 7.95%)
+// Unaccounted          : -515              (-2.00%)
+
+// Num.of PE sections   : 3
+//   .text    - 7168
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 6084
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -  151 (2114 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  3101 bytes
+//   Blobs         -   372 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Data
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 44 61 74 61 00 00 ) // ...System.Data..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 44 61 74 61 00 00 ) // ...System.Data..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 44 61 74 61 00 00 ) // ...System.Data..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Data.AcceptRejectRule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Data.CommandBehavior
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Data.CommandType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Data.ConflictOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Data.ConnectionState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Data.Constraint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Data.ConstraintCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Data.ConstraintException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Data.DataColumn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Data.DataColumnChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Data.DataColumnChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Data.DataColumnCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Data.DataException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Data.DataRelation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Data.DataRelationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Data.DataRow
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Data.DataRowAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Data.DataRowBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Data.DataRowChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Data.DataRowChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Data.DataRowCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Data.DataRowState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Data.DataRowVersion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Data.DataRowView
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Data.DataSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Data.DataSetDateTime
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Data.DataSysDescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Data.DataTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Data.DataTableClearEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Data.DataTableClearEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Data.DataTableCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Data.DataTableNewRowEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Data.DataTableNewRowEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Data.DataTableReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Data.DataView
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Data.DataViewManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Data.DataViewRowState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Data.DataViewSetting
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Data.DataViewSettingCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Data.DBConcurrencyException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Data.DbType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Data.DeletedRowInaccessibleException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Data.DuplicateNameException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Data.EvaluateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Data.FillErrorEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Data.FillErrorEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.Data.ForeignKeyConstraint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.Data.IColumnMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.Data.IColumnMappingCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.Data.IDataAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.Data.IDataParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.Data.IDataParameterCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.Data.IDataReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Data.IDataRecord
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.Data.IDbCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.Data.IDbConnection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.Data.IDbDataAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.Data.IDbDataParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.Data.IDbTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.Data.InRowChangingEventException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.Data.InternalDataCollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.Data.InvalidConstraintException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.Data.InvalidExpressionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.Data.IsolationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.Data.ITableMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.Data.ITableMappingCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.Data.KeyRestrictionBehavior
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ forwarder System.Data.LoadOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000045*/ forwarder System.Data.MappingType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.Data.MergeFailedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.Data.MergeFailedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.Data.MissingMappingAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.Data.MissingPrimaryKeyException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.Data.MissingSchemaAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.Data.NoNullAllowedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.Data.ParameterDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.Data.PropertyCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.Data.ReadOnlyException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.Data.RowNotInTableException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.Data.Rule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.Data.SchemaSerializationMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.Data.SchemaType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.Data.SerializationFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.Data.SqlDbType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Data.StateChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ forwarder System.Data.StateChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000057*/ forwarder System.Data.StatementCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000058*/ forwarder System.Data.StatementCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.Data.StatementType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.Data.StrongTypingException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.Data.SyntaxErrorException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.Data.UniqueConstraint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.Data.UpdateRowSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.Data.UpdateStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.Data.VersionNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.Data.XmlReadMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.Data.XmlWriteMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.Data.Common.CatalogLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.Data.Common.DataAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.Data.Common.DataColumnMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.Data.Common.DataColumnMappingCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.Data.Common.DataTableMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.Data.Common.DataTableMappingCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.Data.Common.DbCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.Data.Common.DbCommandBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.Data.Common.DbConnection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.Data.Common.DbConnectionStringBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.Data.Common.DbDataAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.Data.Common.DbDataReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ forwarder System.Data.Common.DbDataRecord
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006F*/ forwarder System.Data.Common.DbDataSourceEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ forwarder System.Data.Common.DbEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000071*/ forwarder System.Data.Common.DbException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.Data.Common.DbMetaDataCollectionNames
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000073*/ forwarder System.Data.Common.DbMetaDataColumnNames
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000074*/ forwarder System.Data.Common.DbParameter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000075*/ forwarder System.Data.Common.DbParameterCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000076*/ forwarder System.Data.Common.DbProviderFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000077*/ forwarder System.Data.Common.DbProviderSpecificTypePropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000078*/ forwarder System.Data.Common.DbTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000079*/ forwarder System.Data.Common.GroupByBehavior
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007A*/ forwarder System.Data.Common.IdentifierCase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.Data.Common.RowUpdatedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007C*/ forwarder System.Data.Common.RowUpdatingEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007D*/ forwarder System.Data.Common.SchemaTableColumn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007E*/ forwarder System.Data.Common.SchemaTableOptionalColumn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007F*/ forwarder System.Data.Common.SupportedJoinOperators
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.Data.SqlTypes.INullable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000081*/ forwarder System.Data.SqlTypes.SqlAlreadyFilledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000082*/ forwarder System.Data.SqlTypes.SqlBinary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.Data.SqlTypes.SqlBoolean
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ forwarder System.Data.SqlTypes.SqlByte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000085*/ forwarder System.Data.SqlTypes.SqlBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000086*/ forwarder System.Data.SqlTypes.SqlChars
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ forwarder System.Data.SqlTypes.SqlCompareOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000088*/ forwarder System.Data.SqlTypes.SqlDateTime
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ forwarder System.Data.SqlTypes.SqlDecimal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008A*/ forwarder System.Data.SqlTypes.SqlDouble
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ forwarder System.Data.SqlTypes.SqlGuid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008C*/ forwarder System.Data.SqlTypes.SqlInt16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008D*/ forwarder System.Data.SqlTypes.SqlInt32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008E*/ forwarder System.Data.SqlTypes.SqlInt64
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008F*/ forwarder System.Data.SqlTypes.SqlMoney
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000090*/ forwarder System.Data.SqlTypes.SqlNotFilledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.Data.SqlTypes.SqlNullValueException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ forwarder System.Data.SqlTypes.SqlSingle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000093*/ forwarder System.Data.SqlTypes.SqlString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ forwarder System.Data.SqlTypes.SqlTruncateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000095*/ forwarder System.Data.SqlTypes.SqlTypeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.Data.SqlTypes.SqlXml
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.Data.SqlTypes.StorageState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Data.dll
+// MVID: {5ce0044b-0967-4037-a936-4017db72d64e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FBE00911000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Contracts.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Contracts.il
@@ -1,0 +1,375 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002aca
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001476d
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a78 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002940 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000ad0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000acc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002aba Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000870] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028c0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000240 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002ac Offset
+//              0x0000039c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000648 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000064c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000065c Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21736
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17647             (81.19%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2160               ( 9.94%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -831              (-3.82%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2160
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   15 (210 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   922 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.Contracts
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 43 6F 6E 74 72 61 63 74 73 00   // stics.Contracts.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 43 6F 6E 74 72 61 63 74 73 00   // stics.Contracts.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 43 6F 6E 74 72 61 63 74 73 00   // stics.Contracts.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.Contracts.Contract
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.Contracts.ContractAbbreviatorAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.Contracts.ContractArgumentValidatorAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Diagnostics.Contracts.ContractClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Diagnostics.Contracts.ContractClassForAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Diagnostics.Contracts.ContractFailedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Diagnostics.Contracts.ContractFailureKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Diagnostics.Contracts.ContractInvariantMethodAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Diagnostics.Contracts.ContractOptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Diagnostics.Contracts.ContractVerificationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Diagnostics.Contracts.PureAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.CompilerServices.ContractHelper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.Contracts.dll
+// MVID: {339ec646-1964-49ff-878d-0151f6a5311b}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F30E1457000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Debug.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Debug.il
@@ -1,0 +1,348 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029aa
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000109d3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002958 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000524] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002820 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009b0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000524 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009ac
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000299a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000750] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027a0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001ec Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000258 Offset
+//              0x000002d4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000052c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000530 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000540 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17603             (83.00%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1872               ( 8.83%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -1027             (-4.84%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1872
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    9 (126 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   722 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.Debug
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 44 65 62 75 67 00 00 )          // stics.Debug..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 44 65 62 75 67 00 00 )          // stics.Debug..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 44 65 62 75 67 00 00 )          // stics.Debug..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.Debug
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.Debugger
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.DebuggerBrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Diagnostics.DebuggerBrowsableState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Diagnostics.DebuggerDisplayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Diagnostics.DebuggerHiddenAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Diagnostics.DebuggerNonUserCodeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Diagnostics.DebuggerStepThroughAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Diagnostics.DebuggerTypeProxyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.Debug.dll
+// MVID: {b4854330-c8bc-47a0-af82-6b42d92b9484}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F32F03F6000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.FileVersionInfo.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.FileVersionInfo.il
@@ -1,0 +1,319 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000289a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000ff40
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002848 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000570] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003f00] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002710 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008a0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000570 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000089c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000288a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000640] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002690 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x00000228 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000410 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000414 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000424 Offset
+//              0x0000021c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21248
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17719             (83.39%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1600               ( 7.53%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.64%)
+// Unaccounted          : -831              (-3.91%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1600
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   549 bytes
+//   Blobs         -   540 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.FileVersionInfo
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 22 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // .."System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 46 69 6C 65 56 65 72 73 69 6F   // stics.FileVersio
+                                                                                                                                                              6E 49 6E 66 6F 00 00 )                            // nInfo..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 22 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // .."System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 46 69 6C 65 56 65 72 73 69 6F   // stics.FileVersio
+                                                                                                                                                                    6E 49 6E 66 6F 00 00 )                            // nInfo..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 22 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // .."System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 46 69 6C 65 56 65 72 73 69 6F   // stics.FileVersio
+                                                                                                                                                                     6E 49 6E 66 6F 00 00 )                            // nInfo..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.FileVersionInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.FileVersionInfo.dll
+// MVID: {1146036a-7a5a-4dd7-8278-5b7272400d55}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F9028F61000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Process.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Process.il
@@ -1,0 +1,364 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a2a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00014376
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029d8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028a0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a30 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a2c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a1a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007d0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002820 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000224 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000290 Offset
+//              0x00000318 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005a8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005ac Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005bc Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21728
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17623             (81.11%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2000               ( 9.20%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -655              (-3.01%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2000
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   13 (182 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   789 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.Process
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 50 72 6F 63 65 73 73 00 00 )    // stics.Process..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 50 72 6F 63 65 73 73 00 00 )    // stics.Process..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 50 72 6F 63 65 73 73 00 00 )    // stics.Process..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeProcessHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.DataReceivedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.DataReceivedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Diagnostics.Process
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Diagnostics.ProcessModule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Diagnostics.ProcessModuleCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Diagnostics.ProcessPriorityClass
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Diagnostics.ProcessStartInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Diagnostics.ProcessThread
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Diagnostics.ProcessThreadCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Diagnostics.ThreadPriorityLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Diagnostics.ThreadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Diagnostics.ThreadWaitReason
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.Process.dll
+// MVID: {db45004b-42dd-47e4-98c7-00bcb1cbb0c0}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6168B62000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.StackTrace.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.StackTrace.il
@@ -1,0 +1,327 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028c6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000d72c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002874 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000273c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008cc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008c8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028b6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000066c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026bc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x0000023c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000440 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000444 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000454 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1644               ( 7.75%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -827              (-3.90%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1644
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   571 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.StackTrace
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 53 74 61 63 6B 54 72 61 63 65   // stics.StackTrace
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 53 74 61 63 6B 54 72 61 63 65   // stics.StackTrace
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 53 74 61 63 6B 54 72 61 63 65   // stics.StackTrace
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:4:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.StackFrame
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.StackFrameExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.StackTrace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.StackTrace.dll
+// MVID: {e0eeb151-ccc4-4461-8fad-25eab06c4cd3}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FDA9349F000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.TextWriterTraceListener.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.TextWriterTraceListener.il
@@ -1,0 +1,323 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028d6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000147ad
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002884 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000005b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003f20] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000274c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008dc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000005b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008d8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028c6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000067c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026cc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000250 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000444 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000448 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000458 Offset
+//              0x00000224 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21280
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17815             (83.72%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1660               ( 7.80%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.62%)
+// Unaccounted          : -955              (-4.49%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1660
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   592 bytes
+//   Blobs         -   548 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.TextWriterTraceListener
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 2A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ..*System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 54 65 78 74 57 72 69 74 65 72   // stics.TextWriter
+                                                                                                                                                              54 72 61 63 65 4C 69 73 74 65 6E 65 72 00 00 )    // TraceListener..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 2A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ..*System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 54 65 78 74 57 72 69 74 65 72   // stics.TextWriter
+                                                                                                                                                                    54 72 61 63 65 4C 69 73 74 65 6E 65 72 00 00 )    // TraceListener..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 2A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ..*System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 54 65 78 74 57 72 69 74 65 72   // stics.TextWriter
+                                                                                                                                                                     54 72 61 63 65 4C 69 73 74 65 6E 65 72 00 00 )    // TraceListener..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.DelimitedListTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.TextWriterTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.TextWriterTraceListener.dll
+// MVID: {8a703e37-1a01-40bd-8944-be908bac4466}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FF361F78000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Tools.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Tools.il
@@ -1,0 +1,320 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028ee
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000143b0
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000289c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002764 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008f4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008f0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028de Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000694] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026e4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x0000027c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000470 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000474 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000484 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17599             (82.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1684               ( 7.94%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -835              (-3.94%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1684
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   633 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.Tools
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 54 6F 6F 6C 73 00 00 )          // stics.Tools..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 54 6F 6F 6C 73 00 00 )          // stics.Tools..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 18 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 54 6F 6F 6C 73 00 00 )          // stics.Tools..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.CodeDom.Compiler.GeneratedCodeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.Tools.dll
+// MVID: {9defba9f-3b85-4d6e-84a9-a91579cdeced}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FDD2BCC7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.TraceSource.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.TraceSource.il
@@ -1,0 +1,383 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a32
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000116ad
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029e0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028a8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a38 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a34
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a22 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007d8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002828 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000025c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002c8 Offset
+//              0x000002e4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005ac Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005b0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005c0 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21744
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17671             (81.27%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2008               ( 9.23%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -695              (-3.20%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2008
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   17 (238 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   740 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.TraceSource
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 54 72 61 63 65 53 6F 75 72 63   // stics.TraceSourc
+                                                                                                                                                              65 00 00 )                                        // e..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 54 72 61 63 65 53 6F 75 72 63   // stics.TraceSourc
+                                                                                                                                                                    65 00 00 )                                        // e..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 54 72 61 63 65 53 6F 75 72 63   // stics.TraceSourc
+                                                                                                                                                                     65 00 00 )                                        // e..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.BooleanSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.DefaultTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.EventTypeFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Diagnostics.SourceFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Diagnostics.SourceLevels
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Diagnostics.SourceSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Diagnostics.Switch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Diagnostics.Trace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Diagnostics.TraceEventCache
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Diagnostics.TraceEventType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Diagnostics.TraceFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Diagnostics.TraceLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Diagnostics.TraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Diagnostics.TraceListenerCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Diagnostics.TraceOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Diagnostics.TraceSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Diagnostics.TraceSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.TraceSource.dll
+// MVID: {e7a5ab3e-0e42-4733-8cb9-980314c0270a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FED5A294000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Tracing.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Diagnostics.Tracing.il
@@ -1,0 +1,416 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b76
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008a2a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b24 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000029ec [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b7c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b78
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b66 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000091c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000296c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002d8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000344 Offset
+//              0x000003b0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000006f4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000006f8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000708 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21728
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17623             (81.11%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2332               (10.73%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -987              (-4.54%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2332
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   26 (364 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   942 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Diagnostics.Tracing
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                              73 74 69 63 73 2E 54 72 61 63 69 6E 67 00 00 )    // stics.Tracing..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                    73 74 69 63 73 2E 54 72 61 63 69 6E 67 00 00 )    // stics.Tracing..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 44 69 61 67 6E 6F   // ...System.Diagno
+                                                                                                                                                                     73 74 69 63 73 2E 54 72 61 63 69 6E 67 00 00 )    // stics.Tracing..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Diagnostics.Tracing.EventActivityOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Diagnostics.Tracing.EventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Diagnostics.Tracing.EventChannel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Diagnostics.Tracing.EventCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Diagnostics.Tracing.EventCommandEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Diagnostics.Tracing.EventCounter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Diagnostics.Tracing.EventDataAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Diagnostics.Tracing.EventFieldAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Diagnostics.Tracing.EventFieldFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Diagnostics.Tracing.EventFieldTags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Diagnostics.Tracing.EventIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Diagnostics.Tracing.EventKeywords
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Diagnostics.Tracing.EventLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Diagnostics.Tracing.EventListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Diagnostics.Tracing.EventManifestOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Diagnostics.Tracing.EventOpcode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Diagnostics.Tracing.EventSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ EventData
+{
+  .class extern System.Diagnostics.Tracing.EventSource /*27000011*/ 
+}
+.class extern /*27000013*/ forwarder System.Diagnostics.Tracing.EventSourceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Diagnostics.Tracing.EventSourceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Diagnostics.Tracing.EventSourceOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Diagnostics.Tracing.EventSourceSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Diagnostics.Tracing.EventTags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Diagnostics.Tracing.EventTask
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Diagnostics.Tracing.EventWrittenEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Diagnostics.Tracing.NonEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Diagnostics.Tracing.dll
+// MVID: {29de44e5-bc33-48e6-ad16-ab632398f574}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F26D4725000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Drawing.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Drawing.Primitives.il
@@ -1,0 +1,336 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028fe
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00006e95
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028ac [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002774 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000904 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000900
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028ee Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006a4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026f4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001c0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000022c Offset
+//              0x00000250 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000047c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000480 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000490 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17599             (82.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1700               ( 8.02%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -851              (-4.01%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1700
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    6 (84 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   591 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Drawing.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 19 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                              67 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )       // g.Primitives..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 19 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                                    67 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )       // g.Primitives..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 19 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                                     67 2E 50 72 69 6D 69 74 69 76 65 73 00 00 )       // g.Primitives..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Drawing.Point
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Drawing.PointF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Drawing.Rectangle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Drawing.RectangleF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Drawing.Size
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Drawing.SizeF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Drawing.Primitives.dll
+// MVID: {3d1d3b1a-3235-4156-96a3-f0e9b4953393}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007EFE16A81000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Drawing.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Drawing.il
@@ -1,0 +1,340 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd3f
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028e2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000da2b
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002890 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002758 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008e8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008e4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028d2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000688] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026d8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001d0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000023c Offset
+//              0x00000230 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000046c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000470 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000480 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21168
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17479             (82.57%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1672               ( 7.90%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -743              (-3.51%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1672
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    7 (98 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   560 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Drawing
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                              67 00 00 )                                        // g..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                                    67 00 00 )                                        // g..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 44 72 61 77 69 6E   // ...System.Drawin
+                                                                                                                                                                     67 00 00 )                                        // g..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Drawing.Color
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Drawing.Point
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Drawing.PointF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Drawing.Rectangle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Drawing.RectangleF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Drawing.Size
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Drawing.SizeF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Drawing.dll
+// MVID: {d289099c-f808-4b8f-91d8-948d000e9900}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FE2865B3000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Dynamic.Runtime.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Dynamic.Runtime.il
@@ -1,0 +1,428 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002c1e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000e660
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002bcc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000514] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a94 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000c24 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000514 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c20
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c0e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000009c4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002a14 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000304 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000370 Offset
+//              0x00000430 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000007a0 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000007a4 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000007b4 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22224
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17579             (79.10%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2500               (11.25%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.22%)
+// Unaccounted          : -615              (-2.77%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2500
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   29 (406 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1072 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Dynamic.Runtime
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 44 79 6E 61 6D 69   // ...System.Dynami
+                                                                                                                                                              63 2E 52 75 6E 74 69 6D 65 00 00 )                // c.Runtime..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 44 79 6E 61 6D 69   // ...System.Dynami
+                                                                                                                                                                    63 2E 52 75 6E 74 69 6D 65 00 00 )                // c.Runtime..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 44 79 6E 61 6D 69   // ...System.Dynami
+                                                                                                                                                                     63 2E 52 75 6E 74 69 6D 65 00 00 )                // c.Runtime..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Dynamic.BinaryOperationBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Dynamic.BindingRestrictions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Dynamic.CallInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Dynamic.ConvertBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Dynamic.CreateInstanceBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Dynamic.DeleteIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Dynamic.DeleteMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Dynamic.DynamicMetaObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Dynamic.DynamicMetaObjectBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Dynamic.DynamicObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Dynamic.ExpandoObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Dynamic.GetIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Dynamic.GetMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Dynamic.IDynamicMetaObjectProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Dynamic.IInvokeOnGetBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Dynamic.InvokeBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Dynamic.InvokeMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Dynamic.SetIndexBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Dynamic.SetMemberBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Dynamic.UnaryOperationBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Linq.Expressions.DynamicExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Linq.Expressions.DynamicExpressionVisitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Runtime.CompilerServices.CallSite
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Runtime.CompilerServices.CallSiteBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Runtime.CompilerServices.CallSiteHelpers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Runtime.CompilerServices.CallSite`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Runtime.CompilerServices.ConditionalWeakTable`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ CreateValueCallback
+{
+  .class extern System.Runtime.CompilerServices.ConditionalWeakTable`2 /*2700001B*/ 
+}
+.class extern /*2700001D*/ forwarder System.Runtime.CompilerServices.DynamicAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Dynamic.Runtime.dll
+// MVID: {038b2e41-34eb-4019-84ee-93b85e07dc70}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F8A9D5BB000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.Calendars.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.Calendars.il
@@ -1,0 +1,379 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002aaa
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000d685
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a58 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002920 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000ab0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000aac
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a9a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000850] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028a0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000024c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002b8 Offset
+//              0x0000036c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000624 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000628 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000638 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21744
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17671             (81.27%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2128               ( 9.79%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -815              (-3.75%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2128
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   16 (224 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   874 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Globalization.Calendars
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                              69 7A 61 74 69 6F 6E 2E 43 61 6C 65 6E 64 61 72   // ization.Calendar
+                                                                                                                                                              73 00 00 )                                        // s..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                    69 7A 61 74 69 6F 6E 2E 43 61 6C 65 6E 64 61 72   // ization.Calendar
+                                                                                                                                                                    73 00 00 )                                        // s..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                     69 7A 61 74 69 6F 6E 2E 43 61 6C 65 6E 64 61 72   // ization.Calendar
+                                                                                                                                                                     73 00 00 )                                        // s..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Globalization.ChineseLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Globalization.EastAsianLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Globalization.GregorianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Globalization.GregorianCalendarTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Globalization.HebrewCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Globalization.HijriCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Globalization.JapaneseCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Globalization.JapaneseLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Globalization.JulianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Globalization.KoreanCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Globalization.KoreanLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Globalization.PersianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Globalization.TaiwanCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Globalization.TaiwanLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Globalization.ThaiBuddhistCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Globalization.UmAlQuraCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Globalization.Calendars.dll
+// MVID: {9653f674-9561-4b10-b5c6-0b918f503302}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB44FD23000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.Extensions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.Extensions.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000292a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000c07d
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028d8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027a0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000930 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000092c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000291a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006d0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002720 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x00000294 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004a4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004a8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004b8 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1744               ( 8.21%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -943              (-4.44%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1744
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   659 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Globalization.Extensions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                              69 7A 61 74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F   // ization.Extensio
+                                                                                                                                                              6E 73 00 00 )                                     // ns..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                    69 7A 61 74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F   // ization.Extensio
+                                                                                                                                                                    6E 73 00 00 )                                     // ns..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                     69 7A 61 74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F   // ization.Extensio
+                                                                                                                                                                     6E 73 00 00 )                                     // ns..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.StringNormalizationExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Globalization.GlobalizationExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Globalization.IdnMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Text.NormalizationForm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Globalization.Extensions.dll
+// MVID: {bf878c3b-f126-44d6-87a4-613ff47af455}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F941C447000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Globalization.il
@@ -1,0 +1,368 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029f2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00014950
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029a0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000504] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002868 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009f8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000504 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009f4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029e2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000798] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027e8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000230 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000029c Offset
+//              0x000002dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000578 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000057c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000058c Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17555             (82.84%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1944               ( 9.17%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -1067             (-5.03%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1944
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   14 (196 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   732 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Globalization
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 14 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                              69 7A 61 74 69 6F 6E 00 00 )                      // ization..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 14 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                    69 7A 61 74 69 6F 6E 00 00 )                      // ization..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 14 53 79 73 74 65 6D 2E 47 6C 6F 62 61 6C   // ...System.Global
+                                                                                                                                                                     69 7A 61 74 69 6F 6E 00 00 )                      // ization..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Globalization.Calendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Globalization.CalendarWeekRule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Globalization.CharUnicodeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Globalization.CompareInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Globalization.CompareOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Globalization.CultureInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Globalization.CultureNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Globalization.DateTimeFormatInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Globalization.NumberFormatInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Globalization.RegionInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Globalization.StringInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Globalization.TextElementEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Globalization.TextInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Globalization.UnicodeCategory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Globalization.dll
+// MVID: {e7c63b1f-9689-48c1-958f-270053fde748}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F21D085B000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.FileSystem.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.FileSystem.il
@@ -1,0 +1,314 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002836
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00010335
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000027e4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000026ac [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000083c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000838
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002826 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000005dc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000262c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x0000024c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000440 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000444 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000454 Offset
+//              0x00000188 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21240
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17695             (83.31%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1500               ( 7.06%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.64%)
+// Unaccounted          : -715              (-3.37%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1500
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   586 bytes
+//   Blobs         -   392 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.Compression.FileSystem
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 20 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // .. System.IO.Com
+                                                                                                                                                              70 72 65 73 73 69 6F 6E 2E 46 69 6C 65 53 79 73   // pression.FileSys
+                                                                                                                                                              74 65 6D 00 00 )                                  // tem..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 20 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // .. System.IO.Com
+                                                                                                                                                                    70 72 65 73 73 69 6F 6E 2E 46 69 6C 65 53 79 73   // pression.FileSys
+                                                                                                                                                                    74 65 6D 00 00 )                                  // tem..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 20 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // .. System.IO.Com
+                                                                                                                                                                     70 72 65 73 73 69 6F 6E 2E 46 69 6C 65 53 79 73   // pression.FileSys
+                                                                                                                                                                     74 65 6D 00 00 )                                  // tem..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.IO.Compression.ZipFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.Compression.ZipFileExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.Compression.FileSystem.dll
+// MVID: {96965787-da75-4656-97d4-202e565bb2c8}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F72F44CF000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.ZipFile.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.ZipFile.il
@@ -1,0 +1,314 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000282a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000eb27
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000027d8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000026a0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000830 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000082c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000281a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000005d0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002620 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000244 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000438 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000043c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000044c Offset
+//              0x00000184 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1488               ( 7.01%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -671              (-3.16%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1488
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   579 bytes
+//   Blobs         -   388 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.Compression.ZipFile
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                              70 72 65 73 73 69 6F 6E 2E 5A 69 70 46 69 6C 65   // pression.ZipFile
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                                    70 72 65 73 73 69 6F 6E 2E 5A 69 70 46 69 6C 65   // pression.ZipFile
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                                     70 72 65 73 73 69 6F 6E 2E 5A 69 70 46 69 6C 65   // pression.ZipFile
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.IO.Compression.ZipFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.Compression.ZipFileExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.Compression.ZipFile.dll
+// MVID: {278a255a-6c2a-4268-acb4-8b5b66947ea5}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F5D20870000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Compression.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002896
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000e596
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002844 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000270c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000089c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000898
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002886 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000063c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000268c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001d0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000023c Offset
+//              0x00000270 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004ac Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004b0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004c0 Offset
+//              0x0000017c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1596               ( 7.53%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -715              (-3.37%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1596
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    7 (98 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   623 bytes
+//   Blobs         -   380 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.Compression
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 15 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                              70 72 65 73 73 69 6F 6E 00 00 )                   // pression..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 15 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                                    70 72 65 73 73 69 6F 6E 00 00 )                   // pression..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 15 53 79 73 74 65 6D 2E 49 4F 2E 43 6F 6D   // ...System.IO.Com
+                                                                                                                                                                     70 72 65 73 73 69 6F 6E 00 00 )                   // pression..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:1:3:0
+}
+.class extern /*27000001*/ forwarder System.IO.Compression.CompressionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.Compression.CompressionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.Compression.DeflateStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.Compression.GZipStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.Compression.ZipArchive
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.Compression.ZipArchiveEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.Compression.ZipArchiveMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.Compression.dll
+// MVID: {071dc4a4-6019-4032-9c6b-b2444049b713}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F7B8D109000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.DriveInfo.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.DriveInfo.il
@@ -1,0 +1,327 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028d2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001188f
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002880 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002748 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008d8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008d4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028c2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000678] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026c8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x00000248 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000044c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000450 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000460 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1656               ( 7.80%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -855              (-4.03%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1656
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   584 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.FileSystem.DriveInfo
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                              65 53 79 73 74 65 6D 2E 44 72 69 76 65 49 6E 66   // eSystem.DriveInf
+                                                                                                                                                              6F 00 00 )                                        // o..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                    65 53 79 73 74 65 6D 2E 44 72 69 76 65 49 6E 66   // eSystem.DriveInf
+                                                                                                                                                                    6F 00 00 )                                        // o..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                     65 53 79 73 74 65 6D 2E 44 72 69 76 65 49 6E 66   // eSystem.DriveInf
+                                                                                                                                                                     6F 00 00 )                                        // o..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.IO.DriveInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.DriveNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.DriveType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.FileSystem.DriveInfo.dll
+// MVID: {4fcc1b49-de89-4f47-8e19-8de7f97291c8}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FC828E48000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.Primitives.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028ee
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000b7c5
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000289c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002764 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008f4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008f0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028de Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000694] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026e4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x00000258 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000468 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000046c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000047c Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1684               ( 7.93%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -883              (-4.16%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1684
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   598 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.FileSystem.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                              65 53 79 73 74 65 6D 2E 50 72 69 6D 69 74 69 76   // eSystem.Primitiv
+                                                                                                                                                              65 73 00 00 )                                     // es..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                    65 53 79 73 74 65 6D 2E 50 72 69 6D 69 74 69 76   // eSystem.Primitiv
+                                                                                                                                                                    65 73 00 00 )                                     // es..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                     65 53 79 73 74 65 6D 2E 50 72 69 6D 69 74 69 76   // eSystem.Primitiv
+                                                                                                                                                                     65 73 00 00 )                                     // es..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.IO.FileAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.FileAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.FileMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.FileShare
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.FileSystem.Primitives.dll
+// MVID: {00584fb3-5fd6-479f-a0de-f5d2f1d295a5}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD77AE89000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.Watcher.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.Watcher.il
@@ -1,0 +1,355 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029c2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000dc8a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002970 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002838 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009c8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009c4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029b2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000768] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027b8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001f8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000264 Offset
+//              0x000002dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000540 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000544 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000554 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1896               ( 8.93%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1079             (-5.08%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1896
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   10 (140 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   732 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.FileSystem.Watcher
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                              65 53 79 73 74 65 6D 2E 57 61 74 63 68 65 72 00   // eSystem.Watcher.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                    65 53 79 73 74 65 6D 2E 57 61 74 63 68 65 72 00   // eSystem.Watcher.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                     65 53 79 73 74 65 6D 2E 57 61 74 63 68 65 72 00   // eSystem.Watcher.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.IO.ErrorEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.ErrorEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.FileSystemEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.FileSystemEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.FileSystemWatcher
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.NotifyFilters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.RenamedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.IO.RenamedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.IO.WaitForChangedResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.IO.WatcherChangeTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.FileSystem.Watcher.dll
+// MVID: {26008d29-deee-413e-86c4-3976883aaefd}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F040B0DC000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.FileSystem.il
@@ -1,0 +1,348 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002962
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000b0cb
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002910 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027d8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000968 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000964
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002952 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000708] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002758 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001ec Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000258 Offset
+//              0x00000290 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004e8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004ec Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004fc Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1800               ( 8.49%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -919              (-4.34%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1800
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    9 (126 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   656 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.FileSystem
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 14 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                              65 53 79 73 74 65 6D 00 00 )                      // eSystem..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 14 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                    65 53 79 73 74 65 6D 00 00 )                      // eSystem..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 14 53 79 73 74 65 6D 2E 49 4F 2E 46 69 6C   // ...System.IO.Fil
+                                                                                                                                                                     65 53 79 73 74 65 6D 00 00 )                      // eSystem..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeFileHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.Directory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.DirectoryInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.File
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.FileInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.FileOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.FileStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.IO.FileSystemInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.IO.SearchOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.FileSystem.dll
+// MVID: {0bb0870c-2519-4d1a-8284-167678a83ac4}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F7AE7B5F000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.IsolatedStorage.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.IsolatedStorage.il
@@ -1,0 +1,324 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028e2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000091af
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002890 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002758 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008e8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008e4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028d2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000688] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026d8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x0000025c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000460 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000464 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000474 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17599             (82.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1672               ( 7.88%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -823              (-3.88%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1672
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   602 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.IsolatedStorage
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 19 53 79 73 74 65 6D 2E 49 4F 2E 49 73 6F   // ...System.IO.Iso
+                                                                                                                                                              6C 61 74 65 64 53 74 6F 72 61 67 65 00 00 )       // latedStorage..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 19 53 79 73 74 65 6D 2E 49 4F 2E 49 73 6F   // ...System.IO.Iso
+                                                                                                                                                                    6C 61 74 65 64 53 74 6F 72 61 67 65 00 00 )       // latedStorage..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 19 53 79 73 74 65 6D 2E 49 4F 2E 49 73 6F   // ...System.IO.Iso
+                                                                                                                                                                     6C 61 74 65 64 53 74 6F 72 61 67 65 00 00 )       // latedStorage..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.IO.IsolatedStorage.IsolatedStorageException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.IsolatedStorage.IsolatedStorageFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.IsolatedStorage.IsolatedStorageFileStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.IsolatedStorage.dll
+// MVID: {50570754-c1cf-4749-83bb-7ae125e226c1}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FF755AD5000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.MemoryMappedFiles.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.MemoryMappedFiles.il
@@ -1,0 +1,344 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029ba
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00009021
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002968 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002830 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009c0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009bc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029aa Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000760] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027b0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001dc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000248 Offset
+//              0x000002f0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000538 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000053c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000054c Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17623             (83.06%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1888               ( 8.90%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1055             (-4.97%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1888
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    8 (112 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   752 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.MemoryMappedFiles
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 49 4F 2E 4D 65 6D   // ...System.IO.Mem
+                                                                                                                                                              6F 72 79 4D 61 70 70 65 64 46 69 6C 65 73 00 00 ) // oryMappedFiles..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 49 4F 2E 4D 65 6D   // ...System.IO.Mem
+                                                                                                                                                                    6F 72 79 4D 61 70 70 65 64 46 69 6C 65 73 00 00 ) // oryMappedFiles..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 49 4F 2E 4D 65 6D   // ...System.IO.Mem
+                                                                                                                                                                     6F 72 79 4D 61 70 70 65 64 46 69 6C 65 73 00 00 ) // oryMappedFiles..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeMemoryMappedFileHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder Microsoft.Win32.SafeHandles.SafeMemoryMappedViewHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedFileRights
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedViewAccessor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.IO.MemoryMappedFiles.MemoryMappedViewStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.MemoryMappedFiles.dll
+// MVID: {bc506b14-ba1b-4e49-a8eb-4150524508ff}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FC78F62C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Pipes.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.Pipes.il
@@ -1,0 +1,348 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002992
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000eb50
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002940 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002808 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000998 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000994
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002982 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000738] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002788 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001ec Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000258 Offset
+//              0x000002c4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000051c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000520 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000530 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21168
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17479             (82.57%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1848               ( 8.73%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -919              (-4.34%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1848
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    9 (126 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   708 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.Pipes
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 49 4F 2E 50 69 70   // ...System.IO.Pip
+                                                                                                                                                              65 73 00 00 )                                     // es..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 49 4F 2E 50 69 70   // ...System.IO.Pip
+                                                                                                                                                                    65 73 00 00 )                                     // es..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 49 4F 2E 50 69 70   // ...System.IO.Pip
+                                                                                                                                                                     65 73 00 00 )                                     // es..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafePipeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.Pipes.AnonymousPipeClientStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.Pipes.AnonymousPipeServerStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.Pipes.NamedPipeClientStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.Pipes.NamedPipeServerStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.Pipes.PipeDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.Pipes.PipeOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.IO.Pipes.PipeStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.IO.Pipes.PipeTransmissionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.Pipes.dll
+// MVID: {b2c87b96-3a64-4e79-9884-0949862921a2}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F63048B4000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.UnmanagedMemoryStream.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.UnmanagedMemoryStream.il
@@ -1,0 +1,323 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028be
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00005731
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000286c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002734 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008c4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008c0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028ae Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000664] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026b4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000244 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000438 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000043c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000044c Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1636               ( 7.71%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -835              (-3.93%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1636
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   577 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO.UnmanagedMemoryStream
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 55 6E 6D   // ...System.IO.Unm
+                                                                                                                                                              61 6E 61 67 65 64 4D 65 6D 6F 72 79 53 74 72 65   // anagedMemoryStre
+                                                                                                                                                              61 6D 00 00 )                                     // am..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 55 6E 6D   // ...System.IO.Unm
+                                                                                                                                                                    61 6E 61 67 65 64 4D 65 6D 6F 72 79 53 74 72 65   // anagedMemoryStre
+                                                                                                                                                                    61 6D 00 00 )                                     // am..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 49 4F 2E 55 6E 6D   // ...System.IO.Unm
+                                                                                                                                                                     61 6E 61 67 65 64 4D 65 6D 6F 72 79 53 74 72 65   // anagedMemoryStre
+                                                                                                                                                                     61 6D 00 00 )                                     // am..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.IO.UnmanagedMemoryAccessor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.UnmanagedMemoryStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.UnmanagedMemoryStream.dll
+// MVID: {20e2ec0f-420e-4964-a48f-48a8d4076448}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FECCCAA7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.IO.il
@@ -1,0 +1,373 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029f6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000eb41
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029a4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004a0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003e98] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000286c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009fc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004a0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009f8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029e6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000079c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027ec [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000024c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002b8 Offset
+//              0x000002cc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000584 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000588 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000598 Offset
+//              0x00000204 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21144
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17407             (82.33%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1948               ( 9.21%)
+// CLR additional info : 128                ( 0.61%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.69%)
+// Unaccounted          : -971              (-4.59%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1948
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   16 (224 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   714 bytes
+//   Blobs         -   516 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.IO
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 09 53 79 73 74 65 6D 2E 49 4F 00 00 )       // ...System.IO..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 09 53 79 73 74 65 6D 2E 49 4F 00 00 )       // ...System.IO..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 09 53 79 73 74 65 6D 2E 49 4F 00 00 )       // ...System.IO..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.IO.BinaryReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.BinaryWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.IO.BufferedStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.IO.EndOfStreamException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.IO.FileNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.IO.InvalidDataException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.IO.IOException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.IO.MemoryStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.IO.SeekOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.IO.Stream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.IO.StreamReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.IO.StreamWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.IO.StringReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.IO.StringWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.IO.TextReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.IO.TextWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.IO.dll
+// MVID: {5dd7f36e-8674-41d9-9238-d7cba1887489}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F3A09EBC000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Expressions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Expressions.il
@@ -1,0 +1,496 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002dda
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000f397
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002d88 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002c50 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000de0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ddc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002dca Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000b80] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002bd0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000003f0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000045c Offset
+//              0x00000500 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000095c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000960 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000970 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22224
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17575             (79.08%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2944               (13.25%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.22%)
+// Unaccounted          : -1055             (-4.75%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2944
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   46 (644 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1277 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Linq.Expressions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 45   // ...System.Linq.E
+                                                                                                                                                              78 70 72 65 73 73 69 6F 6E 73 00 00 )             // xpressions..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 45   // ...System.Linq.E
+                                                                                                                                                                    78 70 72 65 73 73 69 6F 6E 73 00 00 )             // xpressions..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 45   // ...System.Linq.E
+                                                                                                                                                                     78 70 72 65 73 73 69 6F 6E 73 00 00 )             // xpressions..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Linq.IOrderedQueryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Linq.IOrderedQueryable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Linq.IQueryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Linq.IQueryable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Linq.IQueryProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Linq.Expressions.BinaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Linq.Expressions.BlockExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Linq.Expressions.CatchBlock
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Linq.Expressions.ConditionalExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Linq.Expressions.ConstantExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Linq.Expressions.DebugInfoExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Linq.Expressions.DefaultExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Linq.Expressions.ElementInit
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Linq.Expressions.Expression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Linq.Expressions.ExpressionType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Linq.Expressions.ExpressionVisitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Linq.Expressions.Expression`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Linq.Expressions.GotoExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Linq.Expressions.GotoExpressionKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Linq.Expressions.IArgumentProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Linq.Expressions.IDynamicExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Linq.Expressions.IndexExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Linq.Expressions.InvocationExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Linq.Expressions.LabelExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Linq.Expressions.LabelTarget
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Linq.Expressions.LambdaExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Linq.Expressions.ListInitExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Linq.Expressions.LoopExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Linq.Expressions.MemberAssignment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Linq.Expressions.MemberBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Linq.Expressions.MemberBindingType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Linq.Expressions.MemberExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Linq.Expressions.MemberInitExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Linq.Expressions.MemberListBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Linq.Expressions.MemberMemberBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Linq.Expressions.MethodCallExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Linq.Expressions.NewArrayExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Linq.Expressions.NewExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Linq.Expressions.ParameterExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Linq.Expressions.RuntimeVariablesExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Linq.Expressions.SwitchCase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Linq.Expressions.SwitchExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Linq.Expressions.SymbolDocumentInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Linq.Expressions.TryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Linq.Expressions.TypeBinaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Linq.Expressions.UnaryExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Linq.Expressions.dll
+// MVID: {e3967481-304e-48fc-a5d6-15701feed836}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FA31C0B7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Parallel.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Parallel.il
@@ -1,0 +1,336 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000291e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000f453
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028cc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002794 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000924 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000920
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000290e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006c4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002714 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001c0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000022c Offset
+//              0x00000278 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004a4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004a8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004b8 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1732               ( 8.17%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -851              (-4.02%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1732
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    6 (84 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   632 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Linq.Parallel
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 14 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 50   // ...System.Linq.P
+                                                                                                                                                              61 72 61 6C 6C 65 6C 00 00 )                      // arallel..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 14 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 50   // ...System.Linq.P
+                                                                                                                                                                    61 72 61 6C 6C 65 6C 00 00 )                      // arallel..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 14 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 50   // ...System.Linq.P
+                                                                                                                                                                     61 72 61 6C 6C 65 6C 00 00 )                      // arallel..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Linq.OrderedParallelQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Linq.ParallelEnumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Linq.ParallelExecutionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Linq.ParallelMergeOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Linq.ParallelQuery
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Linq.ParallelQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Linq.Parallel.dll
+// MVID: {a7a6b36f-f6b3-48d0-9b49-0c5e35920484}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F80C0542000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Queryable.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.Queryable.il
@@ -1,0 +1,332 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002902
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001468e
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028b0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002778 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000908 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000904
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028f2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006a8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026f8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x00000264 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000484 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000488 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000498 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1704               ( 8.04%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -823              (-3.88%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1704
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   609 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Linq.Queryable
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 51   // ...System.Linq.Q
+                                                                                                                                                              75 65 72 79 61 62 6C 65 00 00 )                   // ueryable..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 51   // ...System.Linq.Q
+                                                                                                                                                                    75 65 72 79 61 62 6C 65 00 00 )                   // ueryable..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4C 69 6E 71 2E 51   // ...System.Linq.Q
+                                                                                                                                                                     75 65 72 79 61 62 6C 65 00 00 )                   // ueryable..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Linq.EnumerableExecutor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Linq.EnumerableExecutor`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Linq.EnumerableQuery
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Linq.EnumerableQuery`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Linq.Queryable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Linq.Queryable.dll
+// MVID: {87780008-d768-4812-8951-a1ad598d0b90}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FDAD5167000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Linq.il
@@ -1,0 +1,329 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028c2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000817e
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002870 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ea0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002738 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008c8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008c4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028b2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000668] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026b8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x00000230 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000450 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000454 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000464 Offset
+//              0x00000204 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21152
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17431             (82.41%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1640               ( 7.75%)
+// CLR additional info : 128                ( 0.61%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.68%)
+// Unaccounted          : -679              (-3.21%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1640
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   557 bytes
+//   Blobs         -   516 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Linq
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 4C 69 6E 71 00 00 ) // ...System.Linq..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 4C 69 6E 71 00 00 ) // ...System.Linq..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0B 53 79 73 74 65 6D 2E 4C 69 6E 71 00 00 ) // ...System.Linq..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Linq.Enumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Linq.IGrouping`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Linq.ILookup`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Linq.IOrderedEnumerable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Linq.Lookup`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Linq.dll
+// MVID: {8f8a735a-009a-4d52-80a2-b055841c8a85}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F16DBA34000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Http.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Http.il
@@ -1,0 +1,488 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001000
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002e66
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00010ed0
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002e14 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001a00 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002cdc [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000e6c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001000 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000e68
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002e56 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000c0c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002c5c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000003d4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000440 Offset
+//              0x000005b0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000009f0 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000009f4 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000a04 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22704
+// PE header size       : 512 (496 used)    ( 2.26%)
+// PE additional info   : 17479             (76.99%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 3084               (13.58%)
+// CLR additional info : 128                ( 0.56%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.02%)
+// Unaccounted          : -619              (-2.73%)
+
+// Num.of PE sections   : 3
+//   .text    - 4096
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 3084
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   44 (616 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1455 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Http
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 48 74   // ...System.Net.Ht
+                                                                                                                                                              74 70 00 00 )                                     // tp..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 48 74   // ...System.Net.Ht
+                                                                                                                                                                    74 70 00 00 )                                     // tp..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 48 74   // ...System.Net.Ht
+                                                                                                                                                                     74 70 00 00 )                                     // tp..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.Http.ByteArrayContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.Http.ClientCertificateOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.Http.DelegatingHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.Http.FormUrlEncodedContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.Http.HttpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.Http.HttpClientHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.Http.HttpCompletionOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.Http.HttpContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.Http.HttpMessageHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.Http.HttpMessageInvoker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Net.Http.HttpMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Net.Http.HttpRequestException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Net.Http.HttpRequestMessage
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.Http.HttpResponseMessage
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Net.Http.MessageProcessingHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Net.Http.MultipartContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Net.Http.MultipartFormDataContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Net.Http.StreamContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Net.Http.StringContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Net.Http.Headers.AuthenticationHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Net.Http.Headers.CacheControlHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Net.Http.Headers.ContentDispositionHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Net.Http.Headers.ContentRangeHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Net.Http.Headers.EntityTagHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Net.Http.Headers.HttpContentHeaders
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Net.Http.Headers.HttpHeaders
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Net.Http.Headers.HttpHeaderValueCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Net.Http.Headers.HttpRequestHeaders
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Net.Http.Headers.HttpResponseHeaders
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Net.Http.Headers.MediaTypeHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Net.Http.Headers.MediaTypeWithQualityHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Net.Http.Headers.NameValueHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Net.Http.Headers.NameValueWithParametersHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Net.Http.Headers.ProductHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Net.Http.Headers.ProductInfoHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Net.Http.Headers.RangeConditionHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Net.Http.Headers.RangeHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Net.Http.Headers.RangeItemHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Net.Http.Headers.RetryConditionHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Net.Http.Headers.StringWithQualityHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Net.Http.Headers.TransferCodingHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Net.Http.Headers.TransferCodingWithQualityHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Net.Http.Headers.ViaHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Net.Http.Headers.WarningHeaderValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Http.dll
+// MVID: {a5718103-68a0-4ed1-ab84-76d3d2b8007e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F94FA0D7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.NameResolution.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.NameResolution.il
@@ -1,0 +1,320 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028a6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000be66
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002854 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000271c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008ac Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008a8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002896 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000064c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000269c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000230 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000424 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000428 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000438 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17599             (82.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1612               ( 7.60%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -763              (-3.60%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1612
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   558 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.NameResolution
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 19 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 61   // ...System.Net.Na
+                                                                                                                                                              6D 65 52 65 73 6F 6C 75 74 69 6F 6E 00 00 )       // meResolution..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 19 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 61   // ...System.Net.Na
+                                                                                                                                                                    6D 65 52 65 73 6F 6C 75 74 69 6F 6E 00 00 )       // meResolution..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 19 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 61   // ...System.Net.Na
+                                                                                                                                                                     6D 65 52 65 73 6F 6C 75 74 69 6F 6E 00 00 )       // meResolution..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.Dns
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.IPHostEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.NameResolution.dll
+// MVID: {ddba9e04-38ff-4de0-aea7-29202abf2e20}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD1CA39B000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.NetworkInformation.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.NetworkInformation.il
@@ -1,0 +1,447 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002cfa
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000075b3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002ca8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002b70 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000d00 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000cfc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002cea Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000aa0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002af0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000033c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003a8 Offset
+//              0x000004cc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000874 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000878 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000888 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22248
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17647             (79.32%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2720               (12.23%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.21%)
+// Unaccounted          : -879              (-3.95%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2720
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   33 (462 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1225 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.NetworkInformation
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 65   // ...System.Net.Ne
+                                                                                                                                                              74 77 6F 72 6B 49 6E 66 6F 72 6D 61 74 69 6F 6E   // tworkInformation
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 65   // ...System.Net.Ne
+                                                                                                                                                                    74 77 6F 72 6B 49 6E 66 6F 72 6D 61 74 69 6F 6E   // tworkInformation
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1D 53 79 73 74 65 6D 2E 4E 65 74 2E 4E 65   // ...System.Net.Ne
+                                                                                                                                                                     74 77 6F 72 6B 49 6E 66 6F 72 6D 61 74 69 6F 6E   // tworkInformation
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.NetworkInformation.DuplicateAddressDetectionState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.NetworkInformation.GatewayIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.NetworkInformation.GatewayIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.NetworkInformation.IcmpV4Statistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.NetworkInformation.IcmpV6Statistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.NetworkInformation.IPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.NetworkInformation.IPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.NetworkInformation.IPGlobalProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.NetworkInformation.IPGlobalStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.NetworkInformation.IPInterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Net.NetworkInformation.IPInterfaceStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Net.NetworkInformation.IPv4InterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Net.NetworkInformation.IPv6InterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.NetworkInformation.MulticastIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Net.NetworkInformation.MulticastIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Net.NetworkInformation.NetBiosNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Net.NetworkInformation.NetworkAddressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Net.NetworkInformation.NetworkChange
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Net.NetworkInformation.NetworkInformationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Net.NetworkInformation.NetworkInterface
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Net.NetworkInformation.NetworkInterfaceComponent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Net.NetworkInformation.NetworkInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Net.NetworkInformation.OperationalStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Net.NetworkInformation.PhysicalAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Net.NetworkInformation.PrefixOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Net.NetworkInformation.ScopeLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Net.NetworkInformation.SuffixOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Net.NetworkInformation.TcpConnectionInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Net.NetworkInformation.TcpState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Net.NetworkInformation.TcpStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Net.NetworkInformation.UdpStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Net.NetworkInformation.UnicastIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Net.NetworkInformation.UnicastIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.NetworkInformation.dll
+// MVID: {458f386f-4d8c-4c47-84b2-ac726ab1c528}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F40F572D000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Ping.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Ping.il
@@ -1,0 +1,332 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028e2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000ef7c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002890 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002758 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008e8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008e4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028d2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000688] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026d8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x0000024c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000046c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000470 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000480 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21168
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17479             (82.57%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1672               ( 7.90%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -743              (-3.51%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1672
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   586 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Ping
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 50 69   // ...System.Net.Pi
+                                                                                                                                                              6E 67 00 00 )                                     // ng..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 50 69   // ...System.Net.Pi
+                                                                                                                                                                    6E 67 00 00 )                                     // ng..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 65 74 2E 50 69   // ...System.Net.Pi
+                                                                                                                                                                     6E 67 00 00 )                                     // ng..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.NetworkInformation.IPStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.NetworkInformation.Ping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.NetworkInformation.PingException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.NetworkInformation.PingOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.NetworkInformation.PingReply
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Ping.dll
+// MVID: {fb9e14bb-3a75-49ee-bfee-0decb1ae7e32}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F95BC971000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Primitives.il
@@ -1,0 +1,432 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002c72
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00006330
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002c20 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000504] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002ae8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000c78 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000504 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c74
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c62 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000a18] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002a68 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000310 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000037c Offset
+//              0x00000478 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000007f4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000007f8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000808 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22216
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17555             (79.02%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2584               (11.63%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.22%)
+// Unaccounted          : -683              (-3.07%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2584
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   30 (420 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1143 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 50 72   // ...System.Net.Pr
+                                                                                                                                                              69 6D 69 74 69 76 65 73 00 00 )                   // imitives..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 50 72   // ...System.Net.Pr
+                                                                                                                                                                    69 6D 69 74 69 76 65 73 00 00 )                   // imitives..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 50 72   // ...System.Net.Pr
+                                                                                                                                                                     69 6D 69 74 69 76 65 73 00 00 )                   // imitives..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Net.AuthenticationSchemes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.Cookie
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.CookieCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.CookieContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.CookieException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.CredentialCache
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.DecompressionMethods
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.DnsEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.EndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.HttpStatusCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Net.ICredentials
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Net.ICredentialsByHost
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Net.IPAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.IPEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Net.IWebProxy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Net.NetworkCredential
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Net.SocketAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Net.TransportContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Net.NetworkInformation.IPAddressCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Net.Security.AuthenticationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Net.Security.SslPolicyErrors
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Net.Sockets.AddressFamily
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Net.Sockets.SocketError
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Net.Sockets.SocketException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Security.Authentication.CipherAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Security.Authentication.ExchangeAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Security.Authentication.HashAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Security.Authentication.SslProtocols
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Security.Authentication.ExtendedProtection.ChannelBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Security.Authentication.ExtendedProtection.ChannelBindingKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Primitives.dll
+// MVID: {99e9fc14-5bc9-44a1-a07f-a2de71700c9a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F1685112000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Requests.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Requests.il
@@ -1,0 +1,352 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002982
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000b164
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002930 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f4] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027f8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000988 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f4 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000984
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002972 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000728] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002778 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001f8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000264 Offset
+//              0x000002a4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000508 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000050c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000051c Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21184
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17531             (82.76%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1832               ( 8.65%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -939              (-4.43%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1832
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   10 (140 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   676 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Requests
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 52 65   // ...System.Net.Re
+                                                                                                                                                              71 75 65 73 74 73 00 00 )                         // quests..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 52 65   // ...System.Net.Re
+                                                                                                                                                                    71 75 65 73 74 73 00 00 )                         // quests..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 52 65   // ...System.Net.Re
+                                                                                                                                                                     71 75 65 73 74 73 00 00 )                         // quests..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Net.HttpRequestHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.HttpWebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.HttpWebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.IWebRequestCreate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.ProtocolViolationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.WebException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.WebExceptionStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.WebHeaderCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.WebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.WebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Requests.dll
+// MVID: {387f3c79-544c-49d4-97e6-b8dcbb7be492}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FCCA2459000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Security.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Security.il
@@ -1,0 +1,364 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a7e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00007e58
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a2c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028f4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a84 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a80
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a6e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000824] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002874 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000224 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000290 Offset
+//              0x00000374 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000604 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000608 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000618 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17527             (80.78%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2084               ( 9.61%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -675              (-3.11%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2084
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   13 (182 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   884 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Security
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 53 65   // ...System.Net.Se
+                                                                                                                                                              63 75 72 69 74 79 00 00 )                         // curity..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 53 65   // ...System.Net.Se
+                                                                                                                                                                    63 75 72 69 74 79 00 00 )                         // curity..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 13 53 79 73 74 65 6D 2E 4E 65 74 2E 53 65   // ...System.Net.Se
+                                                                                                                                                                     63 75 72 69 74 79 00 00 )                         // curity..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.Security.AuthenticatedStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.Security.EncryptionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.Security.LocalCertificateSelectionCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.Security.NegotiateStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.Security.ProtectionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.Security.RemoteCertificateValidationCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.Security.SslStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Security.Authentication.AuthenticationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Security.Authentication.InvalidCredentialException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Security.Authentication.ExtendedProtection.PolicyEnforcement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Security.Authentication.ExtendedProtection.ProtectionScenario
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Security.Authentication.ExtendedProtection.ServiceNameCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Security.dll
+// MVID: {4c1ee1ae-de79-43e8-93d4-bbcf6bb6902e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB17F244000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Sockets.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.Sockets.il
@@ -1,0 +1,412 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b3e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00014549
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002aec [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000029b4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b44 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b40
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b2e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000008e4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002934 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002cc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000338 Offset
+//              0x0000038c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000006c4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000006c8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000006d8 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17527             (80.78%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2276               (10.49%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -867              (-4.00%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2276
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   25 (350 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   906 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.Sockets
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4E 65 74 2E 53 6F   // ...System.Net.So
+                                                                                                                                                              63 6B 65 74 73 00 00 )                            // ckets..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4E 65 74 2E 53 6F   // ...System.Net.So
+                                                                                                                                                                    63 6B 65 74 73 00 00 )                            // ckets..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4E 65 74 2E 53 6F   // ...System.Net.So
+                                                                                                                                                                     63 6B 65 74 73 00 00 )                            // ckets..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.Sockets.IOControlCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.Sockets.IPPacketInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.Sockets.IPProtectionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.Sockets.IPv6MulticastOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.Sockets.LingerOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.Sockets.MulticastOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.Sockets.NetworkStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.Sockets.ProtocolType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.Sockets.SelectMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.Sockets.SendPacketsElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Net.Sockets.Socket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Net.Sockets.SocketAsyncEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Net.Sockets.SocketAsyncOperation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.Sockets.SocketFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Net.Sockets.SocketOptionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Net.Sockets.SocketOptionName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Net.Sockets.SocketReceiveFromResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Net.Sockets.SocketReceiveMessageFromResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Net.Sockets.SocketShutdown
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Net.Sockets.SocketTaskExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Net.Sockets.SocketType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Net.Sockets.TcpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Net.Sockets.TcpListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Net.Sockets.UdpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Net.Sockets.UdpReceiveResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.Sockets.dll
+// MVID: {64b99d07-9537-44d4-b8fe-28de95477f4f}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FA79300C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebHeaderCollection.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebHeaderCollection.il
@@ -1,0 +1,327 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028da
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00009ff3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002888 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002750 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008e0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008dc
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028ca Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000680] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026d0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x00000250 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000454 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000458 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000468 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1664               ( 7.84%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -863              (-4.06%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1664
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   589 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.WebHeaderCollection
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                              62 48 65 61 64 65 72 43 6F 6C 6C 65 63 74 69 6F   // bHeaderCollectio
+                                                                                                                                                              6E 00 00 )                                        // n..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                    62 48 65 61 64 65 72 43 6F 6C 6C 65 63 74 69 6F   // bHeaderCollectio
+                                                                                                                                                                    6E 00 00 )                                        // n..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                     62 48 65 61 64 65 72 43 6F 6C 6C 65 63 74 69 6F   // bHeaderCollectio
+                                                                                                                                                                     6E 00 00 )                                        // n..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Net.HttpRequestHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.HttpResponseHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.WebHeaderCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.WebHeaderCollection.dll
+// MVID: {34fdbddf-f59b-4b3b-884a-610c34b2a63d}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD3B49FB000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebSockets.Client.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebSockets.Client.il
@@ -1,0 +1,323 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028ce
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008eac
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000287c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002744 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008d4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008d0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028be Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000674] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026c4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000258 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000044c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000450 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000460 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1652               ( 7.78%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -835              (-3.93%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1652
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   598 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.WebSockets.Client
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                              62 53 6F 63 6B 65 74 73 2E 43 6C 69 65 6E 74 00   // bSockets.Client.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                    62 53 6F 63 6B 65 74 73 2E 43 6C 69 65 6E 74 00   // bSockets.Client.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                     62 53 6F 63 6B 65 74 73 2E 43 6C 69 65 6E 74 00   // bSockets.Client.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.WebSockets.ClientWebSocket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.WebSockets.ClientWebSocketOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.WebSockets.Client.dll
+// MVID: {01db460d-6e35-4948-bed0-002d656bb65f}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F49DE3AA000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebSockets.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.WebSockets.il
@@ -1,0 +1,340 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002942
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000e49e
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028f0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000500] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027b8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000948 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000500 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000944
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002932 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006e8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002738 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001d0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000023c Offset
+//              0x00000288 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004c4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004c8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004d8 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17551             (82.82%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1768               ( 8.34%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -887              (-4.19%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1768
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    7 (98 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   647 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net.WebSockets
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                              62 53 6F 63 6B 65 74 73 00 00 )                   // bSockets..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                    62 53 6F 63 6B 65 74 73 00 00 )                   // bSockets..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 15 53 79 73 74 65 6D 2E 4E 65 74 2E 57 65   // ...System.Net.We
+                                                                                                                                                                     62 53 6F 63 6B 65 74 73 00 00 )                   // bSockets..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Net.WebSockets.WebSocket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.WebSockets.WebSocketCloseStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.WebSockets.WebSocketError
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.WebSockets.WebSocketException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.WebSockets.WebSocketMessageType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.WebSockets.WebSocketReceiveResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.WebSockets.WebSocketState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.WebSockets.dll
+// MVID: {8c9659fb-23e0-4c5d-8291-cc5adf207187}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6EDC217000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Net.il
@@ -1,0 +1,497 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001000
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002e7a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000dc9c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002e28 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001a00 [0x00003ea0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002cf0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000e80 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001000 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000e7c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002e6a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000c20] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002c70 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000400 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000046c Offset
+//              0x0000059c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000a08 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000a0c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000a1c Offset
+//              0x00000204 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22688
+// PE header size       : 512 (496 used)    ( 2.26%)
+// PE additional info   : 17431             (76.83%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 3104               (13.68%)
+// CLR additional info : 128                ( 0.56%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.03%)
+// Unaccounted          : -607              (-2.68%)
+
+// Num.of PE sections   : 3
+//   .text    - 4096
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 3104
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   47 (658 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1434 bytes
+//   Blobs         -   516 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Net
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 4E 65 74 00 00 )    // ...System.Net..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 4E 65 74 00 00 )    // ...System.Net..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 4E 65 74 00 00 )    // ...System.Net..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Net.Cookie
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Net.CookieCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Net.CookieContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Net.CookieException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Net.DnsEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Net.DownloadProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Net.DownloadProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Net.DownloadStringCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Net.DownloadStringCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Net.EndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Net.HttpRequestHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Net.HttpStatusCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Net.HttpWebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.HttpWebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Net.ICredentials
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Net.IPAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Net.IPEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Net.IWebRequestCreate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Net.NetworkCredential
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Net.OpenReadCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Net.OpenReadCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Net.OpenWriteCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Net.OpenWriteCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Net.ProtocolViolationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Net.SocketAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Net.UploadProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Net.UploadProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Net.UploadStringCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Net.UploadStringCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Net.WebClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Net.WebException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Net.WebExceptionStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Net.WebHeaderCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Net.WebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Net.WebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Net.NetworkInformation.NetworkAddressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Net.NetworkInformation.NetworkChange
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Net.NetworkInformation.NetworkInterface
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Net.Sockets.AddressFamily
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Net.Sockets.ProtocolType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Net.Sockets.Socket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Net.Sockets.SocketAsyncEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Net.Sockets.SocketAsyncOperation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Net.Sockets.SocketError
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Net.Sockets.SocketException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Net.Sockets.SocketShutdown
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.Net.Sockets.SocketType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Net.dll
+// MVID: {f9d3c250-d198-45ab-949d-5ae840c4b405}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FF8B6BC6000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Numerics.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Numerics.il
@@ -1,0 +1,311 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000800
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000027ee
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000072e7
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000279c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001200 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002664 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000007f4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000800 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000a00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000007f0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000027de Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000594] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000025e4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000214 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000408 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000040c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000041c Offset
+//              0x00000178 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 20656
+// PE header size       : 512 (496 used)    ( 2.48%)
+// PE additional info   : 17479             (84.62%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.35%)
+// CLR meta-data size  : 1428               ( 6.91%)
+// CLR additional info : 128                ( 0.62%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.91%)
+// Unaccounted          : -1011             (-4.89%)
+
+// Num.of PE sections   : 3
+//   .text    - 2048
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1428
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   530 bytes
+//   Blobs         -   376 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Numerics
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 75 6D 65 72 69   // ...System.Numeri
+                                                                                                                                                              63 73 00 00 )                                     // cs..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 75 6D 65 72 69   // ...System.Numeri
+                                                                                                                                                                    63 73 00 00 )                                     // cs..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 4E 75 6D 65 72 69   // ...System.Numeri
+                                                                                                                                                                     63 73 00 00 )                                     // cs..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Numerics.BigInteger
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Numerics.Complex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Numerics.dll
+// MVID: {b68ca547-6352-42c9-9c6b-07f97eeda5d1}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F0B9A96C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ObjectModel.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ObjectModel.il
@@ -1,0 +1,388 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b82
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00014cc4
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b30 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f4] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000029f8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b88 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f4 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b84
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b72 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000928] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002978 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000278 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002e4 Offset
+//              0x00000424 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000708 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000070c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000071c Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17531             (80.80%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2344               (10.80%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -939              (-4.33%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2344
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   19 (266 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1058 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ObjectModel
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4F 62 6A 65 63 74   // ...System.Object
+                                                                                                                                                              4D 6F 64 65 6C 00 00 )                            // Model..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4F 62 6A 65 63 74   // ...System.Object
+                                                                                                                                                                    4D 6F 64 65 6C 00 00 )                            // Model..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 12 53 79 73 74 65 6D 2E 4F 62 6A 65 63 74   // ...System.Object
+                                                                                                                                                                     4D 6F 64 65 6C 00 00 )                            // Model..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Collections.ObjectModel.KeyedCollection`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Collections.ObjectModel.ObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.ObjectModel.ReadOnlyDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ KeyCollection
+{
+  .class extern System.Collections.ObjectModel.ReadOnlyDictionary`2 /*27000003*/ 
+}
+.class extern /*27000005*/ ValueCollection
+{
+  .class extern System.Collections.ObjectModel.ReadOnlyDictionary`2 /*27000003*/ 
+}
+.class extern /*27000006*/ forwarder System.Collections.ObjectModel.ReadOnlyObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Collections.Specialized.INotifyCollectionChanged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Collections.Specialized.NotifyCollectionChangedAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.ComponentModel.DataErrorsChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.ComponentModel.INotifyDataErrorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.ComponentModel.INotifyPropertyChanged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.ComponentModel.INotifyPropertyChanging
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.ComponentModel.PropertyChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.ComponentModel.PropertyChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.ComponentModel.PropertyChangingEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.ComponentModel.PropertyChangingEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Windows.Input.ICommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ObjectModel.dll
+// MVID: {85231558-9fec-4863-ac86-9925af5a506e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F108BF83000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.Extensions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.Extensions.il
@@ -1,0 +1,327 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028e6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000abdd
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002894 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000275c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008ec Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008e8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028d6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000068c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026dc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x00000260 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000464 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000468 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000478 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21224
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17647             (83.15%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1676               ( 7.90%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -859              (-4.05%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1676
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   608 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Reflection.Extensions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                              74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F 6E 73 00   // tion.Extensions.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                    74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F 6E 73 00   // tion.Extensions.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                     74 69 6F 6E 2E 45 78 74 65 6E 73 69 6F 6E 73 00   // tion.Extensions.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Reflection.CustomAttributeExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Reflection.InterfaceMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Reflection.RuntimeReflectionExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Reflection.Extensions.dll
+// MVID: {f9707c34-df03-4262-9d63-0ddbcbf701de}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FE8CFA74000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.Primitives.il
@@ -1,0 +1,379 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a4e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00009f1b
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029fc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028c4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a54 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a50
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a3e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007f4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002844 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000024c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002b8 Offset
+//              0x00000314 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005cc Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005d0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005e0 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21736
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17647             (81.19%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2036               ( 9.37%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -707              (-3.25%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2036
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   16 (224 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   787 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Reflection.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                              74 69 6F 6E 2E 50 72 69 6D 69 74 69 76 65 73 00   // tion.Primitives.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                    74 69 6F 6E 2E 50 72 69 6D 69 74 69 76 65 73 00   // tion.Primitives.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                     74 69 6F 6E 2E 50 72 69 6D 69 74 69 76 65 73 00   // tion.Primitives.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Reflection.CallingConventions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Reflection.EventAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Reflection.FieldAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Reflection.GenericParameterAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Reflection.MethodAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Reflection.MethodImplAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Reflection.ParameterAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Reflection.PropertyAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Reflection.TypeAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Reflection.Emit.FlowControl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Reflection.Emit.OpCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Reflection.Emit.OpCodes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Reflection.Emit.OpCodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Reflection.Emit.OperandType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Reflection.Emit.PackingSize
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Reflection.Emit.StackBehaviour
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Reflection.Primitives.dll
+// MVID: {33f9cac9-b372-475b-8f9a-530b47c40465}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F560B4CA000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Reflection.il
@@ -1,0 +1,448 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002c72
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001345a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002c20 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004e0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003eb8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002ae8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000c78 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004e0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c74
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c62 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000a18] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002a68 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000348 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003b4 Offset
+//              0x00000444 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000007f8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000007fc Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000080c Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22200
+// PE header size       : 512 (496 used)    ( 2.31%)
+// PE additional info   : 17503             (78.84%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2584               (11.64%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.23%)
+// Unaccounted          : -647              (-2.91%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2584
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   34 (476 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1091 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Reflection
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 11 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                              74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 11 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                    74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 11 53 79 73 74 65 6D 2E 52 65 66 6C 65 63   // ...System.Reflec
+                                                                                                                                                                     74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Reflection.AmbiguousMatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Reflection.Assembly
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Reflection.AssemblyContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Reflection.AssemblyName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Reflection.BindingFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Reflection.ConstructorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Reflection.CustomAttributeData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Reflection.CustomAttributeNamedArgument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Reflection.CustomAttributeTypedArgument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Reflection.EventInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Reflection.FieldInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Reflection.ICustomAttributeProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Reflection.IntrospectionExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Reflection.InvalidFilterCriteriaException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Reflection.IReflectableType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Reflection.LocalVariableInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Reflection.ManifestResourceInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Reflection.MemberFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Reflection.MemberInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Reflection.MemberTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Reflection.MethodBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Reflection.MethodInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Reflection.Module
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Reflection.ParameterInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Reflection.ParameterModifier
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Reflection.PropertyInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Reflection.ReflectionContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Reflection.ReflectionTypeLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Reflection.ResourceLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Reflection.TargetException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Reflection.TargetInvocationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Reflection.TargetParameterCountException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Reflection.TypeFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Reflection.TypeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Reflection.dll
+// MVID: {5ef4e9b5-b3d2-4c6f-8db4-e7043d1f2e83}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F16DD28E000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.Reader.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.Reader.il
@@ -1,0 +1,316 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002896
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00007117
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002844 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000270c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000089c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000898
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002886 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000063c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000268c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x00000230 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000418 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000041c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000042c Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1596               ( 7.53%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -731              (-3.45%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1596
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   559 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Resources.Reader
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                              63 65 73 2E 52 65 61 64 65 72 00 00 )             // ces.Reader..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                                    63 65 73 2E 52 65 61 64 65 72 00 00 )             // ces.Reader..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                                     63 65 73 2E 52 65 61 64 65 72 00 00 )             // ces.Reader..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Resources.ResourceReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Resources.Reader.dll
+// MVID: {5db7d10d-f108-422e-81e3-3c05c29e154a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB62CC92000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.ResourceManager.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.ResourceManager.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000292e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000082b6
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028dc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027a4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000934 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000930
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000291e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006d4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002724 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x00000298 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004a8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004ac Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004bc Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17687             (83.30%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1748               ( 8.23%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -963              (-4.54%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1748
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   663 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Resources.ResourceManager
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // .. System.Resour
+                                                                                                                                                              63 65 73 2E 52 65 73 6F 75 72 63 65 4D 61 6E 61   // ces.ResourceMana
+                                                                                                                                                              67 65 72 00 00 )                                  // ger..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // .. System.Resour
+                                                                                                                                                                    63 65 73 2E 52 65 73 6F 75 72 63 65 4D 61 6E 61   // ces.ResourceMana
+                                                                                                                                                                    67 65 72 00 00 )                                  // ger..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // .. System.Resour
+                                                                                                                                                                     63 65 73 2E 52 65 73 6F 75 72 63 65 4D 61 6E 61   // ces.ResourceMana
+                                                                                                                                                                     67 65 72 00 00 )                                  // ger..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Resources.MissingManifestResourceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Resources.NeutralResourcesLanguageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Resources.ResourceManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Resources.SatelliteContractVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Resources.ResourceManager.dll
+// MVID: {eff30b81-f75d-4593-852d-72489b7707cd}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6CF2DA7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.Writer.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Resources.Writer.il
@@ -1,0 +1,316 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002896
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00010cf8
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002844 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000270c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000089c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000898
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002886 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000063c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000268c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x00000230 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000418 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000041c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000042c Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1596               ( 7.53%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -731              (-3.45%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1596
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   559 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Resources.Writer
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                              63 65 73 2E 57 72 69 74 65 72 00 00 )             // ces.Writer..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                                    63 65 73 2E 57 72 69 74 65 72 00 00 )             // ces.Writer..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 65 73 6F 75 72   // ...System.Resour
+                                                                                                                                                                     63 65 73 2E 57 72 69 74 65 72 00 00 )             // ces.Writer..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Resources.ResourceWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Resources.Writer.dll
+// MVID: {d4d1d43e-446e-4d72-b915-157359e47d39}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F2B67350000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.CompilerServices.VisualC.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.CompilerServices.VisualC.il
@@ -1,0 +1,375 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a6a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000152dd
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a18 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000590] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003f18] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028e0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a70 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000590 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a6c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a5a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000810] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002860 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000240 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002ac Offset
+//              0x00000330 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005dc Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005e0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005f0 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21784
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17775             (81.60%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2064               ( 9.47%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.40%)
+// Unaccounted          : -815              (-3.74%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2064
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   15 (210 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   816 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.CompilerServices.VisualC
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                              65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
+                                                                                                                                                              65 73 2E 56 69 73 75 61 6C 43 00 00 )             // es.VisualC..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                    65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
+                                                                                                                                                                    65 73 2E 56 69 73 75 61 6C 43 00 00 )             // es.VisualC..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                     65 2E 43 6F 6D 70 69 6C 65 72 53 65 72 76 69 63   // e.CompilerServic
+                                                                                                                                                                     65 73 2E 56 69 73 75 61 6C 43 00 00 )             // es.VisualC..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.CompilerServices.CallConvCdecl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.CompilerServices.CallConvFastcall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.CompilerServices.CallConvStdcall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.CompilerServices.CallConvThiscall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.CompilerServices.IsBoxed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.CompilerServices.IsByValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Runtime.CompilerServices.IsCopyConstructed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.CompilerServices.IsExplicitlyDereferenced
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Runtime.CompilerServices.IsImplicitlyDereferenced
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Runtime.CompilerServices.IsJitIntrinsic
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.CompilerServices.IsLong
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Runtime.CompilerServices.IsSignUnspecifiedByte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Runtime.CompilerServices.IsUdtReturn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Runtime.CompilerServices.NativeCppClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.CompilerServices.RequiredAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.CompilerServices.VisualC.dll
+// MVID: {c6d1999b-d8ba-4bf5-8d65-ef8c8cc38cef}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB3E7C81000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Extensions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Extensions.il
@@ -1,0 +1,372 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a1e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000599e
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029cc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002894 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a24 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a20
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a0e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007c4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002814 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000240 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002ac Offset
+//              0x000002f0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000059c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005a0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005b0 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21720
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17599             (81.03%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 1988               ( 9.15%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -627              (-2.89%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1988
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   15 (210 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   751 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Extensions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 19 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 2E 45 78 74 65 6E 73 69 6F 6E 73 00 00 )       // e.Extensions..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 19 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 2E 45 78 74 65 6E 73 69 6F 6E 73 00 00 )       // e.Extensions..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 19 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 2E 45 78 74 65 6E 73 69 6F 6E 73 00 00 )       // e.Extensions..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.BitConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Convert
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Environment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ SpecialFolder
+{
+  .class extern System.Environment /*27000003*/ 
+}
+.class extern /*27000005*/ SpecialFolderOption
+{
+  .class extern System.Environment /*27000003*/ 
+}
+.class extern /*27000006*/ forwarder System.Math
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.MidpointRounding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Progress`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Random
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.StringComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.UriBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Diagnostics.Stopwatch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.IO.Path
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Net.WebUtility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.Versioning.FrameworkName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Extensions.dll
+// MVID: {5344445c-bd07-48be-96bc-d20059d7d1d5}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FE507C90000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Handles.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Handles.il
@@ -1,0 +1,332 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002956
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000064b5
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002904 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027cc [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000095c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000958
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002946 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006fc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000274c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x000002b8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004d8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004dc Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004ec Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1788               ( 8.43%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -923              (-4.35%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1788
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   694 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Handles
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 2E 48 61 6E 64 6C 65 73 00 00 )                // e.Handles..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 2E 48 61 6E 64 6C 65 73 00 00 )                // e.Handles..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 2E 48 61 6E 64 6C 65 73 00 00 )                // e.Handles..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.IO.HandleInheritability
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.InteropServices.CriticalHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.InteropServices.SafeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Threading.WaitHandleExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Handles.dll
+// MVID: {7d713997-d822-4f49-8ca6-7ab8679f0058}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FBEC1BDE000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.InteropServices.RuntimeInformation.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.InteropServices.RuntimeInformation.il
@@ -1,0 +1,330 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000291a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000f9c8
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028c8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000005e0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003f40] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002790 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000920 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000005e0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000091c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000290a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006c0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002710 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x0000027c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000480 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000484 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000494 Offset
+//              0x0000022c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21312
+// PE header size       : 512 (496 used)    ( 2.40%)
+// PE additional info   : 17895             (83.97%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1728               ( 8.11%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.61%)
+// Unaccounted          : -1071             (-5.03%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1728
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   634 bytes
+//   Blobs         -   556 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.InteropServices.RuntimeInformation
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 31 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..1System.Runtim
+                                                                                                                                                              65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                              73 2E 52 75 6E 74 69 6D 65 49 6E 66 6F 72 6D 61   // s.RuntimeInforma
+                                                                                                                                                              74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 31 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..1System.Runtim
+                                                                                                                                                                    65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                                    73 2E 52 75 6E 74 69 6D 65 49 6E 66 6F 72 6D 61   // s.RuntimeInforma
+                                                                                                                                                                    74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 31 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..1System.Runtim
+                                                                                                                                                                     65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                                     73 2E 52 75 6E 74 69 6D 65 49 6E 66 6F 72 6D 61   // s.RuntimeInforma
+                                                                                                                                                                     74 69 6F 6E 00 00 )                               // tion..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.InteropServices.Architecture
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.InteropServices.OSPlatform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.InteropServices.RuntimeInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.InteropServices.RuntimeInformation.dll
+// MVID: {0a288c87-fb9e-4092-9d11-5b10fa5da60a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F49D66D6000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.InteropServices.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.InteropServices.il
@@ -1,0 +1,771 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001600
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00003572
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00006b83
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00003520 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00002000 [0x00003ee8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000033e8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00001578 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001600 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00003000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000574
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00003562 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00001318] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00003368 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000007a8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000814 Offset
+//              0x000008d8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000010ec Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000010f0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00001100 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 24296
+// PE header size       : 512 (496 used)    ( 2.11%)
+// PE additional info   : 17663             (72.70%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.30%)
+// CLR meta-data size  : 4888               (20.12%)
+// CLR additional info : 128                ( 0.53%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 8.43%)
+// Unaccounted          : -1015             (-4.18%)
+
+// Num.of PE sections   : 3
+//   .text    - 5632
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 4888
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -  114 (1596 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  2263 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.InteropServices
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                              73 00 00 )                                        // s..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                                    73 00 00 )                                        // s..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 2E 49 6E 74 65 72 6F 70 53 65 72 76 69 63 65   // e.InteropService
+                                                                                                                                                                     73 00 00 )                                        // s..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.DataMisalignedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.DllNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Reflection.Missing
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.InteropServices.ArrayWithOffset
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.InteropServices.BestFitMappingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.InteropServices.BStrWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Runtime.InteropServices.CallingConvention
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.InteropServices.ClassInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Runtime.InteropServices.ClassInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Runtime.InteropServices.CoClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.InteropServices.ComAwareEventInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Runtime.InteropServices.ComDefaultInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Runtime.InteropServices.ComEventInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Runtime.InteropServices.ComEventsHelper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.InteropServices.COMException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Runtime.InteropServices.ComImportAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Runtime.InteropServices.ComInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Runtime.InteropServices.ComMemberType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Runtime.InteropServices.ComSourceInterfacesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Runtime.InteropServices.CriticalHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Runtime.InteropServices.CurrencyWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Runtime.InteropServices.CustomQueryInterfaceMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Runtime.InteropServices.CustomQueryInterfaceResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Runtime.InteropServices.DefaultCharSetAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Runtime.InteropServices.DefaultParameterValueAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Runtime.InteropServices.DispatchWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Runtime.InteropServices.DispIdAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Runtime.InteropServices.DllImportAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Runtime.InteropServices.DllImportSearchPath
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Runtime.InteropServices.ErrorWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Runtime.InteropServices.GCHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Runtime.InteropServices.GCHandleType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Runtime.InteropServices.GuidAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Runtime.InteropServices.HandleCollector
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Runtime.InteropServices.ICustomAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Runtime.InteropServices.ICustomQueryInterface
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Runtime.InteropServices.InAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Runtime.InteropServices.InterfaceTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Runtime.InteropServices.InvalidComObjectException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Runtime.InteropServices.InvalidOleVariantTypeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Runtime.InteropServices.Marshal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Runtime.InteropServices.MarshalAsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Runtime.InteropServices.MarshalDirectiveException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Runtime.InteropServices.OptionalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Runtime.InteropServices.PreserveSigAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.Runtime.InteropServices.SafeArrayRankMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.Runtime.InteropServices.SafeArrayTypeMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.Runtime.InteropServices.SafeBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.Runtime.InteropServices.SafeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.Runtime.InteropServices.SEHException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.Runtime.InteropServices.TypeIdentifierAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.Runtime.InteropServices.UnknownWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.Runtime.InteropServices.UnmanagedType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.Runtime.InteropServices.VarEnum
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.Runtime.InteropServices.VariantWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.Runtime.InteropServices.ComTypes.ADVF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.Runtime.InteropServices.ComTypes.BINDPTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.Runtime.InteropServices.ComTypes.BIND_OPTS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.Runtime.InteropServices.ComTypes.CALLCONV
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.Runtime.InteropServices.ComTypes.CONNECTDATA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.Runtime.InteropServices.ComTypes.DATADIR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.Runtime.InteropServices.ComTypes.DESCKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.Runtime.InteropServices.ComTypes.DISPPARAMS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.Runtime.InteropServices.ComTypes.DVASPECT
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.Runtime.InteropServices.ComTypes.ELEMDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ DESCUNION
+{
+  .class extern System.Runtime.InteropServices.ComTypes.ELEMDESC /*27000043*/ 
+}
+.class extern /*27000045*/ forwarder System.Runtime.InteropServices.ComTypes.EXCEPINFO
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.Runtime.InteropServices.ComTypes.FILETIME
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.Runtime.InteropServices.ComTypes.FORMATETC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.Runtime.InteropServices.ComTypes.IAdviseSink
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.Runtime.InteropServices.ComTypes.IBindCtx
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.Runtime.InteropServices.ComTypes.IConnectionPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.Runtime.InteropServices.ComTypes.IConnectionPointContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.Runtime.InteropServices.ComTypes.IDLDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.Runtime.InteropServices.ComTypes.IDLFLAG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumConnections
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumFORMATETC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumMoniker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumVARIANT
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000057*/ forwarder System.Runtime.InteropServices.ComTypes.IMoniker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000058*/ forwarder System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.Runtime.InteropServices.ComTypes.INVOKEKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.Runtime.InteropServices.ComTypes.IPersistFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.Runtime.InteropServices.ComTypes.IRunningObjectTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.Runtime.InteropServices.ComTypes.IStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeComp
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeInfo2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeLib
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeLib2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.Runtime.InteropServices.ComTypes.LIBFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.Runtime.InteropServices.ComTypes.PARAMDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.Runtime.InteropServices.ComTypes.PARAMFLAG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.Runtime.InteropServices.ComTypes.STATDATA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.Runtime.InteropServices.ComTypes.STATSTG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.Runtime.InteropServices.ComTypes.STGMEDIUM
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.Runtime.InteropServices.ComTypes.SYSKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.Runtime.InteropServices.ComTypes.TYMED
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEATTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ forwarder System.Runtime.InteropServices.ComTypes.TYPELIBATTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006F*/ forwarder System.Runtime.InteropServices.ComTypes.VARDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ DESCUNION
+{
+  .class extern System.Runtime.InteropServices.ComTypes.VARDESC /*2700006F*/ 
+}
+.class extern /*27000071*/ forwarder System.Runtime.InteropServices.ComTypes.VARFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.Runtime.InteropServices.ComTypes.VARKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.InteropServices.dll
+// MVID: {ba56e0b3-854f-4f85-9e21-c5ef1a12c01e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F1FF3D3C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Numerics.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Numerics.il
@@ -1,0 +1,320 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028a6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00009796
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002854 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000271c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008ac Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008a8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002896 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000064c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000269c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000234 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000428 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000042c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000043c Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1612               ( 7.60%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -747              (-3.52%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1612
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   562 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Numerics
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 2E 4E 75 6D 65 72 69 63 73 00 00 )             // e.Numerics..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 2E 4E 75 6D 65 72 69 63 73 00 00 )             // e.Numerics..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 2E 4E 75 6D 65 72 69 63 73 00 00 )             // e.Numerics..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Numerics.BigInteger
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Numerics.Complex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Numerics.dll
+// MVID: {86b222c6-6eed-4295-8a91-852e486ddfcb}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F4215784000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Formatters.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Formatters.il
@@ -1,0 +1,347 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029ce
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000f2d6
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000297c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000590] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003f10] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002844 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009d4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000590 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009d0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029be Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000774] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027c4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001dc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000248 Offset
+//              0x000002f8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000540 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000544 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000554 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21264
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17767             (83.55%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1908               ( 8.97%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.63%)
+// Unaccounted          : -1171             (-5.51%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1908
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    8 (112 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   757 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Serialization.Formatters
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                              65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                              46 6F 72 6D 61 74 74 65 72 73 00 00 )             // Formatters..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                    65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                    46 6F 72 6D 61 74 74 65 72 73 00 00 )             // Formatters..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                     65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                     46 6F 72 6D 61 74 74 65 72 73 00 00 )             // Formatters..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.NonSerializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.SerializableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.IDeserializationCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.IFormatterConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.Serialization.ISerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.Serialization.SerializationEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Runtime.Serialization.SerializationInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.Serialization.SerializationInfoEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Serialization.Formatters.dll
+// MVID: {1b6438b7-2dd6-4a5f-a6c3-f1ff2b2a39d9}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FEA4E9C6000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Json.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Json.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000293e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00012390
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028ec [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027b4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000944 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000940
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000292e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006e4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002734 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x000002a4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004b4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004b8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004c8 Offset
+//              0x0000021c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21240
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17695             (83.31%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1764               ( 8.31%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.64%)
+// Unaccounted          : -979              (-4.61%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1764
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   673 bytes
+//   Blobs         -   540 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Serialization.Json
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 21 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..!System.Runtim
+                                                                                                                                                              65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                              4A 73 6F 6E 00 00 )                               // Json..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 21 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..!System.Runtim
+                                                                                                                                                                    65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                    4A 73 6F 6E 00 00 )                               // Json..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 21 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..!System.Runtim
+                                                                                                                                                                     65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                     4A 73 6F 6E 00 00 )                               // Json..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.Serialization.DateTimeFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.Serialization.EmitTypeInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.Json.DataContractJsonSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.Json.DataContractJsonSerializerSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Serialization.Json.dll
+// MVID: {0499056d-9ee7-45ca-a3ee-ac6080e85d8e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FCDA3EB1000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Primitives.il
@@ -1,0 +1,375 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002ac6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00005542
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a74 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000590] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003f10] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000293c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000acc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000590 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ac8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002ab6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000086c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028bc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000240 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002ac Offset
+//              0x0000038c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000638 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000063c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000064c Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21776
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17767             (81.59%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2156               ( 9.90%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.40%)
+// Unaccounted          : -907              (-4.17%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2156
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   15 (210 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   907 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Serialization.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                              65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                              50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                    65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                    50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 27 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ..'System.Runtim
+                                                                                                                                                                     65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                     50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:3:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.Serialization.CollectionDataContractAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.Serialization.ContractNamespaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.DataContractAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.DataMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.Serialization.EnumMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.Serialization.IgnoreDataMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Runtime.Serialization.InvalidDataContractException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.Serialization.ISerializationSurrogateProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Runtime.Serialization.KnownTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Runtime.Serialization.OnDeserializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.Serialization.OnDeserializingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Runtime.Serialization.OnSerializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Runtime.Serialization.OnSerializingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Runtime.Serialization.SerializationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.Serialization.StreamingContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Serialization.Primitives.dll
+// MVID: {b9c5e328-fc54-4151-b67e-138bc0997dec}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F2732361000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Xml.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.Xml.il
@@ -1,0 +1,383 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b0a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00010ecd
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002ab8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002980 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b10 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b0c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002afa Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000008b0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002900 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000025c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000002c8 Offset
+//              0x000003bc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000684 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000688 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000698 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21744
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17687             (81.34%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2224               (10.23%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.42%)
+// Unaccounted          : -927              (-4.26%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2224
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   17 (238 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   955 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Serialization.Xml
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // .. System.Runtim
+                                                                                                                                                              65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                              58 6D 6C 00 00 )                                  // Xml..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // .. System.Runtim
+                                                                                                                                                                    65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                    58 6D 6C 00 00 )                                  // Xml..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 20 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // .. System.Runtim
+                                                                                                                                                                     65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 2E   // e.Serialization.
+                                                                                                                                                                     58 6D 6C 00 00 )                                  // Xml..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:3:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.Serialization.DataContractResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.Serialization.DataContractSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.DataContractSerializerExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.DataContractSerializerSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.Serialization.InvalidDataContractException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.Serialization.XmlObjectSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.IXmlDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.OnXmlDictionaryReaderClose
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.UniqueId
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.XmlBinaryReaderSession
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.XmlBinaryWriterSession
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.XmlDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.XmlDictionaryReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.XmlDictionaryReaderQuotas
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.XmlDictionaryReaderQuotaTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.XmlDictionaryString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.XmlDictionaryWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Serialization.Xml.dll
+// MVID: {4856010f-255a-4988-88a7-4aef00534641}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F71B0786000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.Serialization.il
@@ -1,0 +1,474 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002dde
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00015678
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002d8c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002c54 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000de4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000de0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002dce Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000b84] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002bd4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000003b8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000424 Offset
+//              0x000005c8 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000009ec Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000009f0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000a00 Offset
+//              0x00000184 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22240
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17639             (79.31%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2948               (13.26%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.21%)
+// Unaccounted          : -1107             (-4.98%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2948
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   42 (588 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1480 bytes
+//   Blobs         -   388 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime.Serialization
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 00   // e.Serialization.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 00   // e.Serialization.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 2E 53 65 72 69 61 6C 69 7A 61 74 69 6F 6E 00   // e.Serialization.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.Serialization.CollectionDataContractAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.Serialization.ContractNamespaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.DataContractAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.DataContractResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.Serialization.DataContractSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.Serialization.DataContractSerializerSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Runtime.Serialization.DataMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.Serialization.DateTimeFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Runtime.Serialization.EmitTypeInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Runtime.Serialization.EnumMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.Serialization.ExportOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Runtime.Serialization.ExtensionDataObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Runtime.Serialization.IExtensibleDataObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Runtime.Serialization.IgnoreDataMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.Serialization.InvalidDataContractException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Runtime.Serialization.KnownTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Runtime.Serialization.XmlObjectSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Runtime.Serialization.XmlSerializableServices
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Runtime.Serialization.XPathQueryGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Runtime.Serialization.XsdDataContractExporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Runtime.Serialization.Json.DataContractJsonSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Runtime.Serialization.Json.DataContractJsonSerializerSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Runtime.Serialization.Json.IXmlJsonReaderInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Runtime.Serialization.Json.IXmlJsonWriterInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Runtime.Serialization.Json.JsonReaderWriterFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Xml.IFragmentCapableXmlDictionaryWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Xml.IStreamProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Xml.IXmlBinaryReaderInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Xml.IXmlBinaryWriterInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Xml.IXmlDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Xml.IXmlTextReaderInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Xml.IXmlTextWriterInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Xml.OnXmlDictionaryReaderClose
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Xml.UniqueId
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Xml.XmlBinaryReaderSession
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Xml.XmlBinaryWriterSession
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Xml.XmlDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Xml.XmlDictionaryReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Xml.XmlDictionaryReaderQuotas
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Xml.XmlDictionaryReaderQuotaTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Xml.XmlDictionaryString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Xml.XmlDictionaryWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.Serialization.dll
+// MVID: {2a5c5a4a-300a-4cd8-9db6-0a7fb80e85a2}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F2811EA8000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Runtime.il
@@ -1,0 +1,1428 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd41
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00002a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00004822
+// Base of code:                   0x00002000
+// Base of data:                   0x00006000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x0000a000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008737
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000047d0 [0x0000004f] address [size] of Import Directory:          
+// 0x00006000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00003400 [0x00003eb0] address [size] of Security Directory:        
+// 0x00008000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00004698 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00002828 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00002a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00002c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00008000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00003200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00004000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000824
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00004812 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000025c8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00004618 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000010b0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000111c Offset
+//              0x00001290 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000023ac Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000023b0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000023c0 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 29360
+// PE header size       : 512 (496 used)    ( 1.74%)
+// PE additional info   : 17479             (59.53%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.25%)
+// CLR meta-data size  : 9672               (32.94%)
+// CLR additional info : 128                ( 0.44%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 6.98%)
+// Unaccounted          : -551              (-1.88%)
+
+// Num.of PE sections   : 3
+//   .text    - 10752
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 9672
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -  279 (3906 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  4751 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Runtime
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                              65 00 00 )                                        // e..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                    65 00 00 )                                        // e..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 52 75 6E 74 69 6D   // ...System.Runtim
+                                                                                                                                                                     65 00 00 )                                        // e..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder System.Action
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Action`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Action`10
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Action`11
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Action`12
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Action`13
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Action`14
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Action`15
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Action`16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Action`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Action`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Action`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Action`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Action`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Action`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Action`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Action`9
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Activator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.ArgumentException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.ArgumentNullException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.ArgumentOutOfRangeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.ArithmeticException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Array
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.ArraySegment`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.ArrayTypeMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.AsyncCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Attribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.AttributeTargets
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.AttributeUsageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.BadImageFormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Boolean
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Buffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Byte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Char
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.CLSCompliantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Comparison`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.DateTime
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.DateTimeKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.DateTimeOffset
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.DayOfWeek
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Decimal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Delegate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.DivideByZeroException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Double
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Enum
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.EventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.EventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.EventHandler`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.Exception
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.FieldAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.FlagsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.FormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.FormattableString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Func`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.Func`10
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.Func`11
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.Func`12
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.Func`13
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.Func`14
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.Func`15
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.Func`16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.Func`17
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.Func`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.Func`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.Func`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.Func`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.Func`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ forwarder System.Func`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000045*/ forwarder System.Func`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.Func`9
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.GC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.GCCollectionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.Guid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.IAsyncResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.IComparable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.IComparable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.IConvertible
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.ICustomFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.IDisposable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.IEquatable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.IFormatProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.IFormattable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.IndexOutOfRangeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.InsufficientExecutionStackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Int16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ forwarder System.Int32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000057*/ forwarder System.Int64
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000058*/ forwarder System.IntPtr
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.InvalidCastException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.InvalidOperationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.InvalidProgramException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.InvalidTimeZoneException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.IObservable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.IObserver`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.IProgress`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.Lazy`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.Lazy`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.MemberAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.MethodAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.MissingFieldException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.MissingMemberException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.MissingMethodException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.MTAThreadAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.MulticastDelegate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.NotImplementedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.NotSupportedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.Nullable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.Nullable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.NullReferenceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ forwarder System.Object
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006F*/ forwarder System.ObjectDisposedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ forwarder System.ObsoleteAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000071*/ forwarder System.OutOfMemoryException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.OverflowException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000073*/ forwarder System.ParamArrayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000074*/ forwarder System.PlatformNotSupportedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000075*/ forwarder System.Predicate`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000076*/ forwarder System.RankException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000077*/ forwarder System.RuntimeFieldHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000078*/ forwarder System.RuntimeMethodHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000079*/ forwarder System.RuntimeTypeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007A*/ forwarder System.SByte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.Single
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007C*/ forwarder System.STAThreadAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007D*/ forwarder System.String
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007E*/ forwarder System.StringComparison
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007F*/ forwarder System.StringSplitOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.ThreadStaticAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000081*/ forwarder System.TimeoutException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000082*/ forwarder System.TimeSpan
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.TimeZoneInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ AdjustmentRule
+{
+  .class extern System.TimeZoneInfo /*27000083*/ 
+}
+.class extern /*27000085*/ TransitionTime
+{
+  .class extern System.TimeZoneInfo /*27000083*/ 
+}
+.class extern /*27000086*/ forwarder System.Tuple
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ forwarder System.Tuple`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000088*/ forwarder System.Tuple`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ forwarder System.Tuple`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008A*/ forwarder System.Tuple`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ forwarder System.Tuple`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008C*/ forwarder System.Tuple`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008D*/ forwarder System.Tuple`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008E*/ forwarder System.Tuple`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008F*/ forwarder System.Type
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000090*/ forwarder System.TypeAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.TypeCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ forwarder System.TypeInitializationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000093*/ forwarder System.TypeLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ forwarder System.UInt16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000095*/ forwarder System.UInt32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.UInt64
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.UIntPtr
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000098*/ forwarder System.UnauthorizedAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000099*/ forwarder System.Uri
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009A*/ forwarder System.UriComponents
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009B*/ forwarder System.UriFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009C*/ forwarder System.UriFormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009D*/ forwarder System.UriHostNameType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009E*/ forwarder System.UriKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009F*/ forwarder System.ValueType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A0*/ forwarder System.Version
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A1*/ forwarder System.Void
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A2*/ forwarder System.WeakReference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A3*/ forwarder System.WeakReference`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A4*/ forwarder System.Collections.DictionaryEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A5*/ forwarder System.Collections.ICollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A6*/ forwarder System.Collections.IComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A7*/ forwarder System.Collections.IDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A8*/ forwarder System.Collections.IDictionaryEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A9*/ forwarder System.Collections.IEnumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AA*/ forwarder System.Collections.IEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AB*/ forwarder System.Collections.IEqualityComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AC*/ forwarder System.Collections.IList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AD*/ forwarder System.Collections.IStructuralComparable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AE*/ forwarder System.Collections.IStructuralEquatable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AF*/ forwarder System.Collections.Generic.ICollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B0*/ forwarder System.Collections.Generic.IComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B1*/ forwarder System.Collections.Generic.IDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B2*/ forwarder System.Collections.Generic.IEnumerable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B3*/ forwarder System.Collections.Generic.IEnumerator`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B4*/ forwarder System.Collections.Generic.IEqualityComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B5*/ forwarder System.Collections.Generic.IList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B6*/ forwarder System.Collections.Generic.IReadOnlyCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B7*/ forwarder System.Collections.Generic.IReadOnlyDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B8*/ forwarder System.Collections.Generic.IReadOnlyList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B9*/ forwarder System.Collections.Generic.ISet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BA*/ forwarder System.Collections.Generic.KeyNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BB*/ forwarder System.Collections.Generic.KeyValuePair`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BC*/ forwarder System.Collections.ObjectModel.Collection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BD*/ forwarder System.Collections.ObjectModel.ReadOnlyCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BE*/ forwarder System.ComponentModel.DefaultValueAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BF*/ forwarder System.ComponentModel.EditorBrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C0*/ forwarder System.ComponentModel.EditorBrowsableState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C1*/ forwarder System.Diagnostics.ConditionalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C2*/ forwarder System.Diagnostics.DebuggableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C3*/ DebuggingModes
+{
+  .class extern System.Diagnostics.DebuggableAttribute /*270000C2*/ 
+}
+.class extern /*270000C4*/ forwarder System.Globalization.DateTimeStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C5*/ forwarder System.Globalization.NumberStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C6*/ forwarder System.Globalization.TimeSpanStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C7*/ forwarder System.IO.DirectoryNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C8*/ forwarder System.IO.FileLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C9*/ forwarder System.IO.FileNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CA*/ forwarder System.IO.IOException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CB*/ forwarder System.IO.PathTooLongException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CC*/ forwarder System.Reflection.AssemblyCompanyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CD*/ forwarder System.Reflection.AssemblyConfigurationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CE*/ forwarder System.Reflection.AssemblyCopyrightAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CF*/ forwarder System.Reflection.AssemblyCultureAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D0*/ forwarder System.Reflection.AssemblyDefaultAliasAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D1*/ forwarder System.Reflection.AssemblyDelaySignAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D2*/ forwarder System.Reflection.AssemblyDescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D3*/ forwarder System.Reflection.AssemblyFileVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D4*/ forwarder System.Reflection.AssemblyFlagsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D5*/ forwarder System.Reflection.AssemblyInformationalVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D6*/ forwarder System.Reflection.AssemblyKeyFileAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D7*/ forwarder System.Reflection.AssemblyKeyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D8*/ forwarder System.Reflection.AssemblyMetadataAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D9*/ forwarder System.Reflection.AssemblyNameFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DA*/ forwarder System.Reflection.AssemblyProductAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DB*/ forwarder System.Reflection.AssemblySignatureKeyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DC*/ forwarder System.Reflection.AssemblyTitleAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DD*/ forwarder System.Reflection.AssemblyTrademarkAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DE*/ forwarder System.Reflection.AssemblyVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DF*/ forwarder System.Reflection.DefaultMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E0*/ forwarder System.Reflection.ProcessorArchitecture
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E1*/ forwarder System.Runtime.GCLargeObjectHeapCompactionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E2*/ forwarder System.Runtime.GCLatencyMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E3*/ forwarder System.Runtime.GCSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E4*/ forwarder System.Runtime.CompilerServices.AccessedThroughPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E5*/ forwarder System.Runtime.CompilerServices.AsyncStateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E6*/ forwarder System.Runtime.CompilerServices.CallerFilePathAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E7*/ forwarder System.Runtime.CompilerServices.CallerLineNumberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E8*/ forwarder System.Runtime.CompilerServices.CallerMemberNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E9*/ forwarder System.Runtime.CompilerServices.CompilationRelaxationsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EA*/ forwarder System.Runtime.CompilerServices.CompilerGeneratedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EB*/ forwarder System.Runtime.CompilerServices.ConditionalWeakTable`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EC*/ CreateValueCallback
+{
+  .class extern System.Runtime.CompilerServices.ConditionalWeakTable`2 /*270000EB*/ 
+}
+.class extern /*270000ED*/ forwarder System.Runtime.CompilerServices.CustomConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EE*/ forwarder System.Runtime.CompilerServices.DateTimeConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EF*/ forwarder System.Runtime.CompilerServices.DecimalConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F0*/ forwarder System.Runtime.CompilerServices.DisablePrivateReflectionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F1*/ forwarder System.Runtime.CompilerServices.ExtensionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F2*/ forwarder System.Runtime.CompilerServices.FixedBufferAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F3*/ forwarder System.Runtime.CompilerServices.FormattableStringFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F4*/ forwarder System.Runtime.CompilerServices.IndexerNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F5*/ forwarder System.Runtime.CompilerServices.InternalsVisibleToAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F6*/ forwarder System.Runtime.CompilerServices.IsConst
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F7*/ forwarder System.Runtime.CompilerServices.IStrongBox
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F8*/ forwarder System.Runtime.CompilerServices.IsVolatile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F9*/ forwarder System.Runtime.CompilerServices.IteratorStateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FA*/ forwarder System.Runtime.CompilerServices.MethodImplAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FB*/ forwarder System.Runtime.CompilerServices.MethodImplOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FC*/ forwarder System.Runtime.CompilerServices.ReferenceAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FD*/ forwarder System.Runtime.CompilerServices.RuntimeCompatibilityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FE*/ forwarder System.Runtime.CompilerServices.RuntimeHelpers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FF*/ CleanupCode
+{
+  .class extern System.Runtime.CompilerServices.RuntimeHelpers /*270000FE*/ 
+}
+.class extern /*27000100*/ TryCode
+{
+  .class extern System.Runtime.CompilerServices.RuntimeHelpers /*270000FE*/ 
+}
+.class extern /*27000101*/ forwarder System.Runtime.CompilerServices.StateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000102*/ forwarder System.Runtime.CompilerServices.StrongBox`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000103*/ forwarder System.Runtime.CompilerServices.TypeForwardedFromAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000104*/ forwarder System.Runtime.CompilerServices.TypeForwardedToAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000105*/ forwarder System.Runtime.CompilerServices.UnsafeValueTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000106*/ forwarder System.Runtime.ExceptionServices.ExceptionDispatchInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000107*/ forwarder System.Runtime.InteropServices.CharSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000108*/ forwarder System.Runtime.InteropServices.ComVisibleAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000109*/ forwarder System.Runtime.InteropServices.FieldOffsetAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010A*/ forwarder System.Runtime.InteropServices.LayoutKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010B*/ forwarder System.Runtime.InteropServices.OutAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010C*/ forwarder System.Runtime.InteropServices.StructLayoutAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010D*/ forwarder System.Runtime.Versioning.TargetFrameworkAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010E*/ forwarder System.Security.AllowPartiallyTrustedCallersAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010F*/ forwarder System.Security.SecurityCriticalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000110*/ forwarder System.Security.SecurityException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000111*/ forwarder System.Security.SecuritySafeCriticalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000112*/ forwarder System.Security.SecurityTransparentAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000113*/ forwarder System.Security.VerificationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000114*/ forwarder System.Text.StringBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000115*/ forwarder System.Threading.LazyThreadSafetyMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000116*/ forwarder System.Threading.Timeout
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000117*/ forwarder System.Threading.WaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Runtime.dll
+// MVID: {bddc3f7c-aa17-419e-a3cc-f8bc46c98b1e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F34037E9000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Claims.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Claims.il
@@ -1,0 +1,340 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002942
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000c214
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028f0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027b8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000948 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000944
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002932 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006e8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002738 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001d0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000023c Offset
+//              0x00000288 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004c4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004c8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004d8 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1768               ( 8.34%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -903              (-4.26%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1768
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    7 (98 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   648 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Claims
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                              74 79 2E 43 6C 61 69 6D 73 00 00 )                // ty.Claims..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                    74 79 2E 43 6C 61 69 6D 73 00 00 )                // ty.Claims..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                     74 79 2E 43 6C 61 69 6D 73 00 00 )                // ty.Claims..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Security.Claims.Claim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Claims.ClaimsIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Claims.ClaimsPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Security.Claims.ClaimTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Security.Claims.ClaimValueTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Principal.GenericIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Security.Principal.GenericPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Claims.dll
+// MVID: {f8468474-14d2-4faa-a39f-e3036b1df304}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F601CAFE000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Algorithms.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Algorithms.il
@@ -1,0 +1,427 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b5a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000d0db
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b08 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000590] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003f18] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000029d0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b60 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000590 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b5c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b4a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000900] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002950 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002f4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000360 Offset
+//              0x0000036c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000006cc Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000006d0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000006e0 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21784
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17775             (81.60%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2304               (10.58%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.40%)
+// Unaccounted          : -1055             (-4.84%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2304
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   28 (392 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   876 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Cryptography.Algorithms
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                              74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                              41 6C 67 6F 72 69 74 68 6D 73 00 00 )             // Algorithms..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                                    74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                    41 6C 67 6F 72 69 74 68 6D 73 00 00 )             // Algorithms..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                                     74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                     41 6C 67 6F 72 69 74 68 6D 73 00 00 )             // Algorithms..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:2:2:0
+}
+.class extern /*27000001*/ forwarder System.Security.Cryptography.Aes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Cryptography.DeriveBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Cryptography.ECCurve
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ ECCurveType
+{
+  .class extern System.Security.Cryptography.ECCurve /*27000003*/ 
+}
+.class extern /*27000005*/ NamedCurves
+{
+  .class extern System.Security.Cryptography.ECCurve /*27000003*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Cryptography.ECDsa
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Security.Cryptography.ECParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Security.Cryptography.ECPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Security.Cryptography.HMACMD5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Security.Cryptography.HMACSHA1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Security.Cryptography.HMACSHA256
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Security.Cryptography.HMACSHA384
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Security.Cryptography.HMACSHA512
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Security.Cryptography.IncrementalHash
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Security.Cryptography.MD5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Security.Cryptography.RandomNumberGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Security.Cryptography.Rfc2898DeriveBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Security.Cryptography.RSA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Security.Cryptography.RSAEncryptionPadding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Security.Cryptography.RSAEncryptionPaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Security.Cryptography.RSAParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Security.Cryptography.RSASignaturePadding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Security.Cryptography.RSASignaturePaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Security.Cryptography.SHA1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Security.Cryptography.SHA256
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Security.Cryptography.SHA384
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Security.Cryptography.SHA512
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Security.Cryptography.TripleDES
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Cryptography.Algorithms.dll
+// MVID: {05df3162-b142-4b78-896c-8248658f24b1}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F4339E0B000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Csp.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Csp.il
@@ -1,0 +1,339 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000295e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00009ae0
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000290c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000560] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027d4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000964 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000560 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000960
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000294e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000704] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002754 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001c0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000022c Offset
+//              0x000002ac Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004d8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004dc Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004ec Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21240
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17695             (83.31%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1796               ( 8.46%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.64%)
+// Unaccounted          : -1011             (-4.76%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1796
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    6 (84 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   684 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Cryptography.Csp
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 20 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // .. System.Securi
+                                                                                                                                                              74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                              43 73 70 00 00 )                                  // Csp..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 20 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // .. System.Securi
+                                                                                                                                                                    74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                    43 73 70 00 00 )                                  // Csp..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 20 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // .. System.Securi
+                                                                                                                                                                     74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                     43 73 70 00 00 )                                  // Csp..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Security.Cryptography.CspKeyContainerInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Cryptography.CspParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Cryptography.CspProviderFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Security.Cryptography.ICspAsymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Security.Cryptography.KeyNumber
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Cryptography.RSACryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Cryptography.Csp.dll
+// MVID: {e5a55ea1-6d46-4253-8727-86c6d4c64e32}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB8436E7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Encoding.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Encoding.il
@@ -1,0 +1,343 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000297e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000100b8
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000292c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000580] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003f08] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027f4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000984 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000580 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000980
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000296e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000724] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002774 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001d0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000023c Offset
+//              0x000002b4 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004f0 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004f4 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000504 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21256
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17743             (83.47%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1828               ( 8.60%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.63%)
+// Unaccounted          : -1075             (-5.06%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1828
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    7 (98 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   690 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Cryptography.Encoding
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 25 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..%System.Securi
+                                                                                                                                                              74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                              45 6E 63 6F 64 69 6E 67 00 00 )                   // Encoding..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 25 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..%System.Securi
+                                                                                                                                                                    74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                    45 6E 63 6F 64 69 6E 67 00 00 )                   // Encoding..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 25 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..%System.Securi
+                                                                                                                                                                     74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                     45 6E 63 6F 64 69 6E 67 00 00 )                   // Encoding..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Security.Cryptography.AsnEncodedData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Cryptography.AsnEncodedDataCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Cryptography.AsnEncodedDataEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Security.Cryptography.Oid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Security.Cryptography.OidCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Cryptography.OidEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Security.Cryptography.OidGroup
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Cryptography.Encoding.dll
+// MVID: {fe5dd1ec-6649-47ee-99d4-d36fdff219f0}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F3DE25FB000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Primitives.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.Primitives.il
@@ -1,0 +1,367 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a22
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000103d3
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029d0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000590] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003f18] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002898 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a28 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000590 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a24
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a12 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007c8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002818 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000224 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000290 Offset
+//              0x00000304 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000594 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000598 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005a8 Offset
+//              0x00000220 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21784
+// PE header size       : 512 (496 used)    ( 2.35%)
+// PE additional info   : 17775             (81.60%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 1992               ( 9.14%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.40%)
+// Unaccounted          : -743              (-3.41%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1992
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   13 (182 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   771 bytes
+//   Blobs         -   544 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Cryptography.Primitives
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                              74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                              50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                                    74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                    50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 27 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..'System.Securi
+                                                                                                                                                                     74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                     50 72 69 6D 69 74 69 76 65 73 00 00 )             // Primitives..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Security.Cryptography.AsymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Cryptography.CipherMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Cryptography.CryptographicException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Security.Cryptography.CryptoStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Security.Cryptography.CryptoStreamMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Cryptography.HashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Security.Cryptography.HashAlgorithmName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Security.Cryptography.HMAC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Security.Cryptography.ICryptoTransform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Security.Cryptography.KeyedHashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Security.Cryptography.KeySizes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Security.Cryptography.PaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Security.Cryptography.SymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Cryptography.Primitives.dll
+// MVID: {392efbc9-0ed2-426b-b1a6-59fea47d8a58}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F4A31924000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.X509Certificates.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Cryptography.X509Certificates.il
@@ -1,0 +1,474 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00001000
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002e0e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000ff6a
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002dbc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000005c0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001a00 [0x00003f30] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002c84 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000e14 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00001000 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000005c0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000e10
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002dfe Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000bb4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002c04 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000390 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003fc Offset
+//              0x0000057c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000978 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000097c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000098c Offset
+//              0x00000228 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22832
+// PE header size       : 512 (496 used)    ( 2.24%)
+// PE additional info   : 17847             (78.17%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2996               (13.12%)
+// CLR additional info : 128                ( 0.56%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 8.97%)
+// Unaccounted          : -771              (-3.38%)
+
+// Num.of PE sections   : 3
+//   .text    - 4096
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2996
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   39 (546 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1403 bytes
+//   Blobs         -   552 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Cryptography.X509Certificates
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 2D 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..-System.Securi
+                                                                                                                                                              74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                              58 35 30 39 43 65 72 74 69 66 69 63 61 74 65 73   // X509Certificates
+                                                                                                                                                              00 00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 2D 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..-System.Securi
+                                                                                                                                                                    74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                    58 35 30 39 43 65 72 74 69 66 69 63 61 74 65 73   // X509Certificates
+                                                                                                                                                                    00 00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 2D 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ..-System.Securi
+                                                                                                                                                                     74 79 2E 43 72 79 70 74 6F 67 72 61 70 68 79 2E   // ty.Cryptography.
+                                                                                                                                                                     58 35 30 39 43 65 72 74 69 66 69 63 61 74 65 73   // X509Certificates
+                                                                                                                                                                     00 00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:2:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.SafeHandles.SafeX509ChainHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Cryptography.X509Certificates.OpenFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Security.Cryptography.X509Certificates.PublicKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Security.Cryptography.X509Certificates.RSACertificateExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Security.Cryptography.X509Certificates.StoreLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Security.Cryptography.X509Certificates.StoreName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Security.Cryptography.X509Certificates.X500DistinguishedName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Security.Cryptography.X509Certificates.X509CertificateCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ X509CertificateEnumerator
+{
+  .class extern System.Security.Cryptography.X509Certificates.X509CertificateCollection /*2700000F*/ 
+}
+.class extern /*27000011*/ forwarder System.Security.Cryptography.X509Certificates.X509Chain
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElementCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainStatusFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Security.Cryptography.X509Certificates.X509ContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Security.Cryptography.X509Certificates.X509Extension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Security.Cryptography.X509Certificates.X509ExtensionCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Security.Cryptography.X509Certificates.X509FindType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyStorageFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyUsageExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyUsageFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Security.Cryptography.X509Certificates.X509NameType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Security.Cryptography.X509Certificates.X509RevocationFlag
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Security.Cryptography.X509Certificates.X509RevocationMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Security.Cryptography.X509Certificates.X509Store
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierHashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Security.Cryptography.X509Certificates.X509VerificationFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Cryptography.X509Certificates.dll
+// MVID: {d41c5450-4027-41aa-ba14-f734551c09ab}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6CB909B000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Principal.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.Principal.il
@@ -1,0 +1,324 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028c6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000073c6
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002874 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000273c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008cc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008c8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028b6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000066c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026bc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000198 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000204 Offset
+//              0x00000240 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000444 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000448 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000458 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21208
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17599             (82.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1644               ( 7.75%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -795              (-3.75%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1644
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    3 (42 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   576 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.Principal
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 19 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                              74 79 2E 50 72 69 6E 63 69 70 61 6C 00 00 )       // ty.Principal..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 19 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                    74 79 2E 50 72 69 6E 63 69 70 61 6C 00 00 )       // ty.Principal..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 19 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                     74 79 2E 50 72 69 6E 63 69 70 61 6C 00 00 )       // ty.Principal..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Security.Principal.IIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.Principal.IPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Security.Principal.TokenImpersonationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.Principal.dll
+// MVID: {97a6a9c4-1a83-4bb9-a001-a190d5869905}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F6846553000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.SecureString.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Security.SecureString.il
@@ -1,0 +1,323 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028b6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000143fd
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002864 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000540] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000272c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008bc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000540 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008b8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028a6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000065c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026ac [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x00000240 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000434 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000438 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000448 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17639             (83.14%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1628               ( 7.67%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -811              (-3.82%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1628
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   573 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Security.SecureString
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                              74 79 2E 53 65 63 75 72 65 53 74 72 69 6E 67 00   // ty.SecureString.
+                                                                                                                                                              00 ) 
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                    74 79 2E 53 65 63 75 72 65 53 74 72 69 6E 67 00   // ty.SecureString.
+                                                                                                                                                                    00 ) 
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1C 53 79 73 74 65 6D 2E 53 65 63 75 72 69   // ...System.Securi
+                                                                                                                                                                     74 79 2E 53 65 63 75 72 65 53 74 72 69 6E 67 00   // ty.SecureString.
+                                                                                                                                                                     00 ) 
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Security.SecureString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Security.SecureStringMarshal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Security.SecureString.dll
+// MVID: {bf03221f-d22e-4c04-b14a-1233a85f7ca3}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FDBBE999000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ServiceModel.Web.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ServiceModel.Web.il
@@ -1,0 +1,328 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002926
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000adcd
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028d4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000279c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000092c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000928
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002916 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006cc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000271c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x00000298 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000004a8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004ac Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004bc Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1740               ( 8.21%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -875              (-4.13%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1740
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   664 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ServiceModel.Web
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 53 65 72 76 69 63   // ...System.Servic
+                                                                                                                                                              65 4D 6F 64 65 6C 2E 57 65 62 00 00 )             // eModel.Web..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 53 65 72 76 69 63   // ...System.Servic
+                                                                                                                                                                    65 4D 6F 64 65 6C 2E 57 65 62 00 00 )             // eModel.Web..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 53 65 72 76 69 63   // ...System.Servic
+                                                                                                                                                                     65 4D 6F 64 65 6C 2E 57 65 62 00 00 )             // eModel.Web..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                B5 FC 90 E7 02 7F 67 87 1E 77 3A 8F DE 89 38 C8   // ......g..w:...8.
+                1D D4 02 BA 65 B9 20 1D 60 59 3E 96 C4 92 65 1E   // ....e. .`Y>...e.
+                88 9C C1 3F 14 15 EB B5 3F AC 11 31 AE 0B D3 33   // ...?....?..1...3
+                C5 EE 60 21 67 2D 97 18 EA 31 A8 AE BD 0D A0 07   // ..`!g-...1......
+                2F 25 D8 7D BA 6F C9 0F FD 59 8E D4 DA 35 E4 4C   // /%.}.o...Y...5.L
+                39 8C 45 43 07 E8 E3 3B 84 26 14 3D AE C9 F5 96   // 9.EC...;.&.=....
+                83 6F 97 C8 F7 47 50 E5 97 5C 64 E2 18 9F 45 DE   // .o...GP..\d...E.
+                F4 6B 2A 2B 12 47 AD C3 65 2B F5 C3 08 05 5D A9 ) // .k*+.G..e+....].
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Runtime.Serialization.Json.DataContractJsonSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Runtime.Serialization.Json.IXmlJsonReaderInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.Serialization.Json.IXmlJsonWriterInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.Serialization.Json.JsonReaderWriterFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ServiceModel.Web.dll
+// MVID: {a33cfaeb-7a93-42f9-801f-765d8b6b1375}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F36BB63B000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.Encoding.Extensions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.Encoding.Extensions.il
@@ -1,0 +1,335 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000291a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00015269
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028c8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000554] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002790 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000920 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000554 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000091c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000290a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006c0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002710 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001b4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000220 Offset
+//              0x00000274 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000494 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000498 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004a8 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17675             (83.25%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1728               ( 8.14%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -931              (-4.38%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1728
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    5 (70 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   625 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Text.Encoding.Extensions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                              6E 63 6F 64 69 6E 67 2E 45 78 74 65 6E 73 69 6F   // ncoding.Extensio
+                                                                                                                                                              6E 73 00 00 )                                     // ns..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                                    6E 63 6F 64 69 6E 67 2E 45 78 74 65 6E 73 69 6F   // ncoding.Extensio
+                                                                                                                                                                    6E 73 00 00 )                                     // ns..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                                     6E 63 6F 64 69 6E 67 2E 45 78 74 65 6E 73 69 6F   // ncoding.Extensio
+                                                                                                                                                                     6E 73 00 00 )                                     // ns..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Text.ASCIIEncoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Text.UnicodeEncoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Text.UTF32Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Text.UTF7Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Text.UTF8Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Text.Encoding.Extensions.dll
+// MVID: {5e6985b7-943f-47c8-b6bf-7542bd425546}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F5219182000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.Encoding.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.Encoding.il
@@ -1,0 +1,368 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a32
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008727
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029e0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000504] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028a8 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a38 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000504 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a34
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a22 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007d8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002828 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000230 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000029c Offset
+//              0x0000031c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000005b8 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000005bc Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005cc Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17547             (80.88%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2008               ( 9.26%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -619              (-2.85%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2008
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   14 (196 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   796 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Text.Encoding
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 14 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                              6E 63 6F 64 69 6E 67 00 00 )                      // ncoding..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 14 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                                    6E 63 6F 64 69 6E 67 00 00 )                      // ncoding..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 14 53 79 73 74 65 6D 2E 54 65 78 74 2E 45   // ...System.Text.E
+                                                                                                                                                                     6E 63 6F 64 69 6E 67 00 00 )                      // ncoding..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Text.Decoder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Text.DecoderExceptionFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Text.DecoderFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Text.DecoderFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Text.DecoderFallbackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Text.DecoderReplacementFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Text.Encoder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Text.EncoderExceptionFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Text.EncoderFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Text.EncoderFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Text.EncoderFallbackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Text.EncoderReplacementFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Text.Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Text.EncodingProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Text.Encoding.dll
+// MVID: {6cd6d268-5c78-4201-8f8d-71ae71393ec2}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD1A51C4000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.RegularExpressions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Text.RegularExpressions.il
@@ -1,0 +1,363 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029c6
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000059d7
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002974 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000283c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009cc Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009c8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029b6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000076c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027bc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000214 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000280 Offset
+//              0x000002c0 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000540 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000544 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000554 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1900               ( 8.95%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -1099             (-5.18%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1900
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   12 (168 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   703 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Text.RegularExpressions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 54 65 78 74 2E 52   // ...System.Text.R
+                                                                                                                                                              65 67 75 6C 61 72 45 78 70 72 65 73 73 69 6F 6E   // egularExpression
+                                                                                                                                                              73 00 00 )                                        // s..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 54 65 78 74 2E 52   // ...System.Text.R
+                                                                                                                                                                    65 67 75 6C 61 72 45 78 70 72 65 73 73 69 6F 6E   // egularExpression
+                                                                                                                                                                    73 00 00 )                                        // s..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1E 53 79 73 74 65 6D 2E 54 65 78 74 2E 52   // ...System.Text.R
+                                                                                                                                                                     65 67 75 6C 61 72 45 78 70 72 65 73 73 69 6F 6E   // egularExpression
+                                                                                                                                                                     73 00 00 )                                        // s..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:1:0
+}
+.class extern /*27000001*/ forwarder System.Text.RegularExpressions.Capture
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Text.RegularExpressions.CaptureCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Text.RegularExpressions.Group
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Text.RegularExpressions.GroupCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Text.RegularExpressions.Match
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Text.RegularExpressions.MatchCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Text.RegularExpressions.MatchEvaluator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Text.RegularExpressions.Regex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Text.RegularExpressions.RegexMatchTimeoutException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Text.RegularExpressions.RegexOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Text.RegularExpressions.RegexRunner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Text.RegularExpressions.RegexRunnerFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Text.RegularExpressions.dll
+// MVID: {80177f4f-20b5-4d1a-be4b-1512cc27a27f}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007EFDFBB0F000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Overlapped.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Overlapped.il
@@ -1,0 +1,328 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000290e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000fa17
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028bc [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002784 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000914 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000910
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028fe Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006b4] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002704 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x0000027c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000048c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000490 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004a0 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17623             (83.06%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1716               ( 8.09%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -883              (-4.16%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1716
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   635 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.Overlapped
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 4F 76 65 72 6C 61 70 70 65 64 00 00 ) // ing.Overlapped..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 4F 76 65 72 6C 61 70 70 65 64 00 00 ) // ing.Overlapped..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 4F 76 65 72 6C 61 70 70 65 64 00 00 ) // ing.Overlapped..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Threading.IOCompletionCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.NativeOverlapped
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Threading.PreAllocatedOverlapped
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Threading.ThreadPoolBoundHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.Overlapped.dll
+// MVID: {73f40ec8-142b-42d6-b9a7-0e982e1e6d9a}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FC68816C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Tasks.Parallel.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Tasks.Parallel.il
@@ -1,0 +1,331 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002902
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008964
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028b0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000550] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ef0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002778 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000908 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000550 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000904
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028f2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006a8] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026f8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x0000026c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000047c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000480 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000490 Offset
+//              0x00000218 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21232
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17671             (83.23%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1704               ( 8.03%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -903              (-4.25%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1704
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   619 bytes
+//   Blobs         -   536 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.Tasks.Parallel
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 54 61 73 6B 73 2E 50 61 72 61 6C 6C   // ing.Tasks.Parall
+                                                                                                                                                              65 6C 00 00 )                                     // el..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 54 61 73 6B 73 2E 50 61 72 61 6C 6C   // ing.Tasks.Parall
+                                                                                                                                                                    65 6C 00 00 )                                     // el..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1F 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 54 61 73 6B 73 2E 50 61 72 61 6C 6C   // ing.Tasks.Parall
+                                                                                                                                                                     65 6C 00 00 )                                     // el..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Threading.Tasks.Parallel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.Tasks.ParallelLoopResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Threading.Tasks.ParallelLoopState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Threading.Tasks.ParallelOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.Tasks.Parallel.dll
+// MVID: {154dc6b4-a370-4b0b-9273-690448dbfba9}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F7C71115000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Tasks.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Tasks.il
@@ -1,0 +1,444 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002cb2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001176b
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002c60 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000514] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002b28 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000cb8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000514 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000cb4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002ca2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000a58] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002aa8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000033c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003a8 Offset
+//              0x0000048c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000834 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000838 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000848 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22224
+// PE header size       : 512 (496 used)    ( 2.30%)
+// PE additional info   : 17579             (79.10%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2648               (11.92%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.22%)
+// Unaccounted          : -763              (-3.43%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2648
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   33 (462 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1164 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.Tasks
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 54 61 73 6B 73 00 00 )                // ing.Tasks..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 54 61 73 6B 73 00 00 )                // ing.Tasks..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 54 61 73 6B 73 00 00 )                // ing.Tasks..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.AggregateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.OperationCanceledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Runtime.CompilerServices.AsyncTaskMethodBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Runtime.CompilerServices.AsyncVoidMethodBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Runtime.CompilerServices.ConfiguredTaskAwaitable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ ConfiguredTaskAwaiter
+{
+  .class extern System.Runtime.CompilerServices.ConfiguredTaskAwaitable /*27000006*/ 
+}
+.class extern /*27000008*/ forwarder System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ ConfiguredTaskAwaiter
+{
+  .class extern System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1 /*27000008*/ 
+}
+.class extern /*2700000A*/ forwarder System.Runtime.CompilerServices.IAsyncStateMachine
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.CompilerServices.ICriticalNotifyCompletion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Runtime.CompilerServices.INotifyCompletion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Runtime.CompilerServices.TaskAwaiter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Runtime.CompilerServices.TaskAwaiter`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Runtime.CompilerServices.YieldAwaitable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ YieldAwaiter
+{
+  .class extern System.Runtime.CompilerServices.YieldAwaitable /*2700000F*/ 
+}
+.class extern /*27000011*/ forwarder System.Threading.CancellationToken
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Threading.CancellationTokenRegistration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Threading.CancellationTokenSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Threading.Tasks.ConcurrentExclusiveSchedulerPair
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Threading.Tasks.Task
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Threading.Tasks.TaskCanceledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Threading.Tasks.TaskCompletionSource`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Threading.Tasks.TaskContinuationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Threading.Tasks.TaskCreationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Threading.Tasks.TaskExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Threading.Tasks.TaskFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Threading.Tasks.TaskFactory`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Threading.Tasks.TaskScheduler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Threading.Tasks.TaskSchedulerException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Threading.Tasks.TaskStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Threading.Tasks.Task`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Threading.Tasks.UnobservedTaskExceptionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.Tasks.dll
+// MVID: {76759fdb-b7fc-4e5f-bad8-dd29eb260cb0}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F11699F3000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Thread.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Thread.il
@@ -1,0 +1,336 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000291a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00008ef4
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028c8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002790 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000920 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x0000091c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000290a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000006c0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002710 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001c0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000022c Offset
+//              0x00000270 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000049c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000004a0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000004b0 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1728               ( 8.15%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -863              (-4.07%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1728
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    6 (84 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   623 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   167 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.Thread
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 54 68 72 65 61 64 00 00 )             // ing.Thread..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 54 68 72 65 61 64 00 00 )             // ing.Thread..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 54 68 72 65 61 64 00 00 )             // ing.Thread..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.Threading.ParameterizedThreadStart
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.Thread
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Threading.ThreadStart
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Threading.ThreadStartException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Threading.ThreadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Threading.ThreadStateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.Thread.dll
+// MVID: {1b68eece-33ce-4db1-a8f2-ad52df715f72}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FEA3B45F000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.ThreadPool.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.ThreadPool.il
@@ -1,0 +1,328 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028f2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001074c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000028a0 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000534] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002768 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008f8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000534 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008f4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028e2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000698] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026e8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001a4 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000210 Offset
+//              0x00000260 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000470 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000474 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000484 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17627             (83.08%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1688               ( 7.96%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -859              (-4.05%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1688
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    4 (56 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   606 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.ThreadPool
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 54 68 72 65 61 64 50 6F 6F 6C 00 00 ) // ing.ThreadPool..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 54 68 72 65 61 64 50 6F 6F 6C 00 00 ) // ing.ThreadPool..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1B 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 54 68 72 65 61 64 50 6F 6F 6C 00 00 ) // ing.ThreadPool..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:12:0
+}
+.class extern /*27000001*/ forwarder System.Threading.RegisteredWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.ThreadPool
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Threading.WaitCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Threading.WaitOrTimerCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.ThreadPool.dll
+// MVID: {d8205295-4e30-4853-b238-c45951116337}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB558AAD000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Timer.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.Timer.il
@@ -1,0 +1,320 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000289e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000b6b6
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000284c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002714 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008a4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008a0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000288e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000644] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002694 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x0000022c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000420 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000424 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000434 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21200
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17575             (82.90%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1604               ( 7.57%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -739              (-3.49%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1604
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   556 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading.Timer
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 2E 54 69 6D 65 72 00 00 )                // ing.Timer..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 2E 54 69 6D 65 72 00 00 )                // ing.Timer..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 2E 54 69 6D 65 72 00 00 )                // ing.Timer..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:1:0
+}
+.class extern /*27000001*/ forwarder System.Threading.Timer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.TimerCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.Timer.dll
+// MVID: {b5f78c29-64ce-4c68-829c-694c71bee650}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD285C43000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Threading.il
@@ -1,0 +1,436 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002c16
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00011629
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002bc4 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004e4] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a8c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000c1c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004e4 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000c18
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c06 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000009bc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002a0c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000320 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000038c Offset
+//              0x00000414 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000007a0 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000007a4 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000007b4 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22192
+// PE header size       : 512 (496 used)    ( 2.31%)
+// PE additional info   : 17499             (78.85%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2492               (11.23%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.23%)
+// Unaccounted          : -559              (-2.52%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2492
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   31 (434 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1044 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Threading
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 10 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                              69 6E 67 00 00 )                                  // ing..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 10 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                    69 6E 67 00 00 )                                  // ing..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 10 53 79 73 74 65 6D 2E 54 68 72 65 61 64   // ...System.Thread
+                                                                                                                                                                     69 6E 67 00 00 )                                  // ing..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Threading.AbandonedMutexException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Threading.AsyncLocalValueChangedArgs`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Threading.AsyncLocal`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Threading.AutoResetEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Threading.Barrier
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Threading.BarrierPostPhaseException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Threading.ContextCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Threading.CountdownEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Threading.EventResetMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Threading.EventWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Threading.ExecutionContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Threading.Interlocked
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Threading.LazyInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Threading.LockRecursionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Threading.LockRecursionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Threading.ManualResetEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Threading.ManualResetEventSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Threading.Monitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Threading.Mutex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Threading.ReaderWriterLockSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Threading.Semaphore
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Threading.SemaphoreFullException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Threading.SemaphoreSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Threading.SendOrPostCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Threading.SpinLock
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Threading.SpinWait
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Threading.SynchronizationContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Threading.SynchronizationLockException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Threading.ThreadLocal`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Threading.Volatile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Threading.WaitHandleCannotBeOpenedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Threading.dll
+// MVID: {42c95ce4-00c8-4477-bc91-4d7e1b1b4491}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FD3BD284000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Transactions.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Transactions.il
@@ -1,0 +1,439 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000e00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002cae
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000cc0d
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002c5c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004f0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001800 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002b24 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000cb4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000e00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004f0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00001000 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001600 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000cb0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002c9e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000a54] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002aa4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000348 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000003b4 Offset
+//              0x00000510 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000008c4 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000008c8 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000008d8 Offset
+//              0x0000017c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 22208
+// PE header size       : 512 (496 used)    ( 2.31%)
+// PE additional info   : 17527             (78.92%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.32%)
+// CLR meta-data size  : 2644               (11.91%)
+// CLR additional info : 128                ( 0.58%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.22%)
+// Unaccounted          : -723              (-3.26%)
+
+// Num.of PE sections   : 3
+//   .text    - 3584
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2644
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   34 (476 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1296 bytes
+//   Blobs         -   380 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Transactions
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 13 53 79 73 74 65 6D 2E 54 72 61 6E 73 61   // ...System.Transa
+                                                                                                                                                              63 74 69 6F 6E 73 00 00 )                         // ctions..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 13 53 79 73 74 65 6D 2E 54 72 61 6E 73 61   // ...System.Transa
+                                                                                                                                                                    63 74 69 6F 6E 73 00 00 )                         // ctions..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 13 53 79 73 74 65 6D 2E 54 72 61 6E 73 61   // ...System.Transa
+                                                                                                                                                                     63 74 69 6F 6E 73 00 00 )                         // ctions..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Transactions.CommittableTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Transactions.DependentCloneOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Transactions.DependentTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Transactions.Enlistment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Transactions.EnlistmentOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Transactions.EnterpriseServicesInteropOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Transactions.HostCurrentTransactionCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Transactions.IDtcTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Transactions.IEnlistmentNotification
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Transactions.IPromotableSinglePhaseNotification
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Transactions.ISimpleTransactionSuperior
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Transactions.ISinglePhaseNotification
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Transactions.IsolationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Transactions.ITransactionPromoter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Transactions.PreparingEnlistment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Transactions.SinglePhaseEnlistment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Transactions.SubordinateTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Transactions.Transaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Transactions.TransactionAbortedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Transactions.TransactionCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Transactions.TransactionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Transactions.TransactionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Transactions.TransactionInDoubtException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Transactions.TransactionInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Transactions.TransactionInterop
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Transactions.TransactionManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Transactions.TransactionManagerCommunicationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Transactions.TransactionOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Transactions.TransactionPromotionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Transactions.TransactionScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Transactions.TransactionScopeAsyncFlowOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Transactions.TransactionScopeOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Transactions.TransactionStartedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Transactions.TransactionStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Transactions.dll
+// MVID: {cc19501b-4a3a-4e4e-8e30-04054de0cd08}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F2032F89000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ValueTuple.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.ValueTuple.il
@@ -1,0 +1,356 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002986
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000125d1
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002934 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004e0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ec8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000027fc [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000098c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004e0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000988
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002976 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x0000072c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000277c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000208 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000274 Offset
+//              0x00000298 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000050c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000510 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000520 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21192
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17519             (82.67%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1836               ( 8.66%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.66%)
+// Unaccounted          : -923              (-4.36%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1836
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   11 (154 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   662 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.ValueTuple
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 11 53 79 73 74 65 6D 2E 56 61 6C 75 65 54   // ...System.ValueT
+                                                                                                                                                              75 70 6C 65 00 00 )                               // uple..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 11 53 79 73 74 65 6D 2E 56 61 6C 75 65 54   // ...System.ValueT
+                                                                                                                                                                    75 70 6C 65 00 00 )                               // uple..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 11 53 79 73 74 65 6D 2E 56 61 6C 75 65 54   // ...System.ValueT
+                                                                                                                                                                     75 70 6C 65 00 00 )                               // uple..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                4B 86 C4 CB 78 54 9B 34 BA B6 1A 3B 18 00 E2 3B   // K...xT.4...;...;
+                FE B5 B3 EC 39 00 74 04 15 36 A7 E3 CB D9 7F 5F   // ....9.t..6....._
+                04 CF 0F 85 71 55 A8 92 8E AA 29 EB FD 11 CF BB   // ....qU....).....
+                AD 3B A7 0E FE A7 BD A3 22 6C 6A 8D 37 0A 4C D3   // .;......"lj.7.L.
+                03 F7 14 48 6B 6E BC 22 59 85 A6 38 47 1E 6E F5   // ...Hkn."Y..8G.n.
+                71 CC 92 A4 61 3C 00 B8 FA 65 D6 1C CE E0 CB E5   // q...a<...e......
+                F3 63 30 C9 A0 1F 41 83 55 9F 1B EF 24 CC 29 17   // .c0...A.U...$.).
+                C6 D9 13 E3 A5 41 33 3A 1D 05 D9 BE D2 2B 38 CB ) // .....A3:.....+8.
+  .hash algorithm 0x00008004
+  .ver 4:0:2:0
+}
+.class extern /*27000001*/ forwarder System.TupleExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.ValueTuple
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.ValueTuple`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.ValueTuple`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.ValueTuple`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.ValueTuple`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ValueTuple`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ValueTuple`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.ValueTuple`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.ValueTuple`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Runtime.CompilerServices.TupleElementNamesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.ValueTuple.dll
+// MVID: {8be4140b-1cf5-4e12-83d6-bd2f3dddbe9b}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB2F03E9000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Web.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Web.il
@@ -1,0 +1,313 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000285e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00006c6d
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000280c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ea0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000026d4 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000864 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000860
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000284e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000604] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002654 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x0000017c Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001e8 Offset
+//              0x00000204 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x000003ec Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x000003f0 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000400 Offset
+//              0x00000204 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21152
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17431             (82.41%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1540               ( 7.28%)
+// CLR additional info : 128                ( 0.61%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.68%)
+// Unaccounted          : -579              (-2.74%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1540
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    1 (14 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   513 bytes
+//   Blobs         -   516 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Web
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 57 65 62 00 00 )    // ...System.Web..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 57 65 62 00 00 )    // ...System.Web..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 57 65 62 00 00 )    // ...System.Web..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Web.HttpUtility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Web.dll
+// MVID: {0b9a24f0-c8a5-461d-a4af-ed1dc51a5270}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F8B487FC000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Windows.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Windows.il
@@ -1,0 +1,348 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a0a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000802d
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000029b8 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ea8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002880 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a10 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a0c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029fa Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000007b0] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002800 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000001ec Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000258 Offset
+//              0x0000033c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000594 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000598 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000005a8 Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21672
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17471             (80.62%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 1968               ( 9.08%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.45%)
+// Unaccounted          : -527              (-2.43%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1968
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    9 (126 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   826 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Windows
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 57 69 6E 64 6F 77   // ...System.Window
+                                                                                                                                                              73 00 00 )                                        // s..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 57 69 6E 64 6F 77   // ...System.Window
+                                                                                                                                                                    73 00 00 )                                        // s..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0E 53 79 73 74 65 6D 2E 57 69 6E 64 6F 77   // ...System.Window
+                                                                                                                                                                     73 00 00 )                                        // s..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Collections.ObjectModel.ObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Collections.ObjectModel.ReadOnlyObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Collections.Specialized.INotifyCollectionChanged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Collections.Specialized.NotifyCollectionChangedAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.ComponentModel.DataErrorsChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.ComponentModel.INotifyDataErrorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Windows.Input.ICommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Windows.dll
+// MVID: {bdceb910-ec07-4526-8c2d-dbbd3a295ee7}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F46964EC000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.Linq.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.Linq.il
@@ -1,0 +1,403 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002a6a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000056d7
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a18 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004d0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003eb0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000028e0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000a70 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004d0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000a6c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002a5a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000810] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002860 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002cc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000338 Offset
+//              0x0000034c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000684 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000688 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000698 Offset
+//              0x00000178 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21680
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17479             (80.62%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2064               ( 9.52%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.45%)
+// Unaccounted          : -623              (-2.87%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2064
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   25 (350 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   843 bytes
+//   Blobs         -   376 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.Linq
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 58 6D 6C 2E 4C 69   // ...System.Xml.Li
+                                                                                                                                                              6E 71 00 00 )                                     // nq..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 58 6D 6C 2E 4C 69   // ...System.Xml.Li
+                                                                                                                                                                    6E 71 00 00 )                                     // nq..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0F 53 79 73 74 65 6D 2E 58 6D 6C 2E 4C 69   // ...System.Xml.Li
+                                                                                                                                                                     6E 71 00 00 )                                     // nq..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Xml.Linq.Extensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.Linq.LoadOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.Linq.ReaderOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.Linq.SaveOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.Linq.XAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.Linq.XCData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.Linq.XComment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.Linq.XContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.Linq.XDeclaration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.Linq.XDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.Linq.XDocumentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.Linq.XElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.Linq.XName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.Linq.XNamespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.Linq.XNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.Linq.XNodeDocumentOrderComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.Linq.XNodeEqualityComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.Linq.XObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.Linq.XObjectChange
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.Linq.XObjectChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.Linq.XProcessingInstruction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.Linq.XStreamingElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.Linq.XText
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Xml.Schema.Extensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Xml.XPath.Extensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.Linq.dll
+// MVID: {0fb4c00a-292a-42ee-8daf-2c01bc4415e0}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F54B40C8000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.ReaderWriter.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.ReaderWriter.il
@@ -1,0 +1,420 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002bae
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000fd57
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b5c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a24 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000bb4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000bb0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b9e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000954] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000029a4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002e8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000354 Offset
+//              0x000003dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000730 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000734 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000744 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21712
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17575             (80.95%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2388               (11.00%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -1011             (-4.66%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2388
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   27 (378 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   985 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   171 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.ReaderWriter
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 17 53 79 73 74 65 6D 2E 58 6D 6C 2E 52 65   // ...System.Xml.Re
+                                                                                                                                                              61 64 65 72 57 72 69 74 65 72 00 00 )             // aderWriter..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 17 53 79 73 74 65 6D 2E 58 6D 6C 2E 52 65   // ...System.Xml.Re
+                                                                                                                                                                    61 64 65 72 57 72 69 74 65 72 00 00 )             // aderWriter..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 17 53 79 73 74 65 6D 2E 58 6D 6C 2E 52 65   // ...System.Xml.Re
+                                                                                                                                                                     61 64 65 72 57 72 69 74 65 72 00 00 )             // aderWriter..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:1:1:0
+}
+.class extern /*27000001*/ forwarder System.Xml.ConformanceLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.DtdProcessing
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.IXmlLineInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.IXmlNamespaceResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.NamespaceHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.NameTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.NewLineHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.ReadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.WriteState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.XmlConvert
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.XmlDateTimeSerializationMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.XmlException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.XmlNamespaceManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.XmlNamespaceScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.XmlNameTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.XmlNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.XmlParserContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.XmlQualifiedName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.XmlReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.XmlReaderSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.XmlSpace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.XmlWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.XmlWriterSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Xml.Schema.XmlSchema
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Xml.Schema.XmlSchemaForm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Xml.Serialization.IXmlSerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Xml.Serialization.XmlSchemaProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.ReaderWriter.dll
+// MVID: {3f489ff5-45fb-4e80-9615-de381b050777}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FE6720B2000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.Serialization.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.Serialization.il
@@ -1,0 +1,411 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b7a
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x000072c7
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b28 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000520] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ed8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x000029f0 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000b80 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000520 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000b7c
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b6a Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000920] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002970 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002e8 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000354 Offset
+//              0x00000438 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000078c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000790 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x000007a0 Offset
+//              0x00000180 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21720
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17599             (81.03%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2336               (10.76%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -975              (-4.49%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2336
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   27 (378 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1080 bytes
+//   Blobs         -   384 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.Serialization
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 53 65   // ...System.Xml.Se
+                                                                                                                                                              72 69 61 6C 69 7A 61 74 69 6F 6E 00 00 )          // rialization..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 53 65   // ...System.Xml.Se
+                                                                                                                                                                    72 69 61 6C 69 7A 61 74 69 6F 6E 00 00 )          // rialization..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 53 65   // ...System.Xml.Se
+                                                                                                                                                                     72 69 61 6C 69 7A 61 74 69 6F 6E 00 00 )          // rialization..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Xml.Serialization.IXmlSerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.Serialization.XmlAnyAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.Serialization.XmlAnyElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.Serialization.XmlAnyElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.Serialization.XmlArrayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.Serialization.XmlArrayItemAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.Serialization.XmlArrayItemAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.Serialization.XmlAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.Serialization.XmlAttributeOverrides
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.Serialization.XmlAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.Serialization.XmlChoiceIdentifierAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.Serialization.XmlElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.Serialization.XmlElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.Serialization.XmlEnumAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.Serialization.XmlIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.Serialization.XmlIncludeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.Serialization.XmlMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.Serialization.XmlMappingAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.Serialization.XmlNamespaceDeclarationsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.Serialization.XmlReflectionImporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.Serialization.XmlRootAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.Serialization.XmlSchemaProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.Serialization.XmlSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Xml.Serialization.XmlSerializerNamespaces
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Xml.Serialization.XmlTextAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Xml.Serialization.XmlTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Xml.Serialization.XmlTypeMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.Serialization.dll
+// MVID: {2ff09a29-9b19-45b5-8dba-10a0eb095395}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FB8997B4000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XDocument.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XDocument.il
@@ -1,0 +1,404 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002ace
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00014623
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a7c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000504] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ec0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002944 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000ad4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000504 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ad0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002abe Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000874] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028c4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002b0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000031c Offset
+//              0x00000338 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000654 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000658 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000668 Offset
+//              0x0000020c Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21696
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17547             (80.88%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2164               ( 9.97%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.44%)
+// Unaccounted          : -775              (-3.57%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2164
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   23 (322 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   824 bytes
+//   Blobs         -   524 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.XDocument
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 14 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 44   // ...System.Xml.XD
+                                                                                                                                                              6F 63 75 6D 65 6E 74 00 00 )                      // ocument..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 14 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 44   // ...System.Xml.XD
+                                                                                                                                                                    6F 63 75 6D 65 6E 74 00 00 )                      // ocument..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 14 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 44   // ...System.Xml.XD
+                                                                                                                                                                     6F 63 75 6D 65 6E 74 00 00 )                      // ocument..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Xml.Linq.Extensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.Linq.LoadOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.Linq.ReaderOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.Linq.SaveOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.Linq.XAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.Linq.XCData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.Linq.XComment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.Linq.XContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.Linq.XDeclaration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.Linq.XDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.Linq.XDocumentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.Linq.XElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.Linq.XName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.Linq.XNamespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.Linq.XNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.Linq.XNodeDocumentOrderComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.Linq.XNodeEqualityComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.Linq.XObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.Linq.XObjectChange
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.Linq.XObjectChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.Linq.XProcessingInstruction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.Linq.XStreamingElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.Linq.XText
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.XDocument.dll
+// MVID: {5e1e1cc8-013f-4591-900c-b0bff32ca20e}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F06D2816000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XPath.XDocument.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XPath.XDocument.il
@@ -1,0 +1,320 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000028b2
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000e69c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002860 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000530] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003ee0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002728 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000008b8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000530 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000008b4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000028a2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000658] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000026a8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000188 Size
+//              '#~' Name
+//    Stream 2:
+//              0x000001f4 Offset
+//              0x0000023c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000430 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000434 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000444 Offset
+//              0x00000214 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21216
+// PE header size       : 512 (496 used)    ( 2.41%)
+// PE additional info   : 17623             (83.06%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1624               ( 7.65%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.65%)
+// Unaccounted          : -791              (-3.73%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1624
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -    2 (28 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   570 bytes
+//   Blobs         -   532 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   168 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.XPath.XDocument
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                              61 74 68 2E 58 44 6F 63 75 6D 65 6E 74 00 00 )    // ath.XDocument..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                                    61 74 68 2E 58 44 6F 63 75 6D 65 6E 74 00 00 )    // ath.XDocument..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 1A 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                                     61 74 68 2E 58 44 6F 63 75 6D 65 6E 74 00 00 )    // ath.XDocument..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Xml.XPath.Extensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.XPath.XDocumentExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.XPath.XDocument.dll
+// MVID: {316cdbac-0538-43ce-b232-b1f161abee37}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F95EAC5C000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XPath.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XPath.il
@@ -1,0 +1,368 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd42
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x000029ee
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00010e78
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000299c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x000004e0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001400 [0x00003eb8] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002864 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x000009f4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004e0 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x000009f0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x000029de Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000794] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000027e4 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000230 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000029c Offset
+//              0x000002dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000578 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x0000057c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x0000058c Offset
+//              0x00000208 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21176
+// PE header size       : 512 (496 used)    ( 2.42%)
+// PE additional info   : 17503             (82.65%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.34%)
+// CLR meta-data size  : 1940               ( 9.16%)
+// CLR additional info : 128                ( 0.60%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.67%)
+// Unaccounted          : -1027             (-4.85%)
+
+// Num.of PE sections   : 3
+//   .text    - 2560
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 1940
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   14 (196 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   729 bytes
+//   Blobs         -   520 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.XPath
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 10 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                              61 74 68 00 00 )                                  // ath..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 10 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                                    61 74 68 00 00 )                                  // ath..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 10 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 50   // ...System.Xml.XP
+                                                                                                                                                                     61 74 68 00 00 )                                  // ath..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Xml.XmlNodeOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.XPath.IXPathNavigable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.XPath.XmlCaseOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.XPath.XmlDataType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.XPath.XmlSortOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.XPath.XPathDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.XPath.XPathException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.XPath.XPathExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.XPath.XPathItem
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.XPath.XPathNamespaceScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.XPath.XPathNavigator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.XPath.XPathNodeIterator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.XPath.XPathNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.XPath.XPathResultType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.XPath.dll
+// MVID: {ec05aaf8-cc0e-473d-ac8d-7ea841500dc1}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F28720E7000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XmlDocument.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XmlDocument.il
@@ -1,0 +1,396 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002aea
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000ed5c
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002a98 [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000510] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002960 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000af0 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000510 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000aec
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002ada Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000890] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x000028e0 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000294 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000300 Offset
+//              0x0000036c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000066c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000670 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000680 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21712
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17575             (80.95%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2192               (10.10%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -815              (-3.75%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2192
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   21 (294 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -   874 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.XmlDocument
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 16 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                              6C 44 6F 63 75 6D 65 6E 74 00 00 )                // lDocument..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 16 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                                    6C 44 6F 63 75 6D 65 6E 74 00 00 )                // lDocument..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 16 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                                     6C 44 6F 63 75 6D 65 6E 74 00 00 )                // lDocument..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:3:0
+}
+.class extern /*27000001*/ forwarder System.Xml.XmlAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.XmlAttributeCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.XmlCDataSection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.XmlCharacterData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.XmlComment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.XmlDeclaration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.XmlDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.XmlDocumentFragment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.XmlElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.XmlImplementation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.XmlLinkedNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.XmlNamedNodeMap
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.XmlNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.XmlNodeChangedAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.XmlNodeChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.XmlNodeChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.XmlNodeList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.XmlProcessingInstruction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.XmlSignificantWhitespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.XmlText
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.XmlWhitespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.XmlDocument.dll
+// MVID: {1f135257-ca53-46b8-b37c-8a554852af09}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F0374398000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XmlSerializer.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.XmlSerializer.il
@@ -1,0 +1,404 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00000c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00002b9e
+// Base of code:                   0x00002000
+// Base of data:                   0x00004000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00008000
+// Size of headers:                0x00000200
+// Checksum:                       0x00011c2e
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00002b4c [0x0000004f] address [size] of Import Directory:          
+// 0x00004000 [0x00000524] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00001600 [0x00003ed0] address [size] of Security Directory:        
+// 0x00006000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00002a14 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00000ba4 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00000c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000524 Virtual Size
+//              0x00004000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00000e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00001400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00002000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ba0
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00002b8e Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00000944] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00002994 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x000002b0 Size
+//              '#~' Name
+//    Stream 2:
+//              0x0000031c Offset
+//              0x00000404 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00000720 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00000724 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00000734 Offset
+//              0x00000210 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 21712
+// PE header size       : 512 (496 used)    ( 2.36%)
+// PE additional info   : 17595             (81.04%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.33%)
+// CLR meta-data size  : 2372               (10.92%)
+// CLR additional info : 128                ( 0.59%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 9.43%)
+// Unaccounted          : -1015             (-4.67%)
+
+// Num.of PE sections   : 3
+//   .text    - 3072
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 2372
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -   23 (322 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  1026 bytes
+//   Blobs         -   528 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   170 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml.XmlSerializer
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                              6C 53 65 72 69 61 6C 69 7A 65 72 00 00 )          // lSerializer..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                                    6C 53 65 72 69 61 6C 69 7A 65 72 00 00 )          // lSerializer..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 18 53 79 73 74 65 6D 2E 58 6D 6C 2E 58 6D   // ...System.Xml.Xm
+                                                                                                                                                                     6C 53 65 72 69 61 6C 69 7A 65 72 00 00 )          // lSerializer..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 24 00 00 04 80 00 00 94 00 00 00 06 02 00 00   // .$..............
+                00 24 00 00 52 53 41 31 00 04 00 00 01 00 01 00   // .$..RSA1........
+                07 D1 FA 57 C4 AE D9 F0 A3 2E 84 AA 0F AE FD 0D   // ...W............
+                E9 E8 FD 6A EC 8F 87 FB 03 76 6C 83 4C 99 92 1E   // ...j.....vl.L...
+                B2 3B E7 9A D9 D5 DC C1 DD 9A D2 36 13 21 02 90   // .;.........6.!..
+                0B 72 3C F9 80 95 7F C4 E1 77 10 8F C6 07 77 4F   // .r<......w....wO
+                29 E8 32 0E 92 EA 05 EC E4 E8 21 C0 A5 EF E8 F1   // ).2.......!.....
+                64 5C 4C 0C 93 C1 AB 99 28 5D 62 2C AA 65 2C 1D   // d\L.....(]b,.e,.
+                FA D6 3D 74 5D 6F 2D E5 F1 7E 5E AF 0F C4 96 3D   // ..=t]o-..~^....=
+                26 1C 8A 12 43 65 18 20 6D C0 93 34 4D 5A D2 93 ) // &...Ce. m..4MZ..
+  .hash algorithm 0x00008004
+  .ver 4:0:11:0
+}
+.class extern /*27000001*/ forwarder System.Xml.Serialization.IXmlSerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.Serialization.XmlAnyAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.Serialization.XmlAnyElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.Serialization.XmlAnyElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.Serialization.XmlArrayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.Serialization.XmlArrayItemAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.Serialization.XmlArrayItemAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.Serialization.XmlAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.Serialization.XmlAttributeOverrides
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.Serialization.XmlAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.Serialization.XmlChoiceIdentifierAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.Serialization.XmlElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.Serialization.XmlElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.Serialization.XmlEnumAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.Serialization.XmlIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.Serialization.XmlIncludeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.Serialization.XmlNamespaceDeclarationsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.Serialization.XmlRootAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.Serialization.XmlSchemaProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.Serialization.XmlSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.Serialization.XmlSerializerNamespaces
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.Serialization.XmlTextAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.Serialization.XmlTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.XmlSerializer.dll
+// MVID: {09ec340f-59db-4b1c-84f6-363a89285ebe}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F3CF06B1000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.Xml.il
@@ -1,0 +1,1292 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00002a00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00004826
+// Base of code:                   0x00002000
+// Base of data:                   0x00006000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x0000a000
+// Size of headers:                0x00000200
+// Checksum:                       0x0000e51b
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x000047d4 [0x0000004f] address [size] of Import Directory:          
+// 0x00006000 [0x000004b0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00003400 [0x00003ea0] address [size] of Security Directory:        
+// 0x00008000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000469c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x0000282c Virtual Size
+//              0x00002000 Virtual Address
+//              0x00002a00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004b0 Virtual Size
+//              0x00006000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00002c00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x00008000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00003200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00004000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000828
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00004816 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x000025cc] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000461c [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00000efc Size
+//              '#~' Name
+//    Stream 2:
+//              0x00000f68 Offset
+//              0x000014dc Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00002444 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00002448 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00002458 Offset
+//              0x00000174 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 29344
+// PE header size       : 512 (496 used)    ( 1.74%)
+// PE additional info   : 17431             (59.40%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.25%)
+// CLR meta-data size  : 9676               (32.97%)
+// CLR additional info : 128                ( 0.44%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 6.98%)
+// Unaccounted          : -523              (-1.78%)
+
+// Num.of PE sections   : 3
+//   .text    - 10752
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 9676
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    1 (20 bytes)
+//   ExportedType  -  248 (3472 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       -  5340 bytes
+//   Blobs         -   372 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly /*20000001*/ System.Xml
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 58 6D 6C 00 00 )    // ...System.Xml..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 58 6D 6C 00 00 )    // ...System.Xml..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 0A 53 79 73 74 65 6D 2E 58 6D 6C 00 00 )    // ...System.Xml..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder System.Xml.ConformanceLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000002*/ forwarder System.Xml.DtdProcessing
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000003*/ forwarder System.Xml.EntityHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder System.Xml.Formatting
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.Xml.IHasXmlNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.Xml.IXmlLineInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.Xml.IXmlNamespaceResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.Xml.NamespaceHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.Xml.NameTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.Xml.NewLineHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.Xml.ReadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.Xml.ValidationType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.Xml.WhitespaceHandling
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.Xml.WriteState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Xml.XmlAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.Xml.XmlAttributeCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.Xml.XmlCDataSection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Xml.XmlCharacterData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Xml.XmlComment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Xml.XmlConvert
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Xml.XmlDateTimeSerializationMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Xml.XmlDeclaration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Xml.XmlDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Xml.XmlDocumentFragment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Xml.XmlDocumentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Xml.XmlElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Xml.XmlEntity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.Xml.XmlEntityReference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.Xml.XmlException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.Xml.XmlImplementation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.Xml.XmlLinkedNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.Xml.XmlNamedNodeMap
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.Xml.XmlNamespaceManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.Xml.XmlNamespaceScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.Xml.XmlNameTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.Xml.XmlNode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.Xml.XmlNodeChangedAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Xml.XmlNodeChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.Xml.XmlNodeChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.Xml.XmlNodeList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.Xml.XmlNodeOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.Xml.XmlNodeReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.Xml.XmlNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Xml.XmlNotation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.Xml.XmlOutputMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.Xml.XmlParserContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.Xml.XmlProcessingInstruction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.Xml.XmlQualifiedName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.Xml.XmlReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.Xml.XmlReaderSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.Xml.XmlResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.Xml.XmlSecureResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.Xml.XmlSignificantWhitespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Xml.XmlSpace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.Xml.XmlText
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.Xml.XmlTextReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.Xml.XmlTextWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.Xml.XmlTokenizedType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.Xml.XmlUrlResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.Xml.XmlValidatingReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.Xml.XmlWhitespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.Xml.XmlWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.Xml.XmlWriterSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.Xml.Resolvers.XmlKnownDtds
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.Xml.Resolvers.XmlPreloadedResolver
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.Xml.Schema.IXmlSchemaInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.Xml.Schema.ValidationEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ forwarder System.Xml.Schema.ValidationEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000045*/ forwarder System.Xml.Schema.XmlAtomicValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.Xml.Schema.XmlSchema
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.Xml.Schema.XmlSchemaAll
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.Xml.Schema.XmlSchemaAnnotated
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.Xml.Schema.XmlSchemaAnnotation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.Xml.Schema.XmlSchemaAny
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.Xml.Schema.XmlSchemaAnyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.Xml.Schema.XmlSchemaAppInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.Xml.Schema.XmlSchemaAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.Xml.Schema.XmlSchemaAttributeGroup
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.Xml.Schema.XmlSchemaAttributeGroupRef
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.Xml.Schema.XmlSchemaChoice
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.Xml.Schema.XmlSchemaCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.Xml.Schema.XmlSchemaCollectionEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.Xml.Schema.XmlSchemaCompilationSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.Xml.Schema.XmlSchemaComplexContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Xml.Schema.XmlSchemaComplexContentExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ forwarder System.Xml.Schema.XmlSchemaComplexContentRestriction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000057*/ forwarder System.Xml.Schema.XmlSchemaComplexType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000058*/ forwarder System.Xml.Schema.XmlSchemaContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.Xml.Schema.XmlSchemaContentModel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.Xml.Schema.XmlSchemaContentProcessing
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.Xml.Schema.XmlSchemaContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.Xml.Schema.XmlSchemaDatatype
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.Xml.Schema.XmlSchemaDatatypeVariety
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.Xml.Schema.XmlSchemaDerivationMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.Xml.Schema.XmlSchemaDocumentation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.Xml.Schema.XmlSchemaElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.Xml.Schema.XmlSchemaEnumerationFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.Xml.Schema.XmlSchemaException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.Xml.Schema.XmlSchemaExternal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.Xml.Schema.XmlSchemaFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.Xml.Schema.XmlSchemaForm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.Xml.Schema.XmlSchemaFractionDigitsFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.Xml.Schema.XmlSchemaGroup
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.Xml.Schema.XmlSchemaGroupBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.Xml.Schema.XmlSchemaGroupRef
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.Xml.Schema.XmlSchemaIdentityConstraint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.Xml.Schema.XmlSchemaImport
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.Xml.Schema.XmlSchemaInclude
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.Xml.Schema.XmlSchemaInference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ InferenceOption
+{
+  .class extern System.Xml.Schema.XmlSchemaInference /*2700006D*/ 
+}
+.class extern /*2700006F*/ forwarder System.Xml.Schema.XmlSchemaInferenceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ forwarder System.Xml.Schema.XmlSchemaInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000071*/ forwarder System.Xml.Schema.XmlSchemaKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.Xml.Schema.XmlSchemaKeyref
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000073*/ forwarder System.Xml.Schema.XmlSchemaLengthFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000074*/ forwarder System.Xml.Schema.XmlSchemaMaxExclusiveFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000075*/ forwarder System.Xml.Schema.XmlSchemaMaxInclusiveFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000076*/ forwarder System.Xml.Schema.XmlSchemaMaxLengthFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000077*/ forwarder System.Xml.Schema.XmlSchemaMinExclusiveFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000078*/ forwarder System.Xml.Schema.XmlSchemaMinInclusiveFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000079*/ forwarder System.Xml.Schema.XmlSchemaMinLengthFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007A*/ forwarder System.Xml.Schema.XmlSchemaNotation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.Xml.Schema.XmlSchemaNumericFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007C*/ forwarder System.Xml.Schema.XmlSchemaObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007D*/ forwarder System.Xml.Schema.XmlSchemaObjectCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007E*/ forwarder System.Xml.Schema.XmlSchemaObjectEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007F*/ forwarder System.Xml.Schema.XmlSchemaObjectTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.Xml.Schema.XmlSchemaParticle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000081*/ forwarder System.Xml.Schema.XmlSchemaPatternFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000082*/ forwarder System.Xml.Schema.XmlSchemaRedefine
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.Xml.Schema.XmlSchemaSequence
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ forwarder System.Xml.Schema.XmlSchemaSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000085*/ forwarder System.Xml.Schema.XmlSchemaSimpleContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000086*/ forwarder System.Xml.Schema.XmlSchemaSimpleContentExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ forwarder System.Xml.Schema.XmlSchemaSimpleContentRestriction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000088*/ forwarder System.Xml.Schema.XmlSchemaSimpleType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ forwarder System.Xml.Schema.XmlSchemaSimpleTypeContent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008A*/ forwarder System.Xml.Schema.XmlSchemaSimpleTypeList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ forwarder System.Xml.Schema.XmlSchemaSimpleTypeRestriction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008C*/ forwarder System.Xml.Schema.XmlSchemaSimpleTypeUnion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008D*/ forwarder System.Xml.Schema.XmlSchemaTotalDigitsFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008E*/ forwarder System.Xml.Schema.XmlSchemaType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008F*/ forwarder System.Xml.Schema.XmlSchemaUnique
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000090*/ forwarder System.Xml.Schema.XmlSchemaUse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.Xml.Schema.XmlSchemaValidationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ forwarder System.Xml.Schema.XmlSchemaValidationFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000093*/ forwarder System.Xml.Schema.XmlSchemaValidator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ forwarder System.Xml.Schema.XmlSchemaValidity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000095*/ forwarder System.Xml.Schema.XmlSchemaWhiteSpaceFacet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.Xml.Schema.XmlSchemaXPath
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.Xml.Schema.XmlSeverityType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000098*/ forwarder System.Xml.Schema.XmlTypeCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000099*/ forwarder System.Xml.Schema.XmlValueGetter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009A*/ forwarder System.Xml.Serialization.CodeGenerationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009B*/ forwarder System.Xml.Serialization.CodeIdentifier
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009C*/ forwarder System.Xml.Serialization.CodeIdentifiers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009D*/ forwarder System.Xml.Serialization.ImportContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009E*/ forwarder System.Xml.Serialization.IXmlSerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009F*/ forwarder System.Xml.Serialization.IXmlTextParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A0*/ forwarder System.Xml.Serialization.SoapAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A1*/ forwarder System.Xml.Serialization.SoapAttributeOverrides
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A2*/ forwarder System.Xml.Serialization.SoapAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A3*/ forwarder System.Xml.Serialization.SoapElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A4*/ forwarder System.Xml.Serialization.SoapEnumAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A5*/ forwarder System.Xml.Serialization.SoapIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A6*/ forwarder System.Xml.Serialization.SoapIncludeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A7*/ forwarder System.Xml.Serialization.SoapReflectionImporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A8*/ forwarder System.Xml.Serialization.SoapSchemaMember
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A9*/ forwarder System.Xml.Serialization.SoapTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AA*/ forwarder System.Xml.Serialization.UnreferencedObjectEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AB*/ forwarder System.Xml.Serialization.UnreferencedObjectEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AC*/ forwarder System.Xml.Serialization.XmlAnyAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AD*/ forwarder System.Xml.Serialization.XmlAnyElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AE*/ forwarder System.Xml.Serialization.XmlAnyElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AF*/ forwarder System.Xml.Serialization.XmlArrayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B0*/ forwarder System.Xml.Serialization.XmlArrayItemAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B1*/ forwarder System.Xml.Serialization.XmlArrayItemAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B2*/ forwarder System.Xml.Serialization.XmlAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B3*/ forwarder System.Xml.Serialization.XmlAttributeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B4*/ forwarder System.Xml.Serialization.XmlAttributeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B5*/ forwarder System.Xml.Serialization.XmlAttributeOverrides
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B6*/ forwarder System.Xml.Serialization.XmlAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B7*/ forwarder System.Xml.Serialization.XmlChoiceIdentifierAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B8*/ forwarder System.Xml.Serialization.XmlDeserializationEvents
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B9*/ forwarder System.Xml.Serialization.XmlElementAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BA*/ forwarder System.Xml.Serialization.XmlElementAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BB*/ forwarder System.Xml.Serialization.XmlElementEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BC*/ forwarder System.Xml.Serialization.XmlElementEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BD*/ forwarder System.Xml.Serialization.XmlEnumAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BE*/ forwarder System.Xml.Serialization.XmlIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BF*/ forwarder System.Xml.Serialization.XmlIncludeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C0*/ forwarder System.Xml.Serialization.XmlMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C1*/ forwarder System.Xml.Serialization.XmlMappingAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C2*/ forwarder System.Xml.Serialization.XmlMemberMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C3*/ forwarder System.Xml.Serialization.XmlMembersMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C4*/ forwarder System.Xml.Serialization.XmlNamespaceDeclarationsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C5*/ forwarder System.Xml.Serialization.XmlNodeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C6*/ forwarder System.Xml.Serialization.XmlNodeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C7*/ forwarder System.Xml.Serialization.XmlReflectionImporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C8*/ forwarder System.Xml.Serialization.XmlReflectionMember
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C9*/ forwarder System.Xml.Serialization.XmlRootAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CA*/ forwarder System.Xml.Serialization.XmlSchemaEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CB*/ forwarder System.Xml.Serialization.XmlSchemaExporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CC*/ forwarder System.Xml.Serialization.XmlSchemaImporter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CD*/ forwarder System.Xml.Serialization.XmlSchemaProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CE*/ forwarder System.Xml.Serialization.XmlSchemas
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CF*/ forwarder System.Xml.Serialization.XmlSerializationCollectionFixupCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D0*/ forwarder System.Xml.Serialization.XmlSerializationFixupCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D1*/ forwarder System.Xml.Serialization.XmlSerializationGeneratedCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D2*/ forwarder System.Xml.Serialization.XmlSerializationReadCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D3*/ forwarder System.Xml.Serialization.XmlSerializationReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D4*/ CollectionFixup
+{
+  .class extern System.Xml.Serialization.XmlSerializationReader /*270000D3*/ 
+}
+.class extern /*270000D5*/ Fixup
+{
+  .class extern System.Xml.Serialization.XmlSerializationReader /*270000D3*/ 
+}
+.class extern /*270000D6*/ forwarder System.Xml.Serialization.XmlSerializationWriteCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D7*/ forwarder System.Xml.Serialization.XmlSerializationWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D8*/ forwarder System.Xml.Serialization.XmlSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D9*/ forwarder System.Xml.Serialization.XmlSerializerAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DA*/ forwarder System.Xml.Serialization.XmlSerializerFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DB*/ forwarder System.Xml.Serialization.XmlSerializerImplementation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DC*/ forwarder System.Xml.Serialization.XmlSerializerNamespaces
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DD*/ forwarder System.Xml.Serialization.XmlSerializerVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DE*/ forwarder System.Xml.Serialization.XmlTextAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DF*/ forwarder System.Xml.Serialization.XmlTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E0*/ forwarder System.Xml.Serialization.XmlTypeMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E1*/ forwarder System.Xml.XPath.IXPathNavigable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E2*/ forwarder System.Xml.XPath.XmlCaseOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E3*/ forwarder System.Xml.XPath.XmlDataType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E4*/ forwarder System.Xml.XPath.XmlSortOrder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E5*/ forwarder System.Xml.XPath.XPathDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E6*/ forwarder System.Xml.XPath.XPathException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E7*/ forwarder System.Xml.XPath.XPathExpression
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E8*/ forwarder System.Xml.XPath.XPathItem
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E9*/ forwarder System.Xml.XPath.XPathNamespaceScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EA*/ forwarder System.Xml.XPath.XPathNavigator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EB*/ forwarder System.Xml.XPath.XPathNodeIterator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EC*/ forwarder System.Xml.XPath.XPathNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000ED*/ forwarder System.Xml.XPath.XPathResultType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EE*/ forwarder System.Xml.Xsl.IXsltContextFunction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EF*/ forwarder System.Xml.Xsl.IXsltContextVariable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F0*/ forwarder System.Xml.Xsl.XslCompiledTransform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F1*/ forwarder System.Xml.Xsl.XsltArgumentList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F2*/ forwarder System.Xml.Xsl.XsltCompileException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F3*/ forwarder System.Xml.Xsl.XsltContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F4*/ forwarder System.Xml.Xsl.XsltException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F5*/ forwarder System.Xml.Xsl.XsltMessageEncounteredEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F6*/ forwarder System.Xml.Xsl.XsltMessageEncounteredEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F7*/ forwarder System.Xml.Xsl.XslTransform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F8*/ forwarder System.Xml.Xsl.XsltSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.Xml.dll
+// MVID: {cb971d95-565e-4ec6-a673-78c23853c07d}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FE0A1869000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/System.il
@@ -1,0 +1,3441 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd43
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00007000
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x00008ee6
+// Base of code:                   0x00002000
+// Base of data:                   0x0000a000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x0000e000
+// Size of headers:                0x00000200
+// Checksum:                       0x00011674
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x00008e94 [0x0000004f] address [size] of Import Directory:          
+// 0x0000a000 [0x00000490] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00007a00 [0x00003e90] address [size] of Security Directory:        
+// 0x0000c000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x00008d5c [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00006eec Virtual Size
+//              0x00002000 Virtual Address
+//              0x00007000 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x00000490 Virtual Size
+//              0x0000a000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00007200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x0000c000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00007800 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x00008000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000ee8
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x00008ed6 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00006c8c] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x00008cdc [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00002c60 Size
+//              '#~' Name
+//    Stream 2:
+//              0x00002ccc Offset
+//              0x00003e3c Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x00006b08 Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00006b0c Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00006b1c Offset
+//              0x00000170 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 47248
+// PE header size       : 512 (496 used)    ( 1.08%)
+// PE additional info   : 17383             (36.79%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.15%)
+// CLR meta-data size  : 27788              (58.81%)
+// CLR additional info : 128                ( 0.27%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 4.33%)
+// Unaccounted          : -683              (-1.45%)
+
+// Num.of PE sections   : 3
+//   .text    - 28672
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 27788
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    2 (40 bytes)
+//   ExportedType  -  784 (10976 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       - 15929 bytes
+//   Blobs         -   368 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   169 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly extern /*23000002*/ System.CodeDom
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 4:0:0:0
+}
+.assembly /*20000001*/ System
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 06 53 79 73 74 65 6D 00 00 )                // ...System..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 06 53 79 73 74 65 6D 00 00 )                // ...System..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 06 53 79 73 74 65 6D 00 00 )                // ...System..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder Microsoft.CSharp.CSharpCodeProvider
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000002*/ forwarder Microsoft.VisualBasic.VBCodeProvider
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000003*/ forwarder Microsoft.Win32.SafeHandles.SafeProcessHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000004*/ forwarder Microsoft.Win32.SafeHandles.SafeX509ChainHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000005*/ forwarder System.FileStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000006*/ forwarder System.FtpStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000007*/ forwarder System.GenericUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000008*/ forwarder System.GenericUriParserOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000009*/ forwarder System.GopherStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder System.HttpStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder System.LdapStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000C*/ forwarder System.NetPipeStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder System.NetTcpStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder System.NewsStyleUriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder System.Uri
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000010*/ forwarder System.UriBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.UriComponents
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.UriFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.UriFormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.UriHostNameType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.UriKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.UriParser
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.UriPartial
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.UriTypeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.CodeDom.CodeArgumentReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001A*/ forwarder System.CodeDom.CodeArrayCreateExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001B*/ forwarder System.CodeDom.CodeArrayIndexerExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001C*/ forwarder System.CodeDom.CodeAssignStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001D*/ forwarder System.CodeDom.CodeAttachEventStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001E*/ forwarder System.CodeDom.CodeAttributeArgument
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700001F*/ forwarder System.CodeDom.CodeAttributeArgumentCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000020*/ forwarder System.CodeDom.CodeAttributeDeclaration
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000021*/ forwarder System.CodeDom.CodeAttributeDeclarationCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000022*/ forwarder System.CodeDom.CodeBaseReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000023*/ forwarder System.CodeDom.CodeBinaryOperatorExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000024*/ forwarder System.CodeDom.CodeBinaryOperatorType
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000025*/ forwarder System.CodeDom.CodeCastExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000026*/ forwarder System.CodeDom.CodeCatchClause
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000027*/ forwarder System.CodeDom.CodeCatchClauseCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000028*/ forwarder System.CodeDom.CodeChecksumPragma
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000029*/ forwarder System.CodeDom.CodeComment
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002A*/ forwarder System.CodeDom.CodeCommentStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002B*/ forwarder System.CodeDom.CodeCommentStatementCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002C*/ forwarder System.CodeDom.CodeCompileUnit
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002D*/ forwarder System.CodeDom.CodeConditionStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002E*/ forwarder System.CodeDom.CodeConstructor
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700002F*/ forwarder System.CodeDom.CodeDefaultValueExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000030*/ forwarder System.CodeDom.CodeDelegateCreateExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000031*/ forwarder System.CodeDom.CodeDelegateInvokeExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000032*/ forwarder System.CodeDom.CodeDirectionExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000033*/ forwarder System.CodeDom.CodeDirective
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000034*/ forwarder System.CodeDom.CodeDirectiveCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000035*/ forwarder System.CodeDom.CodeEntryPointMethod
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000036*/ forwarder System.CodeDom.CodeEventReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000037*/ forwarder System.CodeDom.CodeExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000038*/ forwarder System.CodeDom.CodeExpressionCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000039*/ forwarder System.CodeDom.CodeExpressionStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003A*/ forwarder System.CodeDom.CodeFieldReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003B*/ forwarder System.CodeDom.CodeGotoStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003C*/ forwarder System.CodeDom.CodeIndexerExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003D*/ forwarder System.CodeDom.CodeIterationStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003E*/ forwarder System.CodeDom.CodeLabeledStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700003F*/ forwarder System.CodeDom.CodeLinePragma
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000040*/ forwarder System.CodeDom.CodeMemberEvent
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000041*/ forwarder System.CodeDom.CodeMemberField
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000042*/ forwarder System.CodeDom.CodeMemberMethod
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000043*/ forwarder System.CodeDom.CodeMemberProperty
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000044*/ forwarder System.CodeDom.CodeMethodInvokeExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000045*/ forwarder System.CodeDom.CodeMethodReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000046*/ forwarder System.CodeDom.CodeMethodReturnStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000047*/ forwarder System.CodeDom.CodeNamespace
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000048*/ forwarder System.CodeDom.CodeNamespaceCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000049*/ forwarder System.CodeDom.CodeNamespaceImport
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004A*/ forwarder System.CodeDom.CodeNamespaceImportCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004B*/ forwarder System.CodeDom.CodeObject
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004C*/ forwarder System.CodeDom.CodeObjectCreateExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004D*/ forwarder System.CodeDom.CodeParameterDeclarationExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004E*/ forwarder System.CodeDom.CodeParameterDeclarationExpressionCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700004F*/ forwarder System.CodeDom.CodePrimitiveExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000050*/ forwarder System.CodeDom.CodePropertyReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000051*/ forwarder System.CodeDom.CodePropertySetValueReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000052*/ forwarder System.CodeDom.CodeRegionDirective
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000053*/ forwarder System.CodeDom.CodeRegionMode
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000054*/ forwarder System.CodeDom.CodeRemoveEventStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000055*/ forwarder System.CodeDom.CodeSnippetCompileUnit
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000056*/ forwarder System.CodeDom.CodeSnippetExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000057*/ forwarder System.CodeDom.CodeSnippetStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000058*/ forwarder System.CodeDom.CodeSnippetTypeMember
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000059*/ forwarder System.CodeDom.CodeStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005A*/ forwarder System.CodeDom.CodeStatementCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005B*/ forwarder System.CodeDom.CodeThisReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005C*/ forwarder System.CodeDom.CodeThrowExceptionStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005D*/ forwarder System.CodeDom.CodeTryCatchFinallyStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005E*/ forwarder System.CodeDom.CodeTypeConstructor
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700005F*/ forwarder System.CodeDom.CodeTypeDeclaration
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000060*/ forwarder System.CodeDom.CodeTypeDeclarationCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000061*/ forwarder System.CodeDom.CodeTypeDelegate
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000062*/ forwarder System.CodeDom.CodeTypeMember
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000063*/ forwarder System.CodeDom.CodeTypeMemberCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000064*/ forwarder System.CodeDom.CodeTypeOfExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000065*/ forwarder System.CodeDom.CodeTypeParameter
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000066*/ forwarder System.CodeDom.CodeTypeParameterCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000067*/ forwarder System.CodeDom.CodeTypeReference
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000068*/ forwarder System.CodeDom.CodeTypeReferenceCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000069*/ forwarder System.CodeDom.CodeTypeReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006A*/ forwarder System.CodeDom.CodeTypeReferenceOptions
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006B*/ forwarder System.CodeDom.CodeVariableDeclarationStatement
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006C*/ forwarder System.CodeDom.CodeVariableReferenceExpression
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006D*/ forwarder System.CodeDom.FieldDirection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006E*/ forwarder System.CodeDom.MemberAttributes
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700006F*/ forwarder System.CodeDom.Compiler.CodeCompiler
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000070*/ forwarder System.CodeDom.Compiler.CodeDomProvider
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000071*/ forwarder System.CodeDom.Compiler.CodeGenerator
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000072*/ forwarder System.CodeDom.Compiler.CodeGeneratorOptions
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000073*/ forwarder System.CodeDom.Compiler.CodeParser
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000074*/ forwarder System.CodeDom.Compiler.CompilerError
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000075*/ forwarder System.CodeDom.Compiler.CompilerErrorCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000076*/ forwarder System.CodeDom.Compiler.CompilerInfo
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000077*/ forwarder System.CodeDom.Compiler.CompilerParameters
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000078*/ forwarder System.CodeDom.Compiler.CompilerResults
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000079*/ forwarder System.CodeDom.Compiler.Executor
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700007A*/ forwarder System.CodeDom.Compiler.GeneratedCodeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.CodeDom.Compiler.GeneratorSupport
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700007C*/ forwarder System.CodeDom.Compiler.ICodeCompiler
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700007D*/ forwarder System.CodeDom.Compiler.ICodeGenerator
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700007E*/ forwarder System.CodeDom.Compiler.ICodeParser
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*2700007F*/ forwarder System.CodeDom.Compiler.IndentedTextWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.CodeDom.Compiler.LanguageOptions
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000081*/ forwarder System.CodeDom.Compiler.TempFileCollection
+{
+  .assembly extern System.CodeDom /*23000002*/ 
+}
+.class extern /*27000082*/ forwarder System.Collections.Concurrent.BlockingCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.Collections.Concurrent.ConcurrentBag`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ forwarder System.Collections.Generic.ISet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000085*/ forwarder System.Collections.Generic.LinkedListNode`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000086*/ forwarder System.Collections.Generic.LinkedList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ Enumerator
+{
+  .class extern System.Collections.Generic.LinkedList`1 /*27000086*/ 
+}
+.class extern /*27000088*/ forwarder System.Collections.Generic.Queue`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ Enumerator
+{
+  .class extern System.Collections.Generic.Queue`1 /*27000088*/ 
+}
+.class extern /*2700008A*/ forwarder System.Collections.Generic.SortedDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*2700008A*/ 
+}
+.class extern /*2700008C*/ KeyCollection
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*2700008A*/ 
+}
+.class extern /*2700008D*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2/KeyCollection /*2700008C*/ 
+}
+.class extern /*2700008E*/ ValueCollection
+{
+  .class extern System.Collections.Generic.SortedDictionary`2 /*2700008A*/ 
+}
+.class extern /*2700008F*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedDictionary`2/ValueCollection /*2700008E*/ 
+}
+.class extern /*27000090*/ forwarder System.Collections.Generic.SortedList`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.Collections.Generic.SortedSet`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ Enumerator
+{
+  .class extern System.Collections.Generic.SortedSet`1 /*27000091*/ 
+}
+.class extern /*27000093*/ forwarder System.Collections.Generic.Stack`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ Enumerator
+{
+  .class extern System.Collections.Generic.Stack`1 /*27000093*/ 
+}
+.class extern /*27000095*/ forwarder System.Collections.ObjectModel.ObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.Collections.ObjectModel.ReadOnlyObservableCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.Collections.Specialized.BitVector32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000098*/ Section
+{
+  .class extern System.Collections.Specialized.BitVector32 /*27000097*/ 
+}
+.class extern /*27000099*/ forwarder System.Collections.Specialized.CollectionsUtil
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009A*/ forwarder System.Collections.Specialized.HybridDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009B*/ forwarder System.Collections.Specialized.INotifyCollectionChanged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009C*/ forwarder System.Collections.Specialized.IOrderedDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009D*/ forwarder System.Collections.Specialized.ListDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009E*/ forwarder System.Collections.Specialized.NameObjectCollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009F*/ KeysCollection
+{
+  .class extern System.Collections.Specialized.NameObjectCollectionBase /*2700009E*/ 
+}
+.class extern /*270000A0*/ forwarder System.Collections.Specialized.NameValueCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A1*/ forwarder System.Collections.Specialized.NotifyCollectionChangedAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A2*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A3*/ forwarder System.Collections.Specialized.NotifyCollectionChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A4*/ forwarder System.Collections.Specialized.OrderedDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A5*/ forwarder System.Collections.Specialized.StringCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A6*/ forwarder System.Collections.Specialized.StringDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A7*/ forwarder System.Collections.Specialized.StringEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A8*/ forwarder System.ComponentModel.AddingNewEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A9*/ forwarder System.ComponentModel.AddingNewEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AA*/ forwarder System.ComponentModel.AmbientValueAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AB*/ forwarder System.ComponentModel.ArrayConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AC*/ forwarder System.ComponentModel.AsyncCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AD*/ forwarder System.ComponentModel.AsyncCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AE*/ forwarder System.ComponentModel.AsyncOperation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AF*/ forwarder System.ComponentModel.AsyncOperationManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B0*/ forwarder System.ComponentModel.AttributeCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B1*/ forwarder System.ComponentModel.AttributeProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B2*/ forwarder System.ComponentModel.BackgroundWorker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B3*/ forwarder System.ComponentModel.BaseNumberConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B4*/ forwarder System.ComponentModel.BindableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B5*/ forwarder System.ComponentModel.BindableSupport
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B6*/ forwarder System.ComponentModel.BindingDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B7*/ forwarder System.ComponentModel.BindingList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B8*/ forwarder System.ComponentModel.BooleanConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B9*/ forwarder System.ComponentModel.BrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BA*/ forwarder System.ComponentModel.ByteConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BB*/ forwarder System.ComponentModel.CancelEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BC*/ forwarder System.ComponentModel.CancelEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BD*/ forwarder System.ComponentModel.CategoryAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BE*/ forwarder System.ComponentModel.CharConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BF*/ forwarder System.ComponentModel.CollectionChangeAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C0*/ forwarder System.ComponentModel.CollectionChangeEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C1*/ forwarder System.ComponentModel.CollectionChangeEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C2*/ forwarder System.ComponentModel.CollectionConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C3*/ forwarder System.ComponentModel.ComplexBindingPropertiesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C4*/ forwarder System.ComponentModel.Component
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C5*/ forwarder System.ComponentModel.ComponentCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C6*/ forwarder System.ComponentModel.ComponentConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C7*/ forwarder System.ComponentModel.ComponentEditor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C8*/ forwarder System.ComponentModel.ComponentResourceManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C9*/ forwarder System.ComponentModel.Container
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CA*/ forwarder System.ComponentModel.ContainerFilterService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CB*/ forwarder System.ComponentModel.CultureInfoConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CC*/ forwarder System.ComponentModel.CustomTypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CD*/ forwarder System.ComponentModel.DataErrorsChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CE*/ forwarder System.ComponentModel.DataObjectAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CF*/ forwarder System.ComponentModel.DataObjectFieldAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D0*/ forwarder System.ComponentModel.DataObjectMethodAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D1*/ forwarder System.ComponentModel.DataObjectMethodType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D2*/ forwarder System.ComponentModel.DateTimeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D3*/ forwarder System.ComponentModel.DateTimeOffsetConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D4*/ forwarder System.ComponentModel.DecimalConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D5*/ forwarder System.ComponentModel.DefaultBindingPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D6*/ forwarder System.ComponentModel.DefaultEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D7*/ forwarder System.ComponentModel.DefaultPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D8*/ forwarder System.ComponentModel.DefaultValueAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D9*/ forwarder System.ComponentModel.DescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DA*/ forwarder System.ComponentModel.DesignerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DB*/ forwarder System.ComponentModel.DesignerCategoryAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DC*/ forwarder System.ComponentModel.DesignerSerializationVisibility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DD*/ forwarder System.ComponentModel.DesignerSerializationVisibilityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DE*/ forwarder System.ComponentModel.DesignOnlyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DF*/ forwarder System.ComponentModel.DesignTimeVisibleAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E0*/ forwarder System.ComponentModel.DisplayNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E1*/ forwarder System.ComponentModel.DoubleConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E2*/ forwarder System.ComponentModel.DoWorkEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E3*/ forwarder System.ComponentModel.DoWorkEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E4*/ forwarder System.ComponentModel.EditorAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E5*/ forwarder System.ComponentModel.EditorBrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E6*/ forwarder System.ComponentModel.EditorBrowsableState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E7*/ forwarder System.ComponentModel.EnumConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E8*/ forwarder System.ComponentModel.EventDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E9*/ forwarder System.ComponentModel.EventDescriptorCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EA*/ forwarder System.ComponentModel.EventHandlerList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EB*/ forwarder System.ComponentModel.ExpandableObjectConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EC*/ forwarder System.ComponentModel.ExtenderProvidedPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000ED*/ forwarder System.ComponentModel.GuidConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EE*/ forwarder System.ComponentModel.HandledEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EF*/ forwarder System.ComponentModel.HandledEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F0*/ forwarder System.ComponentModel.IBindingList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F1*/ forwarder System.ComponentModel.IBindingListView
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F2*/ forwarder System.ComponentModel.ICancelAddNew
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F3*/ forwarder System.ComponentModel.IChangeTracking
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F4*/ forwarder System.ComponentModel.IComNativeDescriptorHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F5*/ forwarder System.ComponentModel.IComponent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F6*/ forwarder System.ComponentModel.IContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F7*/ forwarder System.ComponentModel.ICustomTypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F8*/ forwarder System.ComponentModel.IDataErrorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F9*/ forwarder System.ComponentModel.IEditableObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FA*/ forwarder System.ComponentModel.IExtenderProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FB*/ forwarder System.ComponentModel.IIntellisenseBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FC*/ forwarder System.ComponentModel.IListSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FD*/ forwarder System.ComponentModel.ImmutableObjectAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FE*/ forwarder System.ComponentModel.INestedContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FF*/ forwarder System.ComponentModel.INestedSite
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000100*/ forwarder System.ComponentModel.InheritanceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000101*/ forwarder System.ComponentModel.InheritanceLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000102*/ forwarder System.ComponentModel.InitializationEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000103*/ forwarder System.ComponentModel.INotifyDataErrorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000104*/ forwarder System.ComponentModel.INotifyPropertyChanged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000105*/ forwarder System.ComponentModel.INotifyPropertyChanging
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000106*/ forwarder System.ComponentModel.InstallerTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000107*/ forwarder System.ComponentModel.InstanceCreationEditor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000108*/ forwarder System.ComponentModel.Int16Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000109*/ forwarder System.ComponentModel.Int32Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010A*/ forwarder System.ComponentModel.Int64Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010B*/ forwarder System.ComponentModel.InvalidAsynchronousStateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010C*/ forwarder System.ComponentModel.InvalidEnumArgumentException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010D*/ forwarder System.ComponentModel.IRaiseItemChangedEvents
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010E*/ forwarder System.ComponentModel.IRevertibleChangeTracking
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010F*/ forwarder System.ComponentModel.ISite
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000110*/ forwarder System.ComponentModel.ISupportInitialize
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000111*/ forwarder System.ComponentModel.ISupportInitializeNotification
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000112*/ forwarder System.ComponentModel.ISynchronizeInvoke
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000113*/ forwarder System.ComponentModel.ITypeDescriptorContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000114*/ forwarder System.ComponentModel.ITypedList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000115*/ forwarder System.ComponentModel.License
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000116*/ forwarder System.ComponentModel.LicenseContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000117*/ forwarder System.ComponentModel.LicenseException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000118*/ forwarder System.ComponentModel.LicenseManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000119*/ forwarder System.ComponentModel.LicenseProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011A*/ forwarder System.ComponentModel.LicenseProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011B*/ forwarder System.ComponentModel.LicenseUsageMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011C*/ forwarder System.ComponentModel.LicFileLicenseProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011D*/ forwarder System.ComponentModel.ListBindableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011E*/ forwarder System.ComponentModel.ListChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011F*/ forwarder System.ComponentModel.ListChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000120*/ forwarder System.ComponentModel.ListChangedType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000121*/ forwarder System.ComponentModel.ListSortDescription
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000122*/ forwarder System.ComponentModel.ListSortDescriptionCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000123*/ forwarder System.ComponentModel.ListSortDirection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000124*/ forwarder System.ComponentModel.LocalizableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000125*/ forwarder System.ComponentModel.LookupBindingPropertiesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000126*/ forwarder System.ComponentModel.MarshalByValueComponent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000127*/ forwarder System.ComponentModel.MaskedTextProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000128*/ forwarder System.ComponentModel.MaskedTextResultHint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000129*/ forwarder System.ComponentModel.MemberDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012A*/ forwarder System.ComponentModel.MergablePropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012B*/ forwarder System.ComponentModel.MultilineStringConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012C*/ forwarder System.ComponentModel.NestedContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012D*/ forwarder System.ComponentModel.NotifyParentPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012E*/ forwarder System.ComponentModel.NullableConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012F*/ forwarder System.ComponentModel.ParenthesizePropertyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000130*/ forwarder System.ComponentModel.PasswordPropertyTextAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000131*/ forwarder System.ComponentModel.ProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000132*/ forwarder System.ComponentModel.ProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000133*/ forwarder System.ComponentModel.PropertyChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000134*/ forwarder System.ComponentModel.PropertyChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000135*/ forwarder System.ComponentModel.PropertyChangingEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000136*/ forwarder System.ComponentModel.PropertyChangingEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000137*/ forwarder System.ComponentModel.PropertyDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000138*/ forwarder System.ComponentModel.PropertyDescriptorCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000139*/ forwarder System.ComponentModel.PropertyTabAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013A*/ forwarder System.ComponentModel.PropertyTabScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013B*/ forwarder System.ComponentModel.ProvidePropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013C*/ forwarder System.ComponentModel.ReadOnlyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013D*/ forwarder System.ComponentModel.RecommendedAsConfigurableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013E*/ forwarder System.ComponentModel.ReferenceConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013F*/ forwarder System.ComponentModel.RefreshEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000140*/ forwarder System.ComponentModel.RefreshEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000141*/ forwarder System.ComponentModel.RefreshProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000142*/ forwarder System.ComponentModel.RefreshPropertiesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000143*/ forwarder System.ComponentModel.RunInstallerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000144*/ forwarder System.ComponentModel.RunWorkerCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000145*/ forwarder System.ComponentModel.RunWorkerCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000146*/ forwarder System.ComponentModel.SByteConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000147*/ forwarder System.ComponentModel.SettingsBindableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000148*/ forwarder System.ComponentModel.SingleConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000149*/ forwarder System.ComponentModel.StringConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014A*/ forwarder System.ComponentModel.SyntaxCheck
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014B*/ forwarder System.ComponentModel.TimeSpanConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014C*/ forwarder System.ComponentModel.ToolboxItemAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014D*/ forwarder System.ComponentModel.ToolboxItemFilterAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014E*/ forwarder System.ComponentModel.ToolboxItemFilterType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014F*/ forwarder System.ComponentModel.TypeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000150*/ SimplePropertyDescriptor
+{
+  .class extern System.ComponentModel.TypeConverter /*2700014F*/ 
+}
+.class extern /*27000151*/ StandardValuesCollection
+{
+  .class extern System.ComponentModel.TypeConverter /*2700014F*/ 
+}
+.class extern /*27000152*/ forwarder System.ComponentModel.TypeConverterAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000153*/ forwarder System.ComponentModel.TypeDescriptionProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000154*/ forwarder System.ComponentModel.TypeDescriptionProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000155*/ forwarder System.ComponentModel.TypeDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000156*/ forwarder System.ComponentModel.TypeListConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000157*/ forwarder System.ComponentModel.UInt16Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000158*/ forwarder System.ComponentModel.UInt32Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000159*/ forwarder System.ComponentModel.UInt64Converter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015A*/ forwarder System.ComponentModel.WarningException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015B*/ forwarder System.ComponentModel.Win32Exception
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015C*/ forwarder System.ComponentModel.Design.ActiveDesignerEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015D*/ forwarder System.ComponentModel.Design.ActiveDesignerEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015E*/ forwarder System.ComponentModel.Design.CheckoutException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015F*/ forwarder System.ComponentModel.Design.CommandID
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000160*/ forwarder System.ComponentModel.Design.ComponentChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000161*/ forwarder System.ComponentModel.Design.ComponentChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000162*/ forwarder System.ComponentModel.Design.ComponentChangingEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000163*/ forwarder System.ComponentModel.Design.ComponentChangingEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000164*/ forwarder System.ComponentModel.Design.ComponentEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000165*/ forwarder System.ComponentModel.Design.ComponentEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000166*/ forwarder System.ComponentModel.Design.ComponentRenameEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000167*/ forwarder System.ComponentModel.Design.ComponentRenameEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000168*/ forwarder System.ComponentModel.Design.DesignerCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000169*/ forwarder System.ComponentModel.Design.DesignerEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016A*/ forwarder System.ComponentModel.Design.DesignerEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016B*/ forwarder System.ComponentModel.Design.DesignerOptionService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016C*/ DesignerOptionCollection
+{
+  .class extern System.ComponentModel.Design.DesignerOptionService /*2700016B*/ 
+}
+.class extern /*2700016D*/ forwarder System.ComponentModel.Design.DesignerTransaction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016E*/ forwarder System.ComponentModel.Design.DesignerTransactionCloseEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016F*/ forwarder System.ComponentModel.Design.DesignerTransactionCloseEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000170*/ forwarder System.ComponentModel.Design.DesignerVerb
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000171*/ forwarder System.ComponentModel.Design.DesignerVerbCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000172*/ forwarder System.ComponentModel.Design.DesigntimeLicenseContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000173*/ forwarder System.ComponentModel.Design.DesigntimeLicenseContextSerializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000174*/ forwarder System.ComponentModel.Design.HelpContextType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000175*/ forwarder System.ComponentModel.Design.HelpKeywordAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000176*/ forwarder System.ComponentModel.Design.HelpKeywordType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000177*/ forwarder System.ComponentModel.Design.IComponentChangeService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000178*/ forwarder System.ComponentModel.Design.IComponentDiscoveryService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000179*/ forwarder System.ComponentModel.Design.IComponentInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017A*/ forwarder System.ComponentModel.Design.IDesigner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017B*/ forwarder System.ComponentModel.Design.IDesignerEventService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017C*/ forwarder System.ComponentModel.Design.IDesignerFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017D*/ forwarder System.ComponentModel.Design.IDesignerHost
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017E*/ forwarder System.ComponentModel.Design.IDesignerHostTransactionState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017F*/ forwarder System.ComponentModel.Design.IDesignerOptionService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000180*/ forwarder System.ComponentModel.Design.IDictionaryService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000181*/ forwarder System.ComponentModel.Design.IEventBindingService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000182*/ forwarder System.ComponentModel.Design.IExtenderListService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000183*/ forwarder System.ComponentModel.Design.IExtenderProviderService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000184*/ forwarder System.ComponentModel.Design.IHelpService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000185*/ forwarder System.ComponentModel.Design.IInheritanceService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000186*/ forwarder System.ComponentModel.Design.IMenuCommandService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000187*/ forwarder System.ComponentModel.Design.IReferenceService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000188*/ forwarder System.ComponentModel.Design.IResourceService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000189*/ forwarder System.ComponentModel.Design.IRootDesigner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018A*/ forwarder System.ComponentModel.Design.ISelectionService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018B*/ forwarder System.ComponentModel.Design.IServiceContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018C*/ forwarder System.ComponentModel.Design.ITreeDesigner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018D*/ forwarder System.ComponentModel.Design.ITypeDescriptorFilterService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018E*/ forwarder System.ComponentModel.Design.ITypeDiscoveryService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018F*/ forwarder System.ComponentModel.Design.ITypeResolutionService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000190*/ forwarder System.ComponentModel.Design.MenuCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000191*/ forwarder System.ComponentModel.Design.SelectionTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000192*/ forwarder System.ComponentModel.Design.ServiceContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000193*/ forwarder System.ComponentModel.Design.ServiceCreatorCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000194*/ forwarder System.ComponentModel.Design.StandardCommands
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000195*/ forwarder System.ComponentModel.Design.StandardToolWindows
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000196*/ forwarder System.ComponentModel.Design.TypeDescriptionProviderService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000197*/ forwarder System.ComponentModel.Design.ViewTechnology
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000198*/ forwarder System.ComponentModel.Design.Serialization.ComponentSerializationService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000199*/ forwarder System.ComponentModel.Design.Serialization.ContextStack
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019A*/ forwarder System.ComponentModel.Design.Serialization.DefaultSerializationProviderAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019B*/ forwarder System.ComponentModel.Design.Serialization.DesignerLoader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019C*/ forwarder System.ComponentModel.Design.Serialization.DesignerSerializerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019D*/ forwarder System.ComponentModel.Design.Serialization.IDesignerLoaderHost
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019E*/ forwarder System.ComponentModel.Design.Serialization.IDesignerLoaderHost2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019F*/ forwarder System.ComponentModel.Design.Serialization.IDesignerLoaderService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A0*/ forwarder System.ComponentModel.Design.Serialization.IDesignerSerializationManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A1*/ forwarder System.ComponentModel.Design.Serialization.IDesignerSerializationProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A2*/ forwarder System.ComponentModel.Design.Serialization.IDesignerSerializationService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A3*/ forwarder System.ComponentModel.Design.Serialization.INameCreationService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A4*/ forwarder System.ComponentModel.Design.Serialization.InstanceDescriptor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A5*/ forwarder System.ComponentModel.Design.Serialization.MemberRelationship
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A6*/ forwarder System.ComponentModel.Design.Serialization.MemberRelationshipService
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A7*/ forwarder System.ComponentModel.Design.Serialization.ResolveNameEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A8*/ forwarder System.ComponentModel.Design.Serialization.ResolveNameEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A9*/ forwarder System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AA*/ forwarder System.ComponentModel.Design.Serialization.SerializationStore
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AB*/ forwarder System.Diagnostics.BooleanSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AC*/ forwarder System.Diagnostics.CorrelationManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AD*/ forwarder System.Diagnostics.DataReceivedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AE*/ forwarder System.Diagnostics.DataReceivedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AF*/ forwarder System.Diagnostics.Debug
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B0*/ forwarder System.Diagnostics.DefaultTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B1*/ forwarder System.Diagnostics.DelimitedListTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B2*/ forwarder System.Diagnostics.EventTypeFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B3*/ forwarder System.Diagnostics.FileVersionInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B4*/ forwarder System.Diagnostics.MonitoringDescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B5*/ forwarder System.Diagnostics.Process
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B6*/ forwarder System.Diagnostics.ProcessModule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B7*/ forwarder System.Diagnostics.ProcessModuleCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B8*/ forwarder System.Diagnostics.ProcessPriorityClass
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B9*/ forwarder System.Diagnostics.ProcessStartInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BA*/ forwarder System.Diagnostics.ProcessThread
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BB*/ forwarder System.Diagnostics.ProcessThreadCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BC*/ forwarder System.Diagnostics.ProcessWindowStyle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BD*/ forwarder System.Diagnostics.SourceFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BE*/ forwarder System.Diagnostics.SourceLevels
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BF*/ forwarder System.Diagnostics.SourceSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C0*/ forwarder System.Diagnostics.Stopwatch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C1*/ forwarder System.Diagnostics.Switch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C2*/ forwarder System.Diagnostics.SwitchAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C3*/ forwarder System.Diagnostics.SwitchLevelAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C4*/ forwarder System.Diagnostics.TextWriterTraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C5*/ forwarder System.Diagnostics.ThreadPriorityLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C6*/ forwarder System.Diagnostics.ThreadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C7*/ forwarder System.Diagnostics.ThreadWaitReason
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C8*/ forwarder System.Diagnostics.Trace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C9*/ forwarder System.Diagnostics.TraceEventCache
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CA*/ forwarder System.Diagnostics.TraceEventType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CB*/ forwarder System.Diagnostics.TraceFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CC*/ forwarder System.Diagnostics.TraceLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CD*/ forwarder System.Diagnostics.TraceListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CE*/ forwarder System.Diagnostics.TraceListenerCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CF*/ forwarder System.Diagnostics.TraceOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D0*/ forwarder System.Diagnostics.TraceSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D1*/ forwarder System.Diagnostics.TraceSwitch
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D2*/ forwarder System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D3*/ forwarder System.IO.ErrorEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D4*/ forwarder System.IO.ErrorEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D5*/ forwarder System.IO.FileSystemEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D6*/ forwarder System.IO.FileSystemEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D7*/ forwarder System.IO.FileSystemWatcher
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D8*/ forwarder System.IO.InternalBufferOverflowException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D9*/ forwarder System.IO.InvalidDataException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DA*/ forwarder System.IO.NotifyFilters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DB*/ forwarder System.IO.RenamedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DC*/ forwarder System.IO.RenamedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DD*/ forwarder System.IO.WaitForChangedResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DE*/ forwarder System.IO.WatcherChangeTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DF*/ forwarder System.IO.Compression.CompressionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E0*/ forwarder System.IO.Compression.CompressionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E1*/ forwarder System.IO.Compression.DeflateStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E2*/ forwarder System.IO.Compression.GZipStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E3*/ forwarder System.Net.AuthenticationManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E4*/ forwarder System.Net.AuthenticationSchemes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E5*/ forwarder System.Net.AuthenticationSchemeSelector
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E6*/ forwarder System.Net.Authorization
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E7*/ forwarder System.Net.BindIPEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E8*/ forwarder System.Net.Cookie
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E9*/ forwarder System.Net.CookieCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EA*/ forwarder System.Net.CookieContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EB*/ forwarder System.Net.CookieException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EC*/ forwarder System.Net.CredentialCache
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001ED*/ forwarder System.Net.DecompressionMethods
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EE*/ forwarder System.Net.Dns
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EF*/ forwarder System.Net.DnsEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F0*/ forwarder System.Net.DownloadDataCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F1*/ forwarder System.Net.DownloadDataCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F2*/ forwarder System.Net.DownloadProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F3*/ forwarder System.Net.DownloadProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F4*/ forwarder System.Net.DownloadStringCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F5*/ forwarder System.Net.DownloadStringCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F6*/ forwarder System.Net.EndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F7*/ forwarder System.Net.FileWebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F8*/ forwarder System.Net.FileWebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F9*/ forwarder System.Net.FtpStatusCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FA*/ forwarder System.Net.FtpWebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FB*/ forwarder System.Net.FtpWebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FC*/ forwarder System.Net.GlobalProxySelection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FD*/ forwarder System.Net.HttpContinueDelegate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FE*/ forwarder System.Net.HttpListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FF*/ ExtendedProtectionSelector
+{
+  .class extern System.Net.HttpListener /*270001FE*/ 
+}
+.class extern /*27000200*/ forwarder System.Net.HttpListenerBasicIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000201*/ forwarder System.Net.HttpListenerContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000202*/ forwarder System.Net.HttpListenerException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000203*/ forwarder System.Net.HttpListenerPrefixCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000204*/ forwarder System.Net.HttpListenerRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000205*/ forwarder System.Net.HttpListenerResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000206*/ forwarder System.Net.HttpListenerTimeoutManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000207*/ forwarder System.Net.HttpRequestHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000208*/ forwarder System.Net.HttpResponseHeader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000209*/ forwarder System.Net.HttpStatusCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020A*/ forwarder System.Net.HttpVersion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020B*/ forwarder System.Net.HttpWebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020C*/ forwarder System.Net.HttpWebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020D*/ forwarder System.Net.IAuthenticationModule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020E*/ forwarder System.Net.ICredentialPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020F*/ forwarder System.Net.ICredentials
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000210*/ forwarder System.Net.ICredentialsByHost
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000211*/ forwarder System.Net.IPAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000212*/ forwarder System.Net.IPEndPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000213*/ forwarder System.Net.IPHostEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000214*/ forwarder System.Net.IWebProxy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000215*/ forwarder System.Net.IWebProxyScript
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000216*/ forwarder System.Net.IWebRequestCreate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000217*/ forwarder System.Net.NetworkCredential
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000218*/ forwarder System.Net.OpenReadCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000219*/ forwarder System.Net.OpenReadCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021A*/ forwarder System.Net.OpenWriteCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021B*/ forwarder System.Net.OpenWriteCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021C*/ forwarder System.Net.ProtocolViolationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021D*/ forwarder System.Net.SecurityProtocolType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021E*/ forwarder System.Net.ServicePoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021F*/ forwarder System.Net.ServicePointManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000220*/ forwarder System.Net.SocketAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000221*/ forwarder System.Net.TransportContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000222*/ forwarder System.Net.UploadDataCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000223*/ forwarder System.Net.UploadDataCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000224*/ forwarder System.Net.UploadFileCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000225*/ forwarder System.Net.UploadFileCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000226*/ forwarder System.Net.UploadProgressChangedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000227*/ forwarder System.Net.UploadProgressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000228*/ forwarder System.Net.UploadStringCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000229*/ forwarder System.Net.UploadStringCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022A*/ forwarder System.Net.UploadValuesCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022B*/ forwarder System.Net.UploadValuesCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022C*/ forwarder System.Net.WebClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022D*/ forwarder System.Net.WebException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022E*/ forwarder System.Net.WebExceptionStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022F*/ forwarder System.Net.WebHeaderCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000230*/ forwarder System.Net.WebProxy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000231*/ forwarder System.Net.WebRequest
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000232*/ forwarder System.Net.WebRequestMethods
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000233*/ File
+{
+  .class extern System.Net.WebRequestMethods /*27000232*/ 
+}
+.class extern /*27000234*/ Ftp
+{
+  .class extern System.Net.WebRequestMethods /*27000232*/ 
+}
+.class extern /*27000235*/ Http
+{
+  .class extern System.Net.WebRequestMethods /*27000232*/ 
+}
+.class extern /*27000236*/ forwarder System.Net.WebResponse
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000237*/ forwarder System.Net.WebUtility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000238*/ forwarder System.Net.Cache.HttpCacheAgeControl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000239*/ forwarder System.Net.Cache.HttpRequestCacheLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023A*/ forwarder System.Net.Cache.HttpRequestCachePolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023B*/ forwarder System.Net.Cache.RequestCacheLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023C*/ forwarder System.Net.Cache.RequestCachePolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023D*/ forwarder System.Net.Mail.AlternateView
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023E*/ forwarder System.Net.Mail.AlternateViewCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023F*/ forwarder System.Net.Mail.Attachment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000240*/ forwarder System.Net.Mail.AttachmentBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000241*/ forwarder System.Net.Mail.AttachmentCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000242*/ forwarder System.Net.Mail.DeliveryNotificationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000243*/ forwarder System.Net.Mail.LinkedResource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000244*/ forwarder System.Net.Mail.LinkedResourceCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000245*/ forwarder System.Net.Mail.MailAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000246*/ forwarder System.Net.Mail.MailAddressCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000247*/ forwarder System.Net.Mail.MailMessage
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000248*/ forwarder System.Net.Mail.MailPriority
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000249*/ forwarder System.Net.Mail.SendCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024A*/ forwarder System.Net.Mail.SmtpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024B*/ forwarder System.Net.Mail.SmtpDeliveryFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024C*/ forwarder System.Net.Mail.SmtpDeliveryMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024D*/ forwarder System.Net.Mail.SmtpException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024E*/ forwarder System.Net.Mail.SmtpFailedRecipientException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024F*/ forwarder System.Net.Mail.SmtpFailedRecipientsException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000250*/ forwarder System.Net.Mail.SmtpStatusCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000251*/ forwarder System.Net.Mime.ContentDisposition
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000252*/ forwarder System.Net.Mime.ContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000253*/ forwarder System.Net.Mime.DispositionTypeNames
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000254*/ forwarder System.Net.Mime.MediaTypeNames
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000255*/ Application
+{
+  .class extern System.Net.Mime.MediaTypeNames /*27000254*/ 
+}
+.class extern /*27000256*/ Image
+{
+  .class extern System.Net.Mime.MediaTypeNames /*27000254*/ 
+}
+.class extern /*27000257*/ Text
+{
+  .class extern System.Net.Mime.MediaTypeNames /*27000254*/ 
+}
+.class extern /*27000258*/ forwarder System.Net.Mime.TransferEncoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000259*/ forwarder System.Net.NetworkInformation.DuplicateAddressDetectionState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025A*/ forwarder System.Net.NetworkInformation.GatewayIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025B*/ forwarder System.Net.NetworkInformation.GatewayIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025C*/ forwarder System.Net.NetworkInformation.IcmpV4Statistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025D*/ forwarder System.Net.NetworkInformation.IcmpV6Statistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025E*/ forwarder System.Net.NetworkInformation.IPAddressCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025F*/ forwarder System.Net.NetworkInformation.IPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000260*/ forwarder System.Net.NetworkInformation.IPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000261*/ forwarder System.Net.NetworkInformation.IPGlobalProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000262*/ forwarder System.Net.NetworkInformation.IPGlobalStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000263*/ forwarder System.Net.NetworkInformation.IPInterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000264*/ forwarder System.Net.NetworkInformation.IPInterfaceStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000265*/ forwarder System.Net.NetworkInformation.IPStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000266*/ forwarder System.Net.NetworkInformation.IPv4InterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000267*/ forwarder System.Net.NetworkInformation.IPv4InterfaceStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000268*/ forwarder System.Net.NetworkInformation.IPv6InterfaceProperties
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000269*/ forwarder System.Net.NetworkInformation.MulticastIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026A*/ forwarder System.Net.NetworkInformation.MulticastIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026B*/ forwarder System.Net.NetworkInformation.NetBiosNodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026C*/ forwarder System.Net.NetworkInformation.NetworkAddressChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026D*/ forwarder System.Net.NetworkInformation.NetworkAvailabilityChangedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026E*/ forwarder System.Net.NetworkInformation.NetworkAvailabilityEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026F*/ forwarder System.Net.NetworkInformation.NetworkChange
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000270*/ forwarder System.Net.NetworkInformation.NetworkInformationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000271*/ forwarder System.Net.NetworkInformation.NetworkInterface
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000272*/ forwarder System.Net.NetworkInformation.NetworkInterfaceComponent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000273*/ forwarder System.Net.NetworkInformation.NetworkInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000274*/ forwarder System.Net.NetworkInformation.OperationalStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000275*/ forwarder System.Net.NetworkInformation.PhysicalAddress
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000276*/ forwarder System.Net.NetworkInformation.Ping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000277*/ forwarder System.Net.NetworkInformation.PingCompletedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000278*/ forwarder System.Net.NetworkInformation.PingCompletedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000279*/ forwarder System.Net.NetworkInformation.PingException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027A*/ forwarder System.Net.NetworkInformation.PingOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027B*/ forwarder System.Net.NetworkInformation.PingReply
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027C*/ forwarder System.Net.NetworkInformation.PrefixOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027D*/ forwarder System.Net.NetworkInformation.ScopeLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027E*/ forwarder System.Net.NetworkInformation.SuffixOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027F*/ forwarder System.Net.NetworkInformation.TcpConnectionInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000280*/ forwarder System.Net.NetworkInformation.TcpState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000281*/ forwarder System.Net.NetworkInformation.TcpStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000282*/ forwarder System.Net.NetworkInformation.UdpStatistics
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000283*/ forwarder System.Net.NetworkInformation.UnicastIPAddressInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000284*/ forwarder System.Net.NetworkInformation.UnicastIPAddressInformationCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000285*/ forwarder System.Net.Security.AuthenticatedStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000286*/ forwarder System.Net.Security.AuthenticationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000287*/ forwarder System.Net.Security.EncryptionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000288*/ forwarder System.Net.Security.LocalCertificateSelectionCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000289*/ forwarder System.Net.Security.NegotiateStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028A*/ forwarder System.Net.Security.ProtectionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028B*/ forwarder System.Net.Security.RemoteCertificateValidationCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028C*/ forwarder System.Net.Security.SslPolicyErrors
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028D*/ forwarder System.Net.Security.SslStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028E*/ forwarder System.Net.Sockets.AddressFamily
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028F*/ forwarder System.Net.Sockets.IOControlCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000290*/ forwarder System.Net.Sockets.IPPacketInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000291*/ forwarder System.Net.Sockets.IPProtectionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000292*/ forwarder System.Net.Sockets.IPv6MulticastOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000293*/ forwarder System.Net.Sockets.LingerOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000294*/ forwarder System.Net.Sockets.MulticastOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000295*/ forwarder System.Net.Sockets.NetworkStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000296*/ forwarder System.Net.Sockets.ProtocolFamily
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000297*/ forwarder System.Net.Sockets.ProtocolType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000298*/ forwarder System.Net.Sockets.SelectMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000299*/ forwarder System.Net.Sockets.SendPacketsElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029A*/ forwarder System.Net.Sockets.Socket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029B*/ forwarder System.Net.Sockets.SocketAsyncEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029C*/ forwarder System.Net.Sockets.SocketAsyncOperation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029D*/ forwarder System.Net.Sockets.SocketError
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029E*/ forwarder System.Net.Sockets.SocketException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029F*/ forwarder System.Net.Sockets.SocketFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A0*/ forwarder System.Net.Sockets.SocketInformation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A1*/ forwarder System.Net.Sockets.SocketInformationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A2*/ forwarder System.Net.Sockets.SocketOptionLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A3*/ forwarder System.Net.Sockets.SocketOptionName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A4*/ forwarder System.Net.Sockets.SocketShutdown
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A5*/ forwarder System.Net.Sockets.SocketType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A6*/ forwarder System.Net.Sockets.TcpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A7*/ forwarder System.Net.Sockets.TcpListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A8*/ forwarder System.Net.Sockets.TransmitFileOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A9*/ forwarder System.Net.Sockets.UdpClient
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AA*/ forwarder System.Net.Sockets.UdpReceiveResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AB*/ forwarder System.Net.WebSockets.ClientWebSocket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AC*/ forwarder System.Net.WebSockets.ClientWebSocketOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AD*/ forwarder System.Net.WebSockets.HttpListenerWebSocketContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AE*/ forwarder System.Net.WebSockets.WebSocket
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AF*/ forwarder System.Net.WebSockets.WebSocketCloseStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B0*/ forwarder System.Net.WebSockets.WebSocketContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B1*/ forwarder System.Net.WebSockets.WebSocketError
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B2*/ forwarder System.Net.WebSockets.WebSocketException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B3*/ forwarder System.Net.WebSockets.WebSocketMessageType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B4*/ forwarder System.Net.WebSockets.WebSocketReceiveResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B5*/ forwarder System.Net.WebSockets.WebSocketState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B6*/ forwarder System.Runtime.InteropServices.DefaultParameterValueAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B7*/ forwarder System.Runtime.InteropServices.HandleCollector
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B8*/ forwarder System.Runtime.InteropServices.ComTypes.ADVF
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B9*/ forwarder System.Runtime.InteropServices.ComTypes.DATADIR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BA*/ forwarder System.Runtime.InteropServices.ComTypes.DVASPECT
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BB*/ forwarder System.Runtime.InteropServices.ComTypes.FORMATETC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BC*/ forwarder System.Runtime.InteropServices.ComTypes.IAdviseSink
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BD*/ forwarder System.Runtime.InteropServices.ComTypes.IDataObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BE*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumFORMATETC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BF*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumSTATDATA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C0*/ forwarder System.Runtime.InteropServices.ComTypes.STATDATA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C1*/ forwarder System.Runtime.InteropServices.ComTypes.STGMEDIUM
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C2*/ forwarder System.Runtime.InteropServices.ComTypes.TYMED
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C3*/ forwarder System.Runtime.Versioning.FrameworkName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C4*/ forwarder System.Security.Authentication.AuthenticationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C5*/ forwarder System.Security.Authentication.CipherAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C6*/ forwarder System.Security.Authentication.ExchangeAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C7*/ forwarder System.Security.Authentication.HashAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C8*/ forwarder System.Security.Authentication.InvalidCredentialException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C9*/ forwarder System.Security.Authentication.SslProtocols
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CA*/ forwarder System.Security.Authentication.ExtendedProtection.ChannelBinding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CB*/ forwarder System.Security.Authentication.ExtendedProtection.ChannelBindingKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CC*/ forwarder System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CD*/ forwarder System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicyTypeConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CE*/ forwarder System.Security.Authentication.ExtendedProtection.PolicyEnforcement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CF*/ forwarder System.Security.Authentication.ExtendedProtection.ProtectionScenario
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D0*/ forwarder System.Security.Authentication.ExtendedProtection.ServiceNameCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D1*/ forwarder System.Security.Cryptography.AsnEncodedData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D2*/ forwarder System.Security.Cryptography.AsnEncodedDataCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D3*/ forwarder System.Security.Cryptography.AsnEncodedDataEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D4*/ forwarder System.Security.Cryptography.Oid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D5*/ forwarder System.Security.Cryptography.OidCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D6*/ forwarder System.Security.Cryptography.OidEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D7*/ forwarder System.Security.Cryptography.OidGroup
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D8*/ forwarder System.Security.Cryptography.X509Certificates.OpenFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D9*/ forwarder System.Security.Cryptography.X509Certificates.PublicKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DA*/ forwarder System.Security.Cryptography.X509Certificates.StoreLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DB*/ forwarder System.Security.Cryptography.X509Certificates.StoreName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DC*/ forwarder System.Security.Cryptography.X509Certificates.X500DistinguishedName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DD*/ forwarder System.Security.Cryptography.X509Certificates.X500DistinguishedNameFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DE*/ forwarder System.Security.Cryptography.X509Certificates.X509BasicConstraintsExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DF*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E0*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E1*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E2*/ forwarder System.Security.Cryptography.X509Certificates.X509CertificateCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E3*/ X509CertificateEnumerator
+{
+  .class extern System.Security.Cryptography.X509Certificates.X509CertificateCollection /*270002E2*/ 
+}
+.class extern /*270002E4*/ forwarder System.Security.Cryptography.X509Certificates.X509Chain
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E5*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E6*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElementCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E7*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E8*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E9*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EA*/ forwarder System.Security.Cryptography.X509Certificates.X509ChainStatusFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EB*/ forwarder System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EC*/ forwarder System.Security.Cryptography.X509Certificates.X509Extension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002ED*/ forwarder System.Security.Cryptography.X509Certificates.X509ExtensionCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EE*/ forwarder System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EF*/ forwarder System.Security.Cryptography.X509Certificates.X509FindType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F0*/ forwarder System.Security.Cryptography.X509Certificates.X509IncludeOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F1*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyUsageExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F2*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyUsageFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F3*/ forwarder System.Security.Cryptography.X509Certificates.X509NameType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F4*/ forwarder System.Security.Cryptography.X509Certificates.X509RevocationFlag
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F5*/ forwarder System.Security.Cryptography.X509Certificates.X509RevocationMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F6*/ forwarder System.Security.Cryptography.X509Certificates.X509Store
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F7*/ forwarder System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierExtension
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F8*/ forwarder System.Security.Cryptography.X509Certificates.X509SubjectKeyIdentifierHashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F9*/ forwarder System.Security.Cryptography.X509Certificates.X509VerificationFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FA*/ forwarder System.Text.RegularExpressions.Capture
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FB*/ forwarder System.Text.RegularExpressions.CaptureCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FC*/ forwarder System.Text.RegularExpressions.Group
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FD*/ forwarder System.Text.RegularExpressions.GroupCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FE*/ forwarder System.Text.RegularExpressions.Match
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FF*/ forwarder System.Text.RegularExpressions.MatchCollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000300*/ forwarder System.Text.RegularExpressions.MatchEvaluator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000301*/ forwarder System.Text.RegularExpressions.Regex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000302*/ forwarder System.Text.RegularExpressions.RegexMatchTimeoutException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000303*/ forwarder System.Text.RegularExpressions.RegexOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000304*/ forwarder System.Text.RegularExpressions.RegexRunner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000305*/ forwarder System.Text.RegularExpressions.RegexRunnerFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000306*/ forwarder System.Threading.Barrier
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000307*/ forwarder System.Threading.BarrierPostPhaseException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000308*/ forwarder System.Threading.Semaphore
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000309*/ forwarder System.Threading.SemaphoreFullException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030A*/ forwarder System.Threading.ThreadExceptionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030B*/ forwarder System.Threading.ThreadExceptionEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030C*/ forwarder System.Timers.ElapsedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030D*/ forwarder System.Timers.ElapsedEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030E*/ forwarder System.Timers.Timer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030F*/ forwarder System.Timers.TimersDescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000310*/ forwarder System.Windows.Input.ICommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module System.dll
+// MVID: {73612301-a4c3-4af4-a84b-aebfa4dd83ed}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007F09EBF14000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/mscorlib.il
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/build/netstandard2.0/ref/mscorlib.il
@@ -1,0 +1,4627 @@
+
+//  Microsoft (R) .NET IL Disassembler.  Version 5.0.0
+
+
+// ----- DOS Header:
+// Magic:                      0x5a4d
+// Bytes on last page:         0x0090
+// Pages in file:              0x0003
+// Relocations:                0x0000
+// Size of header (paragraphs):0x0004
+// Min extra paragraphs:       0x0000
+// Max extra paragraphs:       0xffff
+// Initial (relative) SS:      0x0000
+// Initial SP:                 0x00b8
+// Checksum:                   0x0000
+// Initial IP:                 0x0000
+// Initial (relative) CS:      0x0000
+// File addr. of reloc table:  0x0040
+// Overlay number:             0x0000
+// OEM identifier:             0x0000
+// OEM info:                   0x0000
+// File addr. of COFF header:  0x0080
+// ----- COFF/PE Headers:
+// Signature:                  0x00004550
+// ----- COFF Header:
+// Machine:                    0x014c
+// Number of sections:         0x0003
+// Time-date stamp:            0x59b9bd40
+// Ptr to symbol table:        0x00000000
+// Number of symbols:          0x00000000
+// Size of optional header:    0x00e0
+// Characteristics:            0x2022
+// ----- PE Optional Header (32 bit):
+// Magic:                          0x010b
+// Major linker version:           0x30
+// Minor linker version:           0x00
+// Size of code:                   0x00008c00
+// Size of init.data:              0x00000800
+// Size of uninit.data:            0x00000000
+// Addr. of entry point:           0x0000aaf2
+// Base of code:                   0x00002000
+// Base of data:                   0x0000c000
+// Image base:                     0x10000000
+// Section alignment:              0x00002000
+// File alignment:                 0x00000200
+// Major OS version:               0x0004
+// Minor OS version:               0x0000
+// Major image version:            0x0000
+// Minor image version:            0x0000
+// Major subsystem version:        0x0004
+// Minor subsystem version:        0x0000
+// Size of image:                  0x00010000
+// Size of headers:                0x00000200
+// Checksum:                       0x0001a106
+// Subsystem:                      0x0003
+// DLL characteristics:            0x8540
+// Size of stack reserve:          0x00100000
+// Size of stack commit:           0x00001000
+// Size of heap reserve:           0x00100000
+// Size of heap commit:            0x00001000
+// Loader flags:                   0x00000000
+// Directories:                    0x00000010
+// 0x00000000 [0x00000000] address [size] of Export Directory:          
+// 0x0000aaa0 [0x0000004f] address [size] of Import Directory:          
+// 0x0000c000 [0x000004a0] address [size] of Resource Directory:        
+// 0x00000000 [0x00000000] address [size] of Exception Directory:       
+// 0x00009600 [0x00003e98] address [size] of Security Directory:        
+// 0x0000e000 [0x0000000c] address [size] of Base Relocation Table:     
+// 0x0000a968 [0x0000001c] address [size] of Debug Directory:           
+// 0x00000000 [0x00000000] address [size] of Architecture Specific:     
+// 0x00000000 [0x00000000] address [size] of Global Pointer:            
+// 0x00000000 [0x00000000] address [size] of TLS Directory:             
+// 0x00000000 [0x00000000] address [size] of Load Config Directory:     
+// 0x00000000 [0x00000000] address [size] of Bound Import Directory:    
+// 0x00002000 [0x00000008] address [size] of Import Address Table:      
+// 0x00000000 [0x00000000] address [size] of Delay Load IAT:            
+// 0x00002008 [0x00000048] address [size] of CLR Header:                
+
+
+// Image sections:
+//              .text
+//              0x00008af8 Virtual Size
+//              0x00002000 Virtual Address
+//              0x00008c00 Size of Raw Data
+//              0x00000200 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x60000020 Characteristics
+//                         CNT_CODE
+//                         MEM_EXECUTE
+//                         MEM_READ
+
+//              .rsrc
+//              0x000004a0 Virtual Size
+//              0x0000c000 Virtual Address
+//              0x00000600 Size of Raw Data
+//              0x00008e00 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x40000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_READ
+
+//              .reloc
+//              0x0000000c Virtual Size
+//              0x0000e000 Virtual Address
+//              0x00000200 Size of Raw Data
+//              0x00009400 Pointer to Raw Data
+//              0x00000000 Pointer to Relocations
+//              0x00000000 Pointer to Linenumbers
+//                  0x0000 Number of Relocations
+//                  0x0000 Number of Linenumbers
+//              0x42000040 Characteristics
+//                         CNT_INITIALIZED_DATA
+//                         MEM_DISCARDABLE
+//                         MEM_READ
+
+// Base Relocation Table
+//              0x0000a000 Page RVA
+//              0x0000000c Block Size
+//              0x00000002 Number of Entries
+//              Entry 1: Type 0x3 Offset 0x00000af4
+//              Entry 2: Type 0x0 Offset 0x00000000
+
+// Import Address Table
+//     DLL : mscoree.dll
+//              0x00002000 Import Address Table
+//              0x0000aae2 Import Name Table
+//              0          Time Date Stamp
+//              0          Index of First Forwarder Reference
+//
+//              0x0000  _CorDllMain
+
+// Delay Load Import Address Table
+// No data.
+
+// Entry point code:
+//FF 25 00 20 00 10 
+
+
+// ----- CLR Header:
+// Header size:                        0x00000048
+// Major runtime version:              0x0002
+// Minor runtime version:              0x0005
+// 0x00002050 [0x00008898] address [size] of Metadata Directory:        
+// Flags:                              0x00000009
+// Entry point token:                  0x00000000
+// 0x00000000 [0x00000000] address [size] of Resources Directory:       
+// 0x0000a8e8 [0x00000080] address [size] of Strong Name Signature:     
+// 0x00000000 [0x00000000] address [size] of CodeManager Table:         
+// 0x00000000 [0x00000000] address [size] of VTableFixups Directory:    
+// 0x00000000 [0x00000000] address [size] of Export Address Table:      
+// 0x00000000 [0x00000000] address [size] of Precompile Header:         
+
+// Metadata Header
+//    Storage Signature:
+//              0x424a5342 Signature
+//                  0x0001 Major Version
+//                  0x0001 Minor Version
+//              0x00000000 Extra Data Offset
+//              0x0000000c Version String Length
+//              'v4.0.30319' Version String
+//    Storage Header:
+//                    0x00 Flags
+//                  0x0005 Number of Streams
+//    Stream 1:
+//              0x0000006c Offset
+//              0x00003c9c Size
+//              '#~' Name
+//    Stream 2:
+//              0x00003d08 Offset
+//              0x00004a04 Size
+//              '#Strings' Name
+//    Stream 3:
+//              0x0000870c Offset
+//              0x00000004 Size
+//              '#US' Name
+//    Stream 4:
+//              0x00008710 Offset
+//              0x00000010 Size
+//              '#GUID' Name
+//    Stream 5:
+//              0x00008720 Offset
+//              0x00000178 Size
+//              '#Blob' Name
+
+//    Metadata Stream Header:
+//              0x00000000 Reserved
+//                    0x02 Major
+//                    0x00 Minor
+//                    0x00 Heaps
+//                    0x01 Rid
+//      0x0000008900001407 MaskValid
+//      0x000016003301fa00 Sorted
+
+// Code Manager Table:
+//  default
+
+
+// Export Address Table Jumps:
+// No data.
+
+// File size            : 54424
+// PE header size       : 512 (496 used)    ( 0.94%)
+// PE additional info   : 17407             (31.98%)
+// Num.of PE sections   : 3
+// CLR header size     : 72                 ( 0.13%)
+// CLR meta-data size  : 34968              (64.25%)
+// CLR additional info : 128                ( 0.24%)
+// CLR method headers  : 0                  ( 0.00%)
+// Managed code         : 0                 ( 0.00%)
+// Data                 : 2048              ( 3.76%)
+// Unaccounted          : -711              (-1.31%)
+
+// Num.of PE sections   : 3
+//   .text    - 35840
+//   .rsrc    - 1536
+//   .reloc   - 512
+
+// CLR meta-data size  : 34968
+//   Module        -    1 (10 bytes)
+//   TypeRef       -   14 (84 bytes)
+//   MemberRef     -   13 (78 bytes)
+//   CustomAttribute-   13 (78 bytes)
+//   Assembly      -    1 (22 bytes)
+//   AssemblyRef   -    4 (80 bytes)
+//   ExportedType  - 1078 (15092 bytes)
+//   TypeDef       -    1 (14 bytes)
+//   Strings       - 18948 bytes
+//   Blobs         -   376 bytes
+//   UserStrings   -     4 bytes
+//   Guids         -    16 bytes
+//   Uncategorized -   166 bytes
+
+// CLR additional info : 128
+
+// CLR method headers : 0
+//   Num.of method bodies  - 0
+//   Num.of fat headers    - 0
+//   Num.of tiny headers   - 0
+
+// Managed code : 0
+// No classes defined in this module
+
+// Metadata version: v4.0.30319
+.assembly extern /*23000001*/ netstandard
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )                         // .{...-.Q
+  .ver 2:0:0:0
+}
+.assembly extern /*23000002*/ Microsoft.Win32.Registry
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:1:0:0
+}
+.assembly extern /*23000003*/ System.Security.Principal.Windows
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:1:0:0
+}
+.assembly extern /*23000004*/ System.Security.AccessControl
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:1:0:0
+}
+.assembly /*20000001*/ mscorlib
+{
+  .custom /*0C000001:0A000001*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.CompilationRelaxationsAttribute/*01000001*/::.ctor(int32) /* 0A000001 */ = ( 01 00 08 00 00 00 00 00 ) 
+  .custom /*0C000002:0A000002*/ instance void [netstandard/*23000001*/]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute/*01000002*/::.ctor() /* 0A000002 */ = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom /*0C000003:0A000003*/ instance void [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*/::.ctor(valuetype [netstandard/*23000001*/]System.Diagnostics.DebuggableAttribute/*01000003*//DebuggingModes/*01000004*/) /* 0A000003 */ = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom /*0C000004:0A000004*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyTitleAttribute/*01000005*/::.ctor(string) /* 0A000004 */ = ( 01 00 08 6D 73 63 6F 72 6C 69 62 00 00 )          // ...mscorlib..
+  .custom /*0C000005:0A000005*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDescriptionAttribute/*01000006*/::.ctor(string) /* 0A000005 */ = ( 01 00 08 6D 73 63 6F 72 6C 69 62 00 00 )          // ...mscorlib..
+  .custom /*0C000006:0A000006*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyDefaultAliasAttribute/*01000007*/::.ctor(string) /* 0A000006 */ = ( 01 00 08 6D 73 63 6F 72 6C 69 62 00 00 )          // ...mscorlib..
+  .custom /*0C000007:0A000007*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCompanyAttribute/*01000008*/::.ctor(string) /* 0A000007 */ = ( 01 00 15 4D 69 63 72 6F 73 6F 66 74 20 43 6F 72   // ...Microsoft Cor
+                                                                                                                                                                70 6F 72 61 74 69 6F 6E 00 00 )                   // poration..
+  .custom /*0C000008:0A000008*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyProductAttribute/*01000009*/::.ctor(string) /* 0A000008 */ = ( 01 00 1A 4D 69 63 72 6F 73 6F 66 74 C2 AE 20 2E   // ...Microsoft.. .
+                                                                                                                                                                4E 45 54 20 46 72 61 6D 65 77 6F 72 6B 00 00 )    // NET Framework..
+  .custom /*0C000009:0A000009*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyCopyrightAttribute/*0100000A*/::.ctor(string) /* 0A000009 */ = ( 01 00 2F C2 A9 20 4D 69 63 72 6F 73 6F 66 74 20   // ../.. Microsoft 
+                                                                                                                                                                  43 6F 72 70 6F 72 61 74 69 6F 6E 2E 20 20 41 6C   // Corporation.  Al
+                                                                                                                                                                  6C 20 72 69 67 68 74 73 20 72 65 73 65 72 76 65   // l rights reserve
+                                                                                                                                                                  64 2E 00 00 )                                     // d...
+  .custom /*0C00000A:0A00000A*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyFileVersionAttribute/*0100000B*/::.ctor(string) /* 0A00000A */ = ( 01 00 0C 34 2E 36 2E 32 35 37 31 34 2E 30 31 00   // ...4.6.25714.01.
+                                                                                                                                                                    00 ) 
+  .custom /*0C00000B:0A00000B*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyInformationalVersionAttribute/*0100000C*/::.ctor(string) /* 0A00000B */ = ( 01 00 61 34 2E 36 2E 32 35 37 31 34 2E 30 31 20   // ..a4.6.25714.01 
+                                                                                                                                                                             62 75 69 6C 74 20 62 79 3A 20 64 6C 61 62 2D 44   // built by: dlab-D
+                                                                                                                                                                             44 56 53 4F 57 49 4E 41 47 45 30 33 32 2E 20 43   // DVSOWINAGE032. C
+                                                                                                                                                                             6F 6D 6D 69 74 20 48 61 73 68 3A 20 62 37 66 31   // ommit Hash: b7f1
+                                                                                                                                                                             38 32 34 31 35 39 32 37 64 33 62 39 38 34 34 35   // 82415927d3b98445
+                                                                                                                                                                             64 30 34 33 65 31 36 38 30 63 35 36 62 39 64 31   // d043e1680c56b9d1
+                                                                                                                                                                             66 31 37 63 00 00 )                               // f17c..
+  .custom /*0C00000C:0A00000C*/ instance void [netstandard/*23000001*/]System.CLSCompliantAttribute/*0100000D*/::.ctor(bool) /* 0A00000C */ = ( 01 00 01 00 00 ) 
+  .custom /*0C00000D:0A00000D*/ instance void [netstandard/*23000001*/]System.Reflection.AssemblyMetadataAttribute/*0100000E*/::.ctor(string,
+                                                                                                                                      string) /* 0A00000D */ = ( 01 00 00 00 00 00 ) 
+  .publickey = (00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 ) 
+  .hash algorithm 0x00008004
+  .ver 4:0:0:0
+}
+.class extern /*27000001*/ forwarder Microsoft.Win32.Registry
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000002*/ forwarder Microsoft.Win32.RegistryHive
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000003*/ forwarder Microsoft.Win32.RegistryKey
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000004*/ forwarder Microsoft.Win32.RegistryKeyPermissionCheck
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000005*/ forwarder Microsoft.Win32.RegistryOptions
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000006*/ forwarder Microsoft.Win32.RegistryValueKind
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000007*/ forwarder Microsoft.Win32.RegistryValueOptions
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000008*/ forwarder Microsoft.Win32.RegistryView
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000009*/ forwarder Microsoft.Win32.SafeHandles.CriticalHandleMinusOneIsInvalid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000A*/ forwarder Microsoft.Win32.SafeHandles.CriticalHandleZeroOrMinusOneIsInvalid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000B*/ forwarder Microsoft.Win32.SafeHandles.SafeAccessTokenHandle
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*2700000C*/ forwarder Microsoft.Win32.SafeHandles.SafeFileHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000D*/ forwarder Microsoft.Win32.SafeHandles.SafeHandleMinusOneIsInvalid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000E*/ forwarder Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700000F*/ forwarder Microsoft.Win32.SafeHandles.SafeRegistryHandle
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000010*/ forwarder Microsoft.Win32.SafeHandles.SafeWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000011*/ forwarder System.AccessViolationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000012*/ forwarder System.Action
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000013*/ forwarder System.Action`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000014*/ forwarder System.Action`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000015*/ forwarder System.Action`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000016*/ forwarder System.Action`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000017*/ forwarder System.Action`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000018*/ forwarder System.Action`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000019*/ forwarder System.Action`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001A*/ forwarder System.Action`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001B*/ forwarder System.Activator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001C*/ forwarder System.AggregateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001D*/ forwarder System.AppContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001E*/ forwarder System.AppDomain
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700001F*/ forwarder System.AppDomainUnloadedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000020*/ forwarder System.ApplicationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000021*/ forwarder System.ApplicationId
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000022*/ forwarder System.ArgumentException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000023*/ forwarder System.ArgumentNullException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000024*/ forwarder System.ArgumentOutOfRangeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000025*/ forwarder System.ArithmeticException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000026*/ forwarder System.Array
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000027*/ forwarder System.ArraySegment`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000028*/ forwarder System.ArrayTypeMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000029*/ forwarder System.AssemblyLoadEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002A*/ forwarder System.AssemblyLoadEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002B*/ forwarder System.AsyncCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002C*/ forwarder System.Attribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002D*/ forwarder System.AttributeTargets
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002E*/ forwarder System.AttributeUsageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700002F*/ forwarder System.BadImageFormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000030*/ forwarder System.Base64FormattingOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000031*/ forwarder System.BitConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000032*/ forwarder System.Boolean
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000033*/ forwarder System.Buffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000034*/ forwarder System.Byte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000035*/ forwarder System.CannotUnloadAppDomainException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000036*/ forwarder System.Char
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000037*/ forwarder System.CharEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000038*/ forwarder System.CLSCompliantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000039*/ forwarder System.Comparison`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003A*/ forwarder System.Console
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003B*/ forwarder System.ConsoleCancelEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003C*/ forwarder System.ConsoleCancelEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003D*/ forwarder System.ConsoleColor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003E*/ forwarder System.ConsoleKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700003F*/ forwarder System.ConsoleKeyInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000040*/ forwarder System.ConsoleModifiers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000041*/ forwarder System.ConsoleSpecialKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000042*/ forwarder System.ContextBoundObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000043*/ forwarder System.ContextMarshalException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000044*/ forwarder System.ContextStaticAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000045*/ forwarder System.Convert
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000046*/ forwarder System.Converter`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000047*/ forwarder System.DataMisalignedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000048*/ forwarder System.DateTime
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000049*/ forwarder System.DateTimeKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004A*/ forwarder System.DateTimeOffset
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004B*/ forwarder System.DayOfWeek
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004C*/ forwarder System.DBNull
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004D*/ forwarder System.Decimal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004E*/ forwarder System.Delegate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700004F*/ forwarder System.DivideByZeroException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000050*/ forwarder System.DllNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000051*/ forwarder System.Double
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000052*/ forwarder System.DuplicateWaitObjectException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000053*/ forwarder System.EntryPointNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000054*/ forwarder System.Enum
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000055*/ forwarder System.Environment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000056*/ SpecialFolder
+{
+  .class extern System.Environment /*27000055*/ 
+}
+.class extern /*27000057*/ SpecialFolderOption
+{
+  .class extern System.Environment /*27000055*/ 
+}
+.class extern /*27000058*/ forwarder System.EnvironmentVariableTarget
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000059*/ forwarder System.EventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005A*/ forwarder System.EventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005B*/ forwarder System.EventHandler`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005C*/ forwarder System.Exception
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005D*/ forwarder System.ExecutionEngineException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005E*/ forwarder System.FieldAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700005F*/ forwarder System.FlagsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000060*/ forwarder System.FormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000061*/ forwarder System.FormattableString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000062*/ forwarder System.Func`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000063*/ forwarder System.Func`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000064*/ forwarder System.Func`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000065*/ forwarder System.Func`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000066*/ forwarder System.Func`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000067*/ forwarder System.Func`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000068*/ forwarder System.Func`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000069*/ forwarder System.Func`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006A*/ forwarder System.Func`9
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006B*/ forwarder System.GC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006C*/ forwarder System.GCCollectionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006D*/ forwarder System.GCNotificationStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006E*/ forwarder System.Guid
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700006F*/ forwarder System.IAsyncResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000070*/ forwarder System.ICloneable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000071*/ forwarder System.IComparable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000072*/ forwarder System.IComparable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000073*/ forwarder System.IConvertible
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000074*/ forwarder System.ICustomFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000075*/ forwarder System.IDisposable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000076*/ forwarder System.IEquatable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000077*/ forwarder System.IFormatProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000078*/ forwarder System.IFormattable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000079*/ forwarder System.IndexOutOfRangeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007A*/ forwarder System.InsufficientExecutionStackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007B*/ forwarder System.InsufficientMemoryException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007C*/ forwarder System.Int16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007D*/ forwarder System.Int32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007E*/ forwarder System.Int64
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700007F*/ forwarder System.IntPtr
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000080*/ forwarder System.InvalidCastException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000081*/ forwarder System.InvalidOperationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000082*/ forwarder System.InvalidProgramException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000083*/ forwarder System.InvalidTimeZoneException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000084*/ forwarder System.IObservable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000085*/ forwarder System.IObserver`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000086*/ forwarder System.IProgress`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000087*/ forwarder System.IServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000088*/ forwarder System.Lazy`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000089*/ forwarder System.LoaderOptimization
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008A*/ forwarder System.LoaderOptimizationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008B*/ forwarder System.LocalDataStoreSlot
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008C*/ forwarder System.MarshalByRefObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008D*/ forwarder System.Math
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008E*/ forwarder System.MemberAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700008F*/ forwarder System.MethodAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000090*/ forwarder System.MidpointRounding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000091*/ forwarder System.MissingFieldException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000092*/ forwarder System.MissingMemberException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000093*/ forwarder System.MissingMethodException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000094*/ forwarder System.ModuleHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000095*/ forwarder System.MTAThreadAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000096*/ forwarder System.MulticastDelegate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000097*/ forwarder System.MulticastNotSupportedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000098*/ forwarder System.NonSerializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000099*/ forwarder System.NotFiniteNumberException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009A*/ forwarder System.NotImplementedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009B*/ forwarder System.NotSupportedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009C*/ forwarder System.Nullable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009D*/ forwarder System.Nullable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009E*/ forwarder System.NullReferenceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700009F*/ forwarder System.Object
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A0*/ forwarder System.ObjectDisposedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A1*/ forwarder System.ObsoleteAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A2*/ forwarder System.OperatingSystem
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A3*/ forwarder System.OperationCanceledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A4*/ forwarder System.OutOfMemoryException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A5*/ forwarder System.OverflowException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A6*/ forwarder System.ParamArrayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A7*/ forwarder System.PlatformID
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A8*/ forwarder System.PlatformNotSupportedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000A9*/ forwarder System.Predicate`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AA*/ forwarder System.Progress`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AB*/ forwarder System.Random
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AC*/ forwarder System.RankException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AD*/ forwarder System.ResolveEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AE*/ forwarder System.ResolveEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000AF*/ forwarder System.RuntimeArgumentHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B0*/ forwarder System.RuntimeFieldHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B1*/ forwarder System.RuntimeMethodHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B2*/ forwarder System.RuntimeTypeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B3*/ forwarder System.SByte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B4*/ forwarder System.SerializableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B5*/ forwarder System.Single
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B6*/ forwarder System.StackOverflowException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B7*/ forwarder System.STAThreadAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B8*/ forwarder System.String
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000B9*/ forwarder System.StringComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BA*/ forwarder System.StringComparison
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BB*/ forwarder System.StringSplitOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BC*/ forwarder System.SystemException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BD*/ forwarder System.ThreadStaticAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BE*/ forwarder System.TimeoutException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000BF*/ forwarder System.TimeSpan
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C0*/ forwarder System.TimeZone
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C1*/ forwarder System.TimeZoneInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C2*/ AdjustmentRule
+{
+  .class extern System.TimeZoneInfo /*270000C1*/ 
+}
+.class extern /*270000C3*/ TransitionTime
+{
+  .class extern System.TimeZoneInfo /*270000C1*/ 
+}
+.class extern /*270000C4*/ forwarder System.TimeZoneNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C5*/ forwarder System.Tuple
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C6*/ forwarder System.TupleExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C7*/ forwarder System.Tuple`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C8*/ forwarder System.Tuple`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000C9*/ forwarder System.Tuple`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CA*/ forwarder System.Tuple`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CB*/ forwarder System.Tuple`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CC*/ forwarder System.Tuple`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CD*/ forwarder System.Tuple`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CE*/ forwarder System.Tuple`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000CF*/ forwarder System.Type
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D0*/ forwarder System.TypeAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D1*/ forwarder System.TypeCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D2*/ forwarder System.TypedReference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D3*/ forwarder System.TypeInitializationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D4*/ forwarder System.TypeLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D5*/ forwarder System.TypeUnloadedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D6*/ forwarder System.UInt16
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D7*/ forwarder System.UInt32
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D8*/ forwarder System.UInt64
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000D9*/ forwarder System.UIntPtr
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DA*/ forwarder System.UnauthorizedAccessException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DB*/ forwarder System.UnhandledExceptionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DC*/ forwarder System.UnhandledExceptionEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DD*/ forwarder System.ValueTuple
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DE*/ forwarder System.ValueTuple`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000DF*/ forwarder System.ValueTuple`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E0*/ forwarder System.ValueTuple`3
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E1*/ forwarder System.ValueTuple`4
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E2*/ forwarder System.ValueTuple`5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E3*/ forwarder System.ValueTuple`6
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E4*/ forwarder System.ValueTuple`7
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E5*/ forwarder System.ValueTuple`8
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E6*/ forwarder System.ValueType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E7*/ forwarder System.Version
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E8*/ forwarder System.Void
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000E9*/ forwarder System.WeakReference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EA*/ forwarder System.WeakReference`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EB*/ forwarder System.Collections.ArrayList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EC*/ forwarder System.Collections.BitArray
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000ED*/ forwarder System.Collections.CaseInsensitiveComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EE*/ forwarder System.Collections.CaseInsensitiveHashCodeProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000EF*/ forwarder System.Collections.CollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F0*/ forwarder System.Collections.Comparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F1*/ forwarder System.Collections.DictionaryBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F2*/ forwarder System.Collections.DictionaryEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F3*/ forwarder System.Collections.Hashtable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F4*/ forwarder System.Collections.ICollection
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F5*/ forwarder System.Collections.IComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F6*/ forwarder System.Collections.IDictionary
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F7*/ forwarder System.Collections.IDictionaryEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F8*/ forwarder System.Collections.IEnumerable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000F9*/ forwarder System.Collections.IEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FA*/ forwarder System.Collections.IEqualityComparer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FB*/ forwarder System.Collections.IHashCodeProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FC*/ forwarder System.Collections.IList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FD*/ forwarder System.Collections.IStructuralComparable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FE*/ forwarder System.Collections.IStructuralEquatable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270000FF*/ forwarder System.Collections.Queue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000100*/ forwarder System.Collections.ReadOnlyCollectionBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000101*/ forwarder System.Collections.SortedList
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000102*/ forwarder System.Collections.Stack
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000103*/ forwarder System.Collections.StructuralComparisons
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000104*/ forwarder System.Collections.Concurrent.ConcurrentDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000105*/ forwarder System.Collections.Concurrent.ConcurrentQueue`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000106*/ forwarder System.Collections.Concurrent.ConcurrentStack`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000107*/ forwarder System.Collections.Concurrent.EnumerablePartitionerOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000108*/ forwarder System.Collections.Concurrent.IProducerConsumerCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000109*/ forwarder System.Collections.Concurrent.OrderablePartitioner`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010A*/ forwarder System.Collections.Concurrent.Partitioner
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010B*/ forwarder System.Collections.Concurrent.Partitioner`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010C*/ forwarder System.Collections.Generic.Comparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010D*/ forwarder System.Collections.Generic.Dictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700010E*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*2700010D*/ 
+}
+.class extern /*2700010F*/ KeyCollection
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*2700010D*/ 
+}
+.class extern /*27000110*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2/KeyCollection /*2700010F*/ 
+}
+.class extern /*27000111*/ ValueCollection
+{
+  .class extern System.Collections.Generic.Dictionary`2 /*2700010D*/ 
+}
+.class extern /*27000112*/ Enumerator
+{
+  .class extern System.Collections.Generic.Dictionary`2/ValueCollection /*27000111*/ 
+}
+.class extern /*27000113*/ forwarder System.Collections.Generic.EqualityComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000114*/ forwarder System.Collections.Generic.ICollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000115*/ forwarder System.Collections.Generic.IComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000116*/ forwarder System.Collections.Generic.IDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000117*/ forwarder System.Collections.Generic.IEnumerable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000118*/ forwarder System.Collections.Generic.IEnumerator`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000119*/ forwarder System.Collections.Generic.IEqualityComparer`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011A*/ forwarder System.Collections.Generic.IList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011B*/ forwarder System.Collections.Generic.IReadOnlyCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011C*/ forwarder System.Collections.Generic.IReadOnlyDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011D*/ forwarder System.Collections.Generic.IReadOnlyList`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011E*/ forwarder System.Collections.Generic.KeyNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700011F*/ forwarder System.Collections.Generic.KeyValuePair`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000120*/ forwarder System.Collections.Generic.List`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000121*/ Enumerator
+{
+  .class extern System.Collections.Generic.List`1 /*27000120*/ 
+}
+.class extern /*27000122*/ forwarder System.Collections.ObjectModel.Collection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000123*/ forwarder System.Collections.ObjectModel.KeyedCollection`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000124*/ forwarder System.Collections.ObjectModel.ReadOnlyCollection`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000125*/ forwarder System.Collections.ObjectModel.ReadOnlyDictionary`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000126*/ KeyCollection
+{
+  .class extern System.Collections.ObjectModel.ReadOnlyDictionary`2 /*27000125*/ 
+}
+.class extern /*27000127*/ ValueCollection
+{
+  .class extern System.Collections.ObjectModel.ReadOnlyDictionary`2 /*27000125*/ 
+}
+.class extern /*27000128*/ forwarder System.Configuration.Assemblies.AssemblyHashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000129*/ forwarder System.Configuration.Assemblies.AssemblyVersionCompatibility
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012A*/ forwarder System.Diagnostics.ConditionalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012B*/ forwarder System.Diagnostics.DebuggableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012C*/ DebuggingModes
+{
+  .class extern System.Diagnostics.DebuggableAttribute /*2700012B*/ 
+}
+.class extern /*2700012D*/ forwarder System.Diagnostics.Debugger
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012E*/ forwarder System.Diagnostics.DebuggerBrowsableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700012F*/ forwarder System.Diagnostics.DebuggerBrowsableState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000130*/ forwarder System.Diagnostics.DebuggerDisplayAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000131*/ forwarder System.Diagnostics.DebuggerHiddenAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000132*/ forwarder System.Diagnostics.DebuggerNonUserCodeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000133*/ forwarder System.Diagnostics.DebuggerStepperBoundaryAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000134*/ forwarder System.Diagnostics.DebuggerStepThroughAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000135*/ forwarder System.Diagnostics.DebuggerTypeProxyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000136*/ forwarder System.Diagnostics.DebuggerVisualizerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000137*/ forwarder System.Diagnostics.StackFrame
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000138*/ forwarder System.Diagnostics.StackTrace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000139*/ forwarder System.Diagnostics.CodeAnalysis.SuppressMessageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013A*/ forwarder System.Diagnostics.Contracts.Contract
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013B*/ forwarder System.Diagnostics.Contracts.ContractAbbreviatorAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013C*/ forwarder System.Diagnostics.Contracts.ContractArgumentValidatorAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013D*/ forwarder System.Diagnostics.Contracts.ContractClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013E*/ forwarder System.Diagnostics.Contracts.ContractClassForAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700013F*/ forwarder System.Diagnostics.Contracts.ContractFailedEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000140*/ forwarder System.Diagnostics.Contracts.ContractFailureKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000141*/ forwarder System.Diagnostics.Contracts.ContractInvariantMethodAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000142*/ forwarder System.Diagnostics.Contracts.ContractOptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000143*/ forwarder System.Diagnostics.Contracts.ContractPublicPropertyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000144*/ forwarder System.Diagnostics.Contracts.ContractReferenceAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000145*/ forwarder System.Diagnostics.Contracts.ContractRuntimeIgnoredAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000146*/ forwarder System.Diagnostics.Contracts.ContractVerificationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000147*/ forwarder System.Diagnostics.Contracts.PureAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000148*/ forwarder System.Diagnostics.SymbolStore.ISymbolBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000149*/ forwarder System.Diagnostics.SymbolStore.ISymbolBinder1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014A*/ forwarder System.Diagnostics.SymbolStore.ISymbolDocument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014B*/ forwarder System.Diagnostics.SymbolStore.ISymbolDocumentWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014C*/ forwarder System.Diagnostics.SymbolStore.ISymbolMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014D*/ forwarder System.Diagnostics.SymbolStore.ISymbolNamespace
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014E*/ forwarder System.Diagnostics.SymbolStore.ISymbolReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700014F*/ forwarder System.Diagnostics.SymbolStore.ISymbolScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000150*/ forwarder System.Diagnostics.SymbolStore.ISymbolVariable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000151*/ forwarder System.Diagnostics.SymbolStore.ISymbolWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000152*/ forwarder System.Diagnostics.SymbolStore.SymAddressKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000153*/ forwarder System.Diagnostics.SymbolStore.SymbolToken
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000154*/ forwarder System.Diagnostics.SymbolStore.SymDocumentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000155*/ forwarder System.Diagnostics.SymbolStore.SymLanguageType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000156*/ forwarder System.Diagnostics.SymbolStore.SymLanguageVendor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000157*/ forwarder System.Diagnostics.Tracing.EventActivityOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000158*/ forwarder System.Diagnostics.Tracing.EventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000159*/ forwarder System.Diagnostics.Tracing.EventChannel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015A*/ forwarder System.Diagnostics.Tracing.EventCommand
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015B*/ forwarder System.Diagnostics.Tracing.EventCommandEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015C*/ forwarder System.Diagnostics.Tracing.EventDataAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015D*/ forwarder System.Diagnostics.Tracing.EventFieldAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015E*/ forwarder System.Diagnostics.Tracing.EventFieldFormat
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700015F*/ forwarder System.Diagnostics.Tracing.EventFieldTags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000160*/ forwarder System.Diagnostics.Tracing.EventIgnoreAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000161*/ forwarder System.Diagnostics.Tracing.EventKeywords
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000162*/ forwarder System.Diagnostics.Tracing.EventLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000163*/ forwarder System.Diagnostics.Tracing.EventListener
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000164*/ forwarder System.Diagnostics.Tracing.EventManifestOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000165*/ forwarder System.Diagnostics.Tracing.EventOpcode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000166*/ forwarder System.Diagnostics.Tracing.EventSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000167*/ EventData
+{
+  .class extern System.Diagnostics.Tracing.EventSource /*27000166*/ 
+}
+.class extern /*27000168*/ forwarder System.Diagnostics.Tracing.EventSourceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000169*/ forwarder System.Diagnostics.Tracing.EventSourceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016A*/ forwarder System.Diagnostics.Tracing.EventSourceOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016B*/ forwarder System.Diagnostics.Tracing.EventSourceSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016C*/ forwarder System.Diagnostics.Tracing.EventTags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016D*/ forwarder System.Diagnostics.Tracing.EventTask
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016E*/ forwarder System.Diagnostics.Tracing.EventWrittenEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700016F*/ forwarder System.Diagnostics.Tracing.NonEventAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000170*/ forwarder System.Globalization.Calendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000171*/ forwarder System.Globalization.CalendarAlgorithmType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000172*/ forwarder System.Globalization.CalendarWeekRule
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000173*/ forwarder System.Globalization.CharUnicodeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000174*/ forwarder System.Globalization.ChineseLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000175*/ forwarder System.Globalization.CompareInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000176*/ forwarder System.Globalization.CompareOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000177*/ forwarder System.Globalization.CultureInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000178*/ forwarder System.Globalization.CultureNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000179*/ forwarder System.Globalization.CultureTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017A*/ forwarder System.Globalization.DateTimeFormatInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017B*/ forwarder System.Globalization.DateTimeStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017C*/ forwarder System.Globalization.DaylightTime
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017D*/ forwarder System.Globalization.DigitShapes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017E*/ forwarder System.Globalization.EastAsianLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700017F*/ forwarder System.Globalization.GregorianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000180*/ forwarder System.Globalization.GregorianCalendarTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000181*/ forwarder System.Globalization.HebrewCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000182*/ forwarder System.Globalization.HijriCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000183*/ forwarder System.Globalization.IdnMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000184*/ forwarder System.Globalization.JapaneseCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000185*/ forwarder System.Globalization.JapaneseLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000186*/ forwarder System.Globalization.JulianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000187*/ forwarder System.Globalization.KoreanCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000188*/ forwarder System.Globalization.KoreanLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000189*/ forwarder System.Globalization.NumberFormatInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018A*/ forwarder System.Globalization.NumberStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018B*/ forwarder System.Globalization.PersianCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018C*/ forwarder System.Globalization.RegionInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018D*/ forwarder System.Globalization.SortKey
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018E*/ forwarder System.Globalization.SortVersion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700018F*/ forwarder System.Globalization.StringInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000190*/ forwarder System.Globalization.TaiwanCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000191*/ forwarder System.Globalization.TaiwanLunisolarCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000192*/ forwarder System.Globalization.TextElementEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000193*/ forwarder System.Globalization.TextInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000194*/ forwarder System.Globalization.ThaiBuddhistCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000195*/ forwarder System.Globalization.TimeSpanStyles
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000196*/ forwarder System.Globalization.UmAlQuraCalendar
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000197*/ forwarder System.Globalization.UnicodeCategory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000198*/ forwarder System.IO.BinaryReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000199*/ forwarder System.IO.BinaryWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019A*/ forwarder System.IO.BufferedStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019B*/ forwarder System.IO.Directory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019C*/ forwarder System.IO.DirectoryInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019D*/ forwarder System.IO.DirectoryNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019E*/ forwarder System.IO.DriveInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700019F*/ forwarder System.IO.DriveNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A0*/ forwarder System.IO.DriveType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A1*/ forwarder System.IO.EndOfStreamException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A2*/ forwarder System.IO.File
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A3*/ forwarder System.IO.FileAccess
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A4*/ forwarder System.IO.FileAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A5*/ forwarder System.IO.FileInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A6*/ forwarder System.IO.FileLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A7*/ forwarder System.IO.FileMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A8*/ forwarder System.IO.FileNotFoundException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001A9*/ forwarder System.IO.FileOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AA*/ forwarder System.IO.FileShare
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AB*/ forwarder System.IO.FileStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AC*/ forwarder System.IO.FileSystemInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AD*/ forwarder System.IO.IOException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AE*/ forwarder System.IO.MemoryStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001AF*/ forwarder System.IO.Path
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B0*/ forwarder System.IO.PathTooLongException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B1*/ forwarder System.IO.SearchOption
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B2*/ forwarder System.IO.SeekOrigin
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B3*/ forwarder System.IO.Stream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B4*/ forwarder System.IO.StreamReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B5*/ forwarder System.IO.StreamWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B6*/ forwarder System.IO.StringReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B7*/ forwarder System.IO.StringWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B8*/ forwarder System.IO.TextReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001B9*/ forwarder System.IO.TextWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BA*/ forwarder System.IO.UnmanagedMemoryAccessor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BB*/ forwarder System.IO.UnmanagedMemoryStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BC*/ forwarder System.IO.IsolatedStorage.INormalizeForIsolatedStorage
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BD*/ forwarder System.IO.IsolatedStorage.IsolatedStorage
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BE*/ forwarder System.IO.IsolatedStorage.IsolatedStorageException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001BF*/ forwarder System.IO.IsolatedStorage.IsolatedStorageFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C0*/ forwarder System.IO.IsolatedStorage.IsolatedStorageFileStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C1*/ forwarder System.IO.IsolatedStorage.IsolatedStorageScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C2*/ forwarder System.Reflection.AmbiguousMatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C3*/ forwarder System.Reflection.Assembly
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C4*/ forwarder System.Reflection.AssemblyAlgorithmIdAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C5*/ forwarder System.Reflection.AssemblyCompanyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C6*/ forwarder System.Reflection.AssemblyConfigurationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C7*/ forwarder System.Reflection.AssemblyContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C8*/ forwarder System.Reflection.AssemblyCopyrightAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001C9*/ forwarder System.Reflection.AssemblyCultureAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CA*/ forwarder System.Reflection.AssemblyDefaultAliasAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CB*/ forwarder System.Reflection.AssemblyDelaySignAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CC*/ forwarder System.Reflection.AssemblyDescriptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CD*/ forwarder System.Reflection.AssemblyFileVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CE*/ forwarder System.Reflection.AssemblyFlagsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001CF*/ forwarder System.Reflection.AssemblyInformationalVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D0*/ forwarder System.Reflection.AssemblyKeyFileAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D1*/ forwarder System.Reflection.AssemblyKeyNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D2*/ forwarder System.Reflection.AssemblyMetadataAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D3*/ forwarder System.Reflection.AssemblyName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D4*/ forwarder System.Reflection.AssemblyNameFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D5*/ forwarder System.Reflection.AssemblyNameProxy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D6*/ forwarder System.Reflection.AssemblyProductAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D7*/ forwarder System.Reflection.AssemblySignatureKeyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D8*/ forwarder System.Reflection.AssemblyTitleAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001D9*/ forwarder System.Reflection.AssemblyTrademarkAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DA*/ forwarder System.Reflection.AssemblyVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DB*/ forwarder System.Reflection.Binder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DC*/ forwarder System.Reflection.BindingFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DD*/ forwarder System.Reflection.CallingConventions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DE*/ forwarder System.Reflection.ConstructorInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001DF*/ forwarder System.Reflection.CustomAttributeData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E0*/ forwarder System.Reflection.CustomAttributeExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E1*/ forwarder System.Reflection.CustomAttributeFormatException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E2*/ forwarder System.Reflection.CustomAttributeNamedArgument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E3*/ forwarder System.Reflection.CustomAttributeTypedArgument
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E4*/ forwarder System.Reflection.DefaultMemberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E5*/ forwarder System.Reflection.EventAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E6*/ forwarder System.Reflection.EventInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E7*/ forwarder System.Reflection.ExceptionHandlingClause
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E8*/ forwarder System.Reflection.ExceptionHandlingClauseOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001E9*/ forwarder System.Reflection.FieldAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EA*/ forwarder System.Reflection.FieldInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EB*/ forwarder System.Reflection.GenericParameterAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EC*/ forwarder System.Reflection.ICustomAttributeProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001ED*/ forwarder System.Reflection.ImageFileMachine
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EE*/ forwarder System.Reflection.InterfaceMapping
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001EF*/ forwarder System.Reflection.IntrospectionExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F0*/ forwarder System.Reflection.InvalidFilterCriteriaException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F1*/ forwarder System.Reflection.IReflect
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F2*/ forwarder System.Reflection.IReflectableType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F3*/ forwarder System.Reflection.LocalVariableInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F4*/ forwarder System.Reflection.ManifestResourceInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F5*/ forwarder System.Reflection.MemberFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F6*/ forwarder System.Reflection.MemberInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F7*/ forwarder System.Reflection.MemberTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F8*/ forwarder System.Reflection.MethodAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001F9*/ forwarder System.Reflection.MethodBase
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FA*/ forwarder System.Reflection.MethodBody
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FB*/ forwarder System.Reflection.MethodImplAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FC*/ forwarder System.Reflection.MethodInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FD*/ forwarder System.Reflection.Missing
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FE*/ forwarder System.Reflection.Module
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270001FF*/ forwarder System.Reflection.ModuleResolveEventHandler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000200*/ forwarder System.Reflection.ObfuscateAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000201*/ forwarder System.Reflection.ObfuscationAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000202*/ forwarder System.Reflection.ParameterAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000203*/ forwarder System.Reflection.ParameterInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000204*/ forwarder System.Reflection.ParameterModifier
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000205*/ forwarder System.Reflection.Pointer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000206*/ forwarder System.Reflection.PortableExecutableKinds
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000207*/ forwarder System.Reflection.ProcessorArchitecture
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000208*/ forwarder System.Reflection.PropertyAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000209*/ forwarder System.Reflection.PropertyInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020A*/ forwarder System.Reflection.ReflectionContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020B*/ forwarder System.Reflection.ReflectionTypeLoadException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020C*/ forwarder System.Reflection.ResourceAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020D*/ forwarder System.Reflection.ResourceLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020E*/ forwarder System.Reflection.RuntimeReflectionExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700020F*/ forwarder System.Reflection.StrongNameKeyPair
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000210*/ forwarder System.Reflection.TargetException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000211*/ forwarder System.Reflection.TargetInvocationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000212*/ forwarder System.Reflection.TargetParameterCountException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000213*/ forwarder System.Reflection.TypeAttributes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000214*/ forwarder System.Reflection.TypeDelegator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000215*/ forwarder System.Reflection.TypeFilter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000216*/ forwarder System.Reflection.TypeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000217*/ forwarder System.Reflection.Emit.FlowControl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000218*/ forwarder System.Reflection.Emit.OpCode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000219*/ forwarder System.Reflection.Emit.OpCodes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021A*/ forwarder System.Reflection.Emit.OpCodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021B*/ forwarder System.Reflection.Emit.OperandType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021C*/ forwarder System.Reflection.Emit.PackingSize
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021D*/ forwarder System.Reflection.Emit.StackBehaviour
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021E*/ forwarder System.Resources.IResourceReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700021F*/ forwarder System.Resources.IResourceWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000220*/ forwarder System.Resources.MissingManifestResourceException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000221*/ forwarder System.Resources.MissingSatelliteAssemblyException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000222*/ forwarder System.Resources.NeutralResourcesLanguageAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000223*/ forwarder System.Resources.ResourceManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000224*/ forwarder System.Resources.ResourceReader
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000225*/ forwarder System.Resources.ResourceSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000226*/ forwarder System.Resources.ResourceWriter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000227*/ forwarder System.Resources.SatelliteContractVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000228*/ forwarder System.Resources.UltimateResourceFallbackLocation
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000229*/ forwarder System.Runtime.AssemblyTargetedPatchBandAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022A*/ forwarder System.Runtime.GCLargeObjectHeapCompactionMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022B*/ forwarder System.Runtime.GCLatencyMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022C*/ forwarder System.Runtime.GCSettings
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022D*/ forwarder System.Runtime.MemoryFailPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022E*/ forwarder System.Runtime.TargetedPatchingOptOutAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700022F*/ forwarder System.Runtime.CompilerServices.AccessedThroughPropertyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000230*/ forwarder System.Runtime.CompilerServices.AsyncStateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000231*/ forwarder System.Runtime.CompilerServices.AsyncTaskMethodBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000232*/ forwarder System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000233*/ forwarder System.Runtime.CompilerServices.AsyncVoidMethodBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000234*/ forwarder System.Runtime.CompilerServices.CallConvCdecl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000235*/ forwarder System.Runtime.CompilerServices.CallConvFastcall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000236*/ forwarder System.Runtime.CompilerServices.CallConvStdcall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000237*/ forwarder System.Runtime.CompilerServices.CallConvThiscall
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000238*/ forwarder System.Runtime.CompilerServices.CallerFilePathAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000239*/ forwarder System.Runtime.CompilerServices.CallerLineNumberAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023A*/ forwarder System.Runtime.CompilerServices.CallerMemberNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023B*/ forwarder System.Runtime.CompilerServices.CompilationRelaxations
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023C*/ forwarder System.Runtime.CompilerServices.CompilationRelaxationsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023D*/ forwarder System.Runtime.CompilerServices.CompilerGeneratedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023E*/ forwarder System.Runtime.CompilerServices.CompilerGlobalScopeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700023F*/ forwarder System.Runtime.CompilerServices.CompilerMarshalOverride
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000240*/ forwarder System.Runtime.CompilerServices.ConditionalWeakTable`2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000241*/ CreateValueCallback
+{
+  .class extern System.Runtime.CompilerServices.ConditionalWeakTable`2 /*27000240*/ 
+}
+.class extern /*27000242*/ forwarder System.Runtime.CompilerServices.ConfiguredTaskAwaitable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000243*/ ConfiguredTaskAwaiter
+{
+  .class extern System.Runtime.CompilerServices.ConfiguredTaskAwaitable /*27000242*/ 
+}
+.class extern /*27000244*/ forwarder System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000245*/ ConfiguredTaskAwaiter
+{
+  .class extern System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1 /*27000244*/ 
+}
+.class extern /*27000246*/ forwarder System.Runtime.CompilerServices.ContractHelper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000247*/ forwarder System.Runtime.CompilerServices.CustomConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000248*/ forwarder System.Runtime.CompilerServices.DateTimeConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000249*/ forwarder System.Runtime.CompilerServices.DecimalConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024A*/ forwarder System.Runtime.CompilerServices.DefaultDependencyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024B*/ forwarder System.Runtime.CompilerServices.DependencyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024C*/ forwarder System.Runtime.CompilerServices.DisablePrivateReflectionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024D*/ forwarder System.Runtime.CompilerServices.DiscardableAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024E*/ forwarder System.Runtime.CompilerServices.ExtensionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700024F*/ forwarder System.Runtime.CompilerServices.FixedAddressValueTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000250*/ forwarder System.Runtime.CompilerServices.FixedBufferAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000251*/ forwarder System.Runtime.CompilerServices.FormattableStringFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000252*/ forwarder System.Runtime.CompilerServices.HasCopySemanticsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000253*/ forwarder System.Runtime.CompilerServices.IAsyncStateMachine
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000254*/ forwarder System.Runtime.CompilerServices.ICriticalNotifyCompletion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000255*/ forwarder System.Runtime.CompilerServices.IndexerNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000256*/ forwarder System.Runtime.CompilerServices.INotifyCompletion
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000257*/ forwarder System.Runtime.CompilerServices.InternalsVisibleToAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000258*/ forwarder System.Runtime.CompilerServices.IsBoxed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000259*/ forwarder System.Runtime.CompilerServices.IsByValue
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025A*/ forwarder System.Runtime.CompilerServices.IsConst
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025B*/ forwarder System.Runtime.CompilerServices.IsCopyConstructed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025C*/ forwarder System.Runtime.CompilerServices.IsExplicitlyDereferenced
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025D*/ forwarder System.Runtime.CompilerServices.IsImplicitlyDereferenced
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025E*/ forwarder System.Runtime.CompilerServices.IsJitIntrinsic
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700025F*/ forwarder System.Runtime.CompilerServices.IsLong
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000260*/ forwarder System.Runtime.CompilerServices.IsPinned
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000261*/ forwarder System.Runtime.CompilerServices.IsSignUnspecifiedByte
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000262*/ forwarder System.Runtime.CompilerServices.IsUdtReturn
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000263*/ forwarder System.Runtime.CompilerServices.IsVolatile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000264*/ forwarder System.Runtime.CompilerServices.IteratorStateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000265*/ forwarder System.Runtime.CompilerServices.IUnknownConstantAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000266*/ forwarder System.Runtime.CompilerServices.LoadHint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000267*/ forwarder System.Runtime.CompilerServices.MethodCodeType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000268*/ forwarder System.Runtime.CompilerServices.MethodImplAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000269*/ forwarder System.Runtime.CompilerServices.MethodImplOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026A*/ forwarder System.Runtime.CompilerServices.NativeCppClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026B*/ forwarder System.Runtime.CompilerServices.ReferenceAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026C*/ forwarder System.Runtime.CompilerServices.RequiredAttributeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026D*/ forwarder System.Runtime.CompilerServices.RuntimeCompatibilityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026E*/ forwarder System.Runtime.CompilerServices.RuntimeHelpers
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700026F*/ CleanupCode
+{
+  .class extern System.Runtime.CompilerServices.RuntimeHelpers /*2700026E*/ 
+}
+.class extern /*27000270*/ TryCode
+{
+  .class extern System.Runtime.CompilerServices.RuntimeHelpers /*2700026E*/ 
+}
+.class extern /*27000271*/ forwarder System.Runtime.CompilerServices.RuntimeWrappedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000272*/ forwarder System.Runtime.CompilerServices.ScopelessEnumAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000273*/ forwarder System.Runtime.CompilerServices.SpecialNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000274*/ forwarder System.Runtime.CompilerServices.StateMachineAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000275*/ forwarder System.Runtime.CompilerServices.StringFreezingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000276*/ forwarder System.Runtime.CompilerServices.SuppressIldasmAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000277*/ forwarder System.Runtime.CompilerServices.TaskAwaiter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000278*/ forwarder System.Runtime.CompilerServices.TaskAwaiter`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000279*/ forwarder System.Runtime.CompilerServices.TupleElementNamesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027A*/ forwarder System.Runtime.CompilerServices.TypeForwardedFromAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027B*/ forwarder System.Runtime.CompilerServices.TypeForwardedToAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027C*/ forwarder System.Runtime.CompilerServices.UnsafeValueTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027D*/ forwarder System.Runtime.CompilerServices.YieldAwaitable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700027E*/ YieldAwaiter
+{
+  .class extern System.Runtime.CompilerServices.YieldAwaitable /*2700027D*/ 
+}
+.class extern /*2700027F*/ forwarder System.Runtime.ConstrainedExecution.Cer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000280*/ forwarder System.Runtime.ConstrainedExecution.Consistency
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000281*/ forwarder System.Runtime.ConstrainedExecution.CriticalFinalizerObject
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000282*/ forwarder System.Runtime.ConstrainedExecution.PrePrepareMethodAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000283*/ forwarder System.Runtime.ConstrainedExecution.ReliabilityContractAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000284*/ forwarder System.Runtime.ExceptionServices.ExceptionDispatchInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000285*/ forwarder System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000286*/ forwarder System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000287*/ forwarder System.Runtime.InteropServices.AllowReversePInvokeCallsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000288*/ forwarder System.Runtime.InteropServices.ArrayWithOffset
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000289*/ forwarder System.Runtime.InteropServices.BestFitMappingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028A*/ forwarder System.Runtime.InteropServices.BStrWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028B*/ forwarder System.Runtime.InteropServices.CallingConvention
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028C*/ forwarder System.Runtime.InteropServices.CharSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028D*/ forwarder System.Runtime.InteropServices.ClassInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028E*/ forwarder System.Runtime.InteropServices.ClassInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700028F*/ forwarder System.Runtime.InteropServices.CoClassAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000290*/ forwarder System.Runtime.InteropServices.ComAliasNameAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000291*/ forwarder System.Runtime.InteropServices.ComCompatibleVersionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000292*/ forwarder System.Runtime.InteropServices.ComConversionLossAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000293*/ forwarder System.Runtime.InteropServices.ComDefaultInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000294*/ forwarder System.Runtime.InteropServices.ComEventInterfaceAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000295*/ forwarder System.Runtime.InteropServices.ComEventsHelper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000296*/ forwarder System.Runtime.InteropServices.COMException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000297*/ forwarder System.Runtime.InteropServices.ComImportAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000298*/ forwarder System.Runtime.InteropServices.ComInterfaceType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000299*/ forwarder System.Runtime.InteropServices.ComMemberType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029A*/ forwarder System.Runtime.InteropServices.ComRegisterFunctionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029B*/ forwarder System.Runtime.InteropServices.ComSourceInterfacesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029C*/ forwarder System.Runtime.InteropServices.ComUnregisterFunctionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029D*/ forwarder System.Runtime.InteropServices.ComVisibleAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029E*/ forwarder System.Runtime.InteropServices.CriticalHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700029F*/ forwarder System.Runtime.InteropServices.CurrencyWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A0*/ forwarder System.Runtime.InteropServices.CustomQueryInterfaceMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A1*/ forwarder System.Runtime.InteropServices.CustomQueryInterfaceResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A2*/ forwarder System.Runtime.InteropServices.DefaultCharSetAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A3*/ forwarder System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A4*/ forwarder System.Runtime.InteropServices.DispatchWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A5*/ forwarder System.Runtime.InteropServices.DispIdAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A6*/ forwarder System.Runtime.InteropServices.DllImportAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A7*/ forwarder System.Runtime.InteropServices.DllImportSearchPath
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A8*/ forwarder System.Runtime.InteropServices.ErrorWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002A9*/ forwarder System.Runtime.InteropServices.ExternalException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AA*/ forwarder System.Runtime.InteropServices.FieldOffsetAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AB*/ forwarder System.Runtime.InteropServices.GCHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AC*/ forwarder System.Runtime.InteropServices.GCHandleType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AD*/ forwarder System.Runtime.InteropServices.GuidAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AE*/ forwarder System.Runtime.InteropServices.HandleRef
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002AF*/ forwarder System.Runtime.InteropServices.ICustomAdapter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B0*/ forwarder System.Runtime.InteropServices.ICustomFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B1*/ forwarder System.Runtime.InteropServices.ICustomMarshaler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B2*/ forwarder System.Runtime.InteropServices.ICustomQueryInterface
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B3*/ forwarder System.Runtime.InteropServices.InAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B4*/ forwarder System.Runtime.InteropServices.InterfaceTypeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B5*/ forwarder System.Runtime.InteropServices.InvalidComObjectException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B6*/ forwarder System.Runtime.InteropServices.InvalidOleVariantTypeException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B7*/ forwarder System.Runtime.InteropServices.LayoutKind
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B8*/ forwarder System.Runtime.InteropServices.LCIDConversionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002B9*/ forwarder System.Runtime.InteropServices.Marshal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BA*/ forwarder System.Runtime.InteropServices.MarshalAsAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BB*/ forwarder System.Runtime.InteropServices.MarshalDirectiveException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BC*/ forwarder System.Runtime.InteropServices.OptionalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BD*/ forwarder System.Runtime.InteropServices.OutAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BE*/ forwarder System.Runtime.InteropServices.PreserveSigAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002BF*/ forwarder System.Runtime.InteropServices.PrimaryInteropAssemblyAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C0*/ forwarder System.Runtime.InteropServices.ProgIdAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C1*/ forwarder System.Runtime.InteropServices.RuntimeEnvironment
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C2*/ forwarder System.Runtime.InteropServices.SafeArrayRankMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C3*/ forwarder System.Runtime.InteropServices.SafeArrayTypeMismatchException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C4*/ forwarder System.Runtime.InteropServices.SafeBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C5*/ forwarder System.Runtime.InteropServices.SafeHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C6*/ forwarder System.Runtime.InteropServices.SEHException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C7*/ forwarder System.Runtime.InteropServices.StructLayoutAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C8*/ forwarder System.Runtime.InteropServices.TypeIdentifierAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002C9*/ forwarder System.Runtime.InteropServices.UnknownWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CA*/ forwarder System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CB*/ forwarder System.Runtime.InteropServices.UnmanagedType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CC*/ forwarder System.Runtime.InteropServices.VarEnum
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CD*/ forwarder System.Runtime.InteropServices.VariantWrapper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CE*/ forwarder System.Runtime.InteropServices.ComTypes.BINDPTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002CF*/ forwarder System.Runtime.InteropServices.ComTypes.BIND_OPTS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D0*/ forwarder System.Runtime.InteropServices.ComTypes.CALLCONV
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D1*/ forwarder System.Runtime.InteropServices.ComTypes.CONNECTDATA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D2*/ forwarder System.Runtime.InteropServices.ComTypes.DESCKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D3*/ forwarder System.Runtime.InteropServices.ComTypes.DISPPARAMS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D4*/ forwarder System.Runtime.InteropServices.ComTypes.ELEMDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D5*/ DESCUNION
+{
+  .class extern System.Runtime.InteropServices.ComTypes.ELEMDESC /*270002D4*/ 
+}
+.class extern /*270002D6*/ forwarder System.Runtime.InteropServices.ComTypes.EXCEPINFO
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D7*/ forwarder System.Runtime.InteropServices.ComTypes.FILETIME
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D8*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002D9*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DA*/ forwarder System.Runtime.InteropServices.ComTypes.FUNCKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DB*/ forwarder System.Runtime.InteropServices.ComTypes.IBindCtx
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DC*/ forwarder System.Runtime.InteropServices.ComTypes.IConnectionPoint
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DD*/ forwarder System.Runtime.InteropServices.ComTypes.IConnectionPointContainer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DE*/ forwarder System.Runtime.InteropServices.ComTypes.IDLDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002DF*/ forwarder System.Runtime.InteropServices.ComTypes.IDLFLAG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E0*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumConnectionPoints
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E1*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumConnections
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E2*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumMoniker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E3*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E4*/ forwarder System.Runtime.InteropServices.ComTypes.IEnumVARIANT
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E5*/ forwarder System.Runtime.InteropServices.ComTypes.IMoniker
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E6*/ forwarder System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E7*/ forwarder System.Runtime.InteropServices.ComTypes.INVOKEKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E8*/ forwarder System.Runtime.InteropServices.ComTypes.IPersistFile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002E9*/ forwarder System.Runtime.InteropServices.ComTypes.IRunningObjectTable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EA*/ forwarder System.Runtime.InteropServices.ComTypes.IStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EB*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeComp
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EC*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002ED*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeInfo2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EE*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeLib
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002EF*/ forwarder System.Runtime.InteropServices.ComTypes.ITypeLib2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F0*/ forwarder System.Runtime.InteropServices.ComTypes.LIBFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F1*/ forwarder System.Runtime.InteropServices.ComTypes.PARAMDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F2*/ forwarder System.Runtime.InteropServices.ComTypes.PARAMFLAG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F3*/ forwarder System.Runtime.InteropServices.ComTypes.STATSTG
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F4*/ forwarder System.Runtime.InteropServices.ComTypes.SYSKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F5*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEATTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F6*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F7*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F8*/ forwarder System.Runtime.InteropServices.ComTypes.TYPEKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002F9*/ forwarder System.Runtime.InteropServices.ComTypes.TYPELIBATTR
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FA*/ forwarder System.Runtime.InteropServices.ComTypes.VARDESC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FB*/ DESCUNION
+{
+  .class extern System.Runtime.InteropServices.ComTypes.VARDESC /*270002FA*/ 
+}
+.class extern /*270002FC*/ forwarder System.Runtime.InteropServices.ComTypes.VARFLAGS
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FD*/ forwarder System.Runtime.InteropServices.ComTypes.VARKIND
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FE*/ forwarder System.Runtime.Serialization.Formatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270002FF*/ forwarder System.Runtime.Serialization.FormatterConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000300*/ forwarder System.Runtime.Serialization.FormatterServices
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000301*/ forwarder System.Runtime.Serialization.IDeserializationCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000302*/ forwarder System.Runtime.Serialization.IFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000303*/ forwarder System.Runtime.Serialization.IFormatterConverter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000304*/ forwarder System.Runtime.Serialization.IObjectReference
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000305*/ forwarder System.Runtime.Serialization.ISafeSerializationData
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000306*/ forwarder System.Runtime.Serialization.ISerializable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000307*/ forwarder System.Runtime.Serialization.ISerializationSurrogate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000308*/ forwarder System.Runtime.Serialization.ISurrogateSelector
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000309*/ forwarder System.Runtime.Serialization.ObjectIDGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030A*/ forwarder System.Runtime.Serialization.ObjectManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030B*/ forwarder System.Runtime.Serialization.OnDeserializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030C*/ forwarder System.Runtime.Serialization.OnDeserializingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030D*/ forwarder System.Runtime.Serialization.OnSerializedAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030E*/ forwarder System.Runtime.Serialization.OnSerializingAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700030F*/ forwarder System.Runtime.Serialization.OptionalFieldAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000310*/ forwarder System.Runtime.Serialization.SafeSerializationEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000311*/ forwarder System.Runtime.Serialization.SerializationBinder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000312*/ forwarder System.Runtime.Serialization.SerializationEntry
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000313*/ forwarder System.Runtime.Serialization.SerializationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000314*/ forwarder System.Runtime.Serialization.SerializationInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000315*/ forwarder System.Runtime.Serialization.SerializationInfoEnumerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000316*/ forwarder System.Runtime.Serialization.SerializationObjectManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000317*/ forwarder System.Runtime.Serialization.StreamingContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000318*/ forwarder System.Runtime.Serialization.StreamingContextStates
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000319*/ forwarder System.Runtime.Serialization.SurrogateSelector
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031A*/ forwarder System.Runtime.Serialization.Formatters.FormatterAssemblyStyle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031B*/ forwarder System.Runtime.Serialization.Formatters.FormatterTypeStyle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031C*/ forwarder System.Runtime.Serialization.Formatters.TypeFilterLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031D*/ forwarder System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031E*/ forwarder System.Runtime.Versioning.ComponentGuaranteesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700031F*/ forwarder System.Runtime.Versioning.ComponentGuaranteesOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000320*/ forwarder System.Runtime.Versioning.ResourceConsumptionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000321*/ forwarder System.Runtime.Versioning.ResourceExposureAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000322*/ forwarder System.Runtime.Versioning.ResourceScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000323*/ forwarder System.Runtime.Versioning.TargetFrameworkAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000324*/ forwarder System.Runtime.Versioning.VersioningHelper
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000325*/ forwarder System.Security.AllowPartiallyTrustedCallersAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000326*/ forwarder System.Security.IPermission
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000327*/ forwarder System.Security.ISecurityEncodable
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000328*/ forwarder System.Security.PartialTrustVisibilityLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000329*/ forwarder System.Security.SecureString
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032A*/ forwarder System.Security.SecurityCriticalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032B*/ forwarder System.Security.SecurityCriticalScope
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032C*/ forwarder System.Security.SecurityElement
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032D*/ forwarder System.Security.SecurityException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032E*/ forwarder System.Security.SecurityRulesAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700032F*/ forwarder System.Security.SecurityRuleSet
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000330*/ forwarder System.Security.SecuritySafeCriticalAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000331*/ forwarder System.Security.SecurityTransparentAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000332*/ forwarder System.Security.SecurityTreatAsSafeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000333*/ forwarder System.Security.SuppressUnmanagedCodeSecurityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000334*/ forwarder System.Security.UnverifiableCodeAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000335*/ forwarder System.Security.VerificationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000336*/ forwarder System.Security.AccessControl.AccessControlActions
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000337*/ forwarder System.Security.AccessControl.AccessControlModification
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000338*/ forwarder System.Security.AccessControl.AccessControlSections
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000339*/ forwarder System.Security.AccessControl.AccessControlType
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033A*/ forwarder System.Security.AccessControl.AccessRule
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033B*/ forwarder System.Security.AccessControl.AccessRule`1
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033C*/ forwarder System.Security.AccessControl.AceEnumerator
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033D*/ forwarder System.Security.AccessControl.AceFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033E*/ forwarder System.Security.AccessControl.AceQualifier
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700033F*/ forwarder System.Security.AccessControl.AceType
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000340*/ forwarder System.Security.AccessControl.AuditFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000341*/ forwarder System.Security.AccessControl.AuditRule
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000342*/ forwarder System.Security.AccessControl.AuditRule`1
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000343*/ forwarder System.Security.AccessControl.AuthorizationRule
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000344*/ forwarder System.Security.AccessControl.AuthorizationRuleCollection
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000345*/ forwarder System.Security.AccessControl.CommonAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000346*/ forwarder System.Security.AccessControl.CommonAcl
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000347*/ forwarder System.Security.AccessControl.CommonObjectSecurity
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000348*/ forwarder System.Security.AccessControl.CommonSecurityDescriptor
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000349*/ forwarder System.Security.AccessControl.CompoundAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034A*/ forwarder System.Security.AccessControl.CompoundAceType
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034B*/ forwarder System.Security.AccessControl.ControlFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034C*/ forwarder System.Security.AccessControl.CustomAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034D*/ forwarder System.Security.AccessControl.DiscretionaryAcl
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034E*/ forwarder System.Security.AccessControl.GenericAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700034F*/ forwarder System.Security.AccessControl.GenericAcl
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000350*/ forwarder System.Security.AccessControl.GenericSecurityDescriptor
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000351*/ forwarder System.Security.AccessControl.InheritanceFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000352*/ forwarder System.Security.AccessControl.KnownAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000353*/ forwarder System.Security.AccessControl.NativeObjectSecurity
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000354*/ ExceptionFromErrorCode
+{
+  .class extern System.Security.AccessControl.NativeObjectSecurity /*27000353*/ 
+}
+.class extern /*27000355*/ forwarder System.Security.AccessControl.ObjectAccessRule
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000356*/ forwarder System.Security.AccessControl.ObjectAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000357*/ forwarder System.Security.AccessControl.ObjectAceFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000358*/ forwarder System.Security.AccessControl.ObjectAuditRule
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000359*/ forwarder System.Security.AccessControl.ObjectSecurity
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035A*/ forwarder System.Security.AccessControl.ObjectSecurity`1
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035B*/ forwarder System.Security.AccessControl.PrivilegeNotHeldException
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035C*/ forwarder System.Security.AccessControl.PropagationFlags
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035D*/ forwarder System.Security.AccessControl.QualifiedAce
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035E*/ forwarder System.Security.AccessControl.RawAcl
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*2700035F*/ forwarder System.Security.AccessControl.RawSecurityDescriptor
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000360*/ forwarder System.Security.AccessControl.RegistryAccessRule
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000361*/ forwarder System.Security.AccessControl.RegistryAuditRule
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000362*/ forwarder System.Security.AccessControl.RegistryRights
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000363*/ forwarder System.Security.AccessControl.RegistrySecurity
+{
+  .assembly extern Microsoft.Win32.Registry /*23000002*/ 
+}
+.class extern /*27000364*/ forwarder System.Security.AccessControl.ResourceType
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000365*/ forwarder System.Security.AccessControl.SecurityInfos
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000366*/ forwarder System.Security.AccessControl.SystemAcl
+{
+  .assembly extern System.Security.AccessControl /*23000004*/ 
+}
+.class extern /*27000367*/ forwarder System.Security.Claims.Claim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000368*/ forwarder System.Security.Claims.ClaimsIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000369*/ forwarder System.Security.Claims.ClaimsPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036A*/ forwarder System.Security.Claims.ClaimTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036B*/ forwarder System.Security.Claims.ClaimValueTypes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036C*/ forwarder System.Security.Cryptography.Aes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036D*/ forwarder System.Security.Cryptography.AsymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036E*/ forwarder System.Security.Cryptography.AsymmetricKeyExchangeDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700036F*/ forwarder System.Security.Cryptography.AsymmetricKeyExchangeFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000370*/ forwarder System.Security.Cryptography.AsymmetricSignatureDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000371*/ forwarder System.Security.Cryptography.AsymmetricSignatureFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000372*/ forwarder System.Security.Cryptography.CipherMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000373*/ forwarder System.Security.Cryptography.CryptoConfig
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000374*/ forwarder System.Security.Cryptography.CryptographicException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000375*/ forwarder System.Security.Cryptography.CryptographicUnexpectedOperationException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000376*/ forwarder System.Security.Cryptography.CryptoStream
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000377*/ forwarder System.Security.Cryptography.CryptoStreamMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000378*/ forwarder System.Security.Cryptography.CspKeyContainerInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000379*/ forwarder System.Security.Cryptography.CspParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037A*/ forwarder System.Security.Cryptography.CspProviderFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037B*/ forwarder System.Security.Cryptography.DeriveBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037C*/ forwarder System.Security.Cryptography.DES
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037D*/ forwarder System.Security.Cryptography.DESCryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037E*/ forwarder System.Security.Cryptography.DSA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700037F*/ forwarder System.Security.Cryptography.DSACryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000380*/ forwarder System.Security.Cryptography.DSAParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000381*/ forwarder System.Security.Cryptography.DSASignatureDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000382*/ forwarder System.Security.Cryptography.DSASignatureFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000383*/ forwarder System.Security.Cryptography.FromBase64Transform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000384*/ forwarder System.Security.Cryptography.FromBase64TransformMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000385*/ forwarder System.Security.Cryptography.HashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000386*/ forwarder System.Security.Cryptography.HashAlgorithmName
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000387*/ forwarder System.Security.Cryptography.HMAC
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000388*/ forwarder System.Security.Cryptography.HMACMD5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000389*/ forwarder System.Security.Cryptography.HMACSHA1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038A*/ forwarder System.Security.Cryptography.HMACSHA256
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038B*/ forwarder System.Security.Cryptography.HMACSHA384
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038C*/ forwarder System.Security.Cryptography.HMACSHA512
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038D*/ forwarder System.Security.Cryptography.ICryptoTransform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038E*/ forwarder System.Security.Cryptography.ICspAsymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700038F*/ forwarder System.Security.Cryptography.KeyedHashAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000390*/ forwarder System.Security.Cryptography.KeyNumber
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000391*/ forwarder System.Security.Cryptography.KeySizes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000392*/ forwarder System.Security.Cryptography.MaskGenerationMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000393*/ forwarder System.Security.Cryptography.MD5
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000394*/ forwarder System.Security.Cryptography.MD5CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000395*/ forwarder System.Security.Cryptography.PaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000396*/ forwarder System.Security.Cryptography.PasswordDeriveBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000397*/ forwarder System.Security.Cryptography.PKCS1MaskGenerationMethod
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000398*/ forwarder System.Security.Cryptography.RandomNumberGenerator
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000399*/ forwarder System.Security.Cryptography.RC2
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039A*/ forwarder System.Security.Cryptography.RC2CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039B*/ forwarder System.Security.Cryptography.Rfc2898DeriveBytes
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039C*/ forwarder System.Security.Cryptography.Rijndael
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039D*/ forwarder System.Security.Cryptography.RijndaelManaged
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039E*/ forwarder System.Security.Cryptography.RNGCryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700039F*/ forwarder System.Security.Cryptography.RSA
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A0*/ forwarder System.Security.Cryptography.RSACryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A1*/ forwarder System.Security.Cryptography.RSAEncryptionPadding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A2*/ forwarder System.Security.Cryptography.RSAEncryptionPaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A3*/ forwarder System.Security.Cryptography.RSAOAEPKeyExchangeDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A4*/ forwarder System.Security.Cryptography.RSAOAEPKeyExchangeFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A5*/ forwarder System.Security.Cryptography.RSAParameters
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A6*/ forwarder System.Security.Cryptography.RSAPKCS1KeyExchangeDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A7*/ forwarder System.Security.Cryptography.RSAPKCS1KeyExchangeFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A8*/ forwarder System.Security.Cryptography.RSAPKCS1SignatureDeformatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003A9*/ forwarder System.Security.Cryptography.RSAPKCS1SignatureFormatter
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AA*/ forwarder System.Security.Cryptography.RSASignaturePadding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AB*/ forwarder System.Security.Cryptography.RSASignaturePaddingMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AC*/ forwarder System.Security.Cryptography.SHA1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AD*/ forwarder System.Security.Cryptography.SHA1CryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AE*/ forwarder System.Security.Cryptography.SHA1Managed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003AF*/ forwarder System.Security.Cryptography.SHA256
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B0*/ forwarder System.Security.Cryptography.SHA256Managed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B1*/ forwarder System.Security.Cryptography.SHA384
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B2*/ forwarder System.Security.Cryptography.SHA384Managed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B3*/ forwarder System.Security.Cryptography.SHA512
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B4*/ forwarder System.Security.Cryptography.SHA512Managed
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B5*/ forwarder System.Security.Cryptography.SignatureDescription
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B6*/ forwarder System.Security.Cryptography.SymmetricAlgorithm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B7*/ forwarder System.Security.Cryptography.ToBase64Transform
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B8*/ forwarder System.Security.Cryptography.TripleDES
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003B9*/ forwarder System.Security.Cryptography.TripleDESCryptoServiceProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BA*/ forwarder System.Security.Cryptography.X509Certificates.X509Certificate
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BB*/ forwarder System.Security.Cryptography.X509Certificates.X509ContentType
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BC*/ forwarder System.Security.Cryptography.X509Certificates.X509KeyStorageFlags
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BD*/ forwarder System.Security.Permissions.CodeAccessSecurityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BE*/ forwarder System.Security.Permissions.SecurityAction
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003BF*/ forwarder System.Security.Permissions.SecurityAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C0*/ forwarder System.Security.Permissions.SecurityPermissionAttribute
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C1*/ forwarder System.Security.Permissions.SecurityPermissionFlag
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C2*/ forwarder System.Security.Principal.GenericIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C3*/ forwarder System.Security.Principal.GenericPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C4*/ forwarder System.Security.Principal.IdentityNotMappedException
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003C5*/ forwarder System.Security.Principal.IdentityReference
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003C6*/ forwarder System.Security.Principal.IdentityReferenceCollection
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003C7*/ forwarder System.Security.Principal.IIdentity
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C8*/ forwarder System.Security.Principal.IPrincipal
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003C9*/ forwarder System.Security.Principal.NTAccount
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003CA*/ forwarder System.Security.Principal.PrincipalPolicy
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003CB*/ forwarder System.Security.Principal.SecurityIdentifier
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003CC*/ forwarder System.Security.Principal.TokenAccessLevels
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003CD*/ forwarder System.Security.Principal.TokenImpersonationLevel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003CE*/ forwarder System.Security.Principal.WellKnownSidType
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003CF*/ forwarder System.Security.Principal.WindowsBuiltInRole
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003D0*/ forwarder System.Security.Principal.WindowsIdentity
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003D1*/ forwarder System.Security.Principal.WindowsPrincipal
+{
+  .assembly extern System.Security.Principal.Windows /*23000003*/ 
+}
+.class extern /*270003D2*/ forwarder System.Text.ASCIIEncoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D3*/ forwarder System.Text.Decoder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D4*/ forwarder System.Text.DecoderExceptionFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D5*/ forwarder System.Text.DecoderExceptionFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D6*/ forwarder System.Text.DecoderFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D7*/ forwarder System.Text.DecoderFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D8*/ forwarder System.Text.DecoderFallbackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003D9*/ forwarder System.Text.DecoderReplacementFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DA*/ forwarder System.Text.DecoderReplacementFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DB*/ forwarder System.Text.Encoder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DC*/ forwarder System.Text.EncoderExceptionFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DD*/ forwarder System.Text.EncoderExceptionFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DE*/ forwarder System.Text.EncoderFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003DF*/ forwarder System.Text.EncoderFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E0*/ forwarder System.Text.EncoderFallbackException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E1*/ forwarder System.Text.EncoderReplacementFallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E2*/ forwarder System.Text.EncoderReplacementFallbackBuffer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E3*/ forwarder System.Text.Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E4*/ forwarder System.Text.EncodingInfo
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E5*/ forwarder System.Text.EncodingProvider
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E6*/ forwarder System.Text.NormalizationForm
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E7*/ forwarder System.Text.StringBuilder
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E8*/ forwarder System.Text.UnicodeEncoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003E9*/ forwarder System.Text.UTF32Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003EA*/ forwarder System.Text.UTF7Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003EB*/ forwarder System.Text.UTF8Encoding
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003EC*/ forwarder System.Threading.AbandonedMutexException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003ED*/ forwarder System.Threading.ApartmentState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003EE*/ forwarder System.Threading.AsyncFlowControl
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003EF*/ forwarder System.Threading.AsyncLocalValueChangedArgs`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F0*/ forwarder System.Threading.AsyncLocal`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F1*/ forwarder System.Threading.AutoResetEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F2*/ forwarder System.Threading.CancellationToken
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F3*/ forwarder System.Threading.CancellationTokenRegistration
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F4*/ forwarder System.Threading.CancellationTokenSource
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F5*/ forwarder System.Threading.CompressedStack
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F6*/ forwarder System.Threading.ContextCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F7*/ forwarder System.Threading.CountdownEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F8*/ forwarder System.Threading.EventResetMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003F9*/ forwarder System.Threading.EventWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FA*/ forwarder System.Threading.ExecutionContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FB*/ forwarder System.Threading.HostExecutionContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FC*/ forwarder System.Threading.HostExecutionContextManager
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FD*/ forwarder System.Threading.Interlocked
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FE*/ forwarder System.Threading.IOCompletionCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*270003FF*/ forwarder System.Threading.LazyInitializer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000400*/ forwarder System.Threading.LazyThreadSafetyMode
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000401*/ forwarder System.Threading.LockCookie
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000402*/ forwarder System.Threading.LockRecursionException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000403*/ forwarder System.Threading.ManualResetEvent
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000404*/ forwarder System.Threading.ManualResetEventSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000405*/ forwarder System.Threading.Monitor
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000406*/ forwarder System.Threading.Mutex
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000407*/ forwarder System.Threading.NativeOverlapped
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000408*/ forwarder System.Threading.Overlapped
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000409*/ forwarder System.Threading.ParameterizedThreadStart
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040A*/ forwarder System.Threading.ReaderWriterLock
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040B*/ forwarder System.Threading.RegisteredWaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040C*/ forwarder System.Threading.SemaphoreFullException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040D*/ forwarder System.Threading.SemaphoreSlim
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040E*/ forwarder System.Threading.SendOrPostCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700040F*/ forwarder System.Threading.SpinLock
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000410*/ forwarder System.Threading.SpinWait
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000411*/ forwarder System.Threading.SynchronizationContext
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000412*/ forwarder System.Threading.SynchronizationLockException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000413*/ forwarder System.Threading.Thread
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000414*/ forwarder System.Threading.ThreadAbortException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000415*/ forwarder System.Threading.ThreadInterruptedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000416*/ forwarder System.Threading.ThreadLocal`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000417*/ forwarder System.Threading.ThreadPool
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000418*/ forwarder System.Threading.ThreadPriority
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000419*/ forwarder System.Threading.ThreadStart
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041A*/ forwarder System.Threading.ThreadStartException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041B*/ forwarder System.Threading.ThreadState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041C*/ forwarder System.Threading.ThreadStateException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041D*/ forwarder System.Threading.Timeout
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041E*/ forwarder System.Threading.Timer
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700041F*/ forwarder System.Threading.TimerCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000420*/ forwarder System.Threading.Volatile
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000421*/ forwarder System.Threading.WaitCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000422*/ forwarder System.Threading.WaitHandle
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000423*/ forwarder System.Threading.WaitHandleCannotBeOpenedException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000424*/ forwarder System.Threading.WaitHandleExtensions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000425*/ forwarder System.Threading.WaitOrTimerCallback
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000426*/ forwarder System.Threading.Tasks.ConcurrentExclusiveSchedulerPair
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000427*/ forwarder System.Threading.Tasks.Parallel
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000428*/ forwarder System.Threading.Tasks.ParallelLoopResult
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000429*/ forwarder System.Threading.Tasks.ParallelLoopState
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042A*/ forwarder System.Threading.Tasks.ParallelOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042B*/ forwarder System.Threading.Tasks.Task
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042C*/ forwarder System.Threading.Tasks.TaskCanceledException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042D*/ forwarder System.Threading.Tasks.TaskCompletionSource`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042E*/ forwarder System.Threading.Tasks.TaskContinuationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*2700042F*/ forwarder System.Threading.Tasks.TaskCreationOptions
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000430*/ forwarder System.Threading.Tasks.TaskFactory
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000431*/ forwarder System.Threading.Tasks.TaskFactory`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000432*/ forwarder System.Threading.Tasks.TaskScheduler
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000433*/ forwarder System.Threading.Tasks.TaskSchedulerException
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000434*/ forwarder System.Threading.Tasks.TaskStatus
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000435*/ forwarder System.Threading.Tasks.Task`1
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.class extern /*27000436*/ forwarder System.Threading.Tasks.UnobservedTaskExceptionEventArgs
+{
+  .assembly extern netstandard /*23000001*/ 
+}
+.module mscorlib.dll
+// MVID: {a9d33822-1d27-4e72-b121-f7083d8427f4}
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000009    //  ILONLY
+// Image base: 0x00007FFAFE7A6000
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/netstandard.library.2.0.1.csproj
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/netstandard.library.2.0.1.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/targetPacks/ILsrc/netstandard.library/2.0.1/netstandard.library.nuspec
+++ b/src/targetPacks/ILsrc/netstandard.library/2.0.1/netstandard.library.nuspec
@@ -1,0 +1,418 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>NETStandard.Library</id>
+    <version>2.0.1</version>
+    <title>NETStandard.Library</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/dotnet/standard/blob/master/LICENSE.TXT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>A set of standard .NET APIs that are prescribed to be used and supported together. 
+b7f182415927d3b98445d043e1680c56b9d1f17c 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>.NET Foundation and Contributors</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework="MonoTouch1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.5.1">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETFramework4.6.1">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETCoreApp2.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.1">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.2">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.4">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.5">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.6">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile259">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework=".NETPortable4.5-Profile111">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETPortable4.6-Profile151">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+      </group>
+      <group targetFramework="UAP10.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="Microsoft.Win32.Primitives" version="4.3.0" />
+        <dependency id="System.AppContext" version="4.3.0" />
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.Concurrent" version="4.3.0" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tools" version="4.3.0" />
+        <dependency id="System.Diagnostics.Tracing" version="4.3.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.Globalization.Calendars" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.Compression" version="4.3.0" />
+        <dependency id="System.IO.Compression.ZipFile" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Linq.Expressions" version="4.3.0" />
+        <dependency id="System.Net.Http" version="4.3.2" />
+        <dependency id="System.Net.Primitives" version="4.3.0" />
+        <dependency id="System.Net.Sockets" version="4.3.0" />
+        <dependency id="System.ObjectModel" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Reflection.Extensions" version="4.3.0" />
+        <dependency id="System.Reflection.Primitives" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.X509Certificates" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.Encoding.Extensions" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Threading.Tasks" version="4.3.0" />
+        <dependency id="System.Threading.Timer" version="4.3.0" />
+        <dependency id="System.Xml.ReaderWriter" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+      </group>
+      <group targetFramework="UAP10.0.15138">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework="WindowsPhoneApp8.1">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+      </group>
+      <group targetFramework="Xamarin.iOS1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework="Xamarin.Mac2.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework="Xamarin.TVOS1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+      <group targetFramework="Xamarin.WatchOS1.0">
+        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="*/**" target="/" exclude="obj/**/*.*;**/Debug/**/*.*" />
+    <file src="*" target="/" exclude="*.csproj" />
+  </files>
+</package>


### PR DESCRIPTION
This is required in order to eliminate prebuilts in .NET 7.0