### PR TITLE
Add back System.Security.Cryptography.OpenSsl 4.3.0

### DIFF
--- a/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.nuspec</NuspecFile>
+   </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)system.security.cryptography.openssl/4.3.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)system.security.cryptography.openssl/4.3.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+        <PackageReference Include="System.Collections" Version="4.3.0" />
+        <PackageReference Include="System.IO" Version="4.3.0" />
+        <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+        <PackageReference Include="System.Runtime" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
+        <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+        <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.3.0" />
+        <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+        <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    </ItemGroup>
+
+  
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/ref/netstandard1.6/System.Security.Cryptography.OpenSsl.cs
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/ref/netstandard1.6/System.Security.Cryptography.OpenSsl.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyDescription("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyDefaultAlias("System.Security.Cryptography.OpenSsl")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("1.0.24212.01")]
+[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("4.0.0.0")]
+
+
+
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class ECDsaOpenSsl : System.Security.Cryptography.ECDsa
+    {
+        public ECDsaOpenSsl() { }
+        public ECDsaOpenSsl(int keySize) { }
+        public ECDsaOpenSsl(System.IntPtr handle) { }
+        public ECDsaOpenSsl(System.Security.Cryptography.ECCurve curve) { }
+        public ECDsaOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
+        public override int KeySize { get { throw null; } set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        protected override void Dispose(bool disposing) { }
+        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
+        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
+        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        public override void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
+        public override byte[] SignHash(byte[] hash) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature) { throw null; }
+    }
+    public sealed partial class RSAOpenSsl : System.Security.Cryptography.RSA
+    {
+        public RSAOpenSsl() { }
+        public RSAOpenSsl(int keySize) { }
+        public RSAOpenSsl(System.IntPtr handle) { }
+        public RSAOpenSsl(System.Security.Cryptography.RSAParameters parameters) { }
+        public RSAOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
+        public override int KeySize { set { } }
+        public override System.Security.Cryptography.KeySizes[] LegalKeySizes { get { throw null; } }
+        public override byte[] Decrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
+        protected override void Dispose(bool disposing) { }
+        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
+        public override byte[] Encrypt(byte[] data, System.Security.Cryptography.RSAEncryptionPadding padding) { throw null; }
+        public override System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override void ImportParameters(System.Security.Cryptography.RSAParameters parameters) { }
+        public override byte[] SignHash(byte[] hash, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+        public override bool VerifyHash(byte[] hash, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
+    }
+    public sealed partial class SafeEvpPKeyHandle : System.Runtime.InteropServices.SafeHandle
+    {
+        public SafeEvpPKeyHandle(System.IntPtr handle, bool ownsHandle) : base (default(System.IntPtr), default(bool)) { }
+        public override bool IsInvalid { get { throw null; } }
+        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateHandle() { throw null; }
+        protected override bool ReleaseHandle() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.nuspec
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>System.Security.Cryptography.OpenSsl</id>
+    <version>4.3.0</version>
+    <title>System.Security.Cryptography.OpenSsl</title>
+    <authors>Microsoft</authors>
+    <owners>microsoft,dotnetframework</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <description>Provides cryptographic algorithm implementations and key management for non-Windows systems with OpenSSL.
+
+Commonly Used Types:
+System.Security.Cryptography.RSAOpenSsl
+ 
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <group targetFramework="MonoAndroid1.0">
+      </group>
+      <group targetFramework="MonoTouch1.0">
+      </group>
+      <group targetFramework=".NETFramework4.6.3">
+        <dependency id="System.IO" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework=".NETStandard1.6">
+        <dependency id="System.Collections" version="4.3.0" exclude="Compile" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Handles" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Runtime.Numerics" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Encoding" version="4.3.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Primitives" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" exclude="Compile" />
+      </group>
+      <group targetFramework="Xamarin.iOS1.0">
+      </group>
+      <group targetFramework="Xamarin.Mac2.0">
+      </group>
+      <group targetFramework="Xamarin.TVOS1.0">
+      </group>
+      <group targetFramework="Xamarin.WatchOS1.0">
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.openssl/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.openssl/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.OpenSsl</AssemblyName>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This was inadvertently removed with https://github.com/dotnet/source-build-reference-packages/pull/396.