### PR TITLE
Add back microsoft.build.centralpackageversions text only package

### DIFF
--- a/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Microsoft.Build.CentralPackageVersions.nuspec
+++ b/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Microsoft.Build.CentralPackageVersions.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Build.CentralPackageVersions</id>
+    <version>2.0.1</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/Microsoft/MSBuildSdks/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/MSBuildSdks</projectUrl>
+    <iconUrl>https://github.com/Microsoft/msbuild/raw/master/branding/MSBuild-NuGet-Icon.png</iconUrl>
+    <description>Provides the ability to centrally manage your NuGet package versions when using PackageReference.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>MSBuild MSBuildSdk</tags>
+    <packageTypes>
+      <packageType name="MSBuildSdk" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <file src="*/**" target="/" exclude="obj/**/*.*" />
+    <file src="*" target="/" />
+  </files>
+</package>

--- a/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Sdk/Sdk.props
+++ b/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Sdk/Sdk.props
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeCentralPackageVersionsProps)" Condition=" '$(CustomBeforeCentralPackageVersionsProps)' != '' And Exists('$(CustomBeforeCentralPackageVersionsProps)') " />
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') "/>
+
+  <Import Project="$(CustomAfterCentralPackageVersionsProps)" Condition=" '$(CustomAfterCentralPackageVersionsProps)' != '' And Exists('$(CustomAfterCentralPackageVersionsProps)') " />
+</Project>

--- a/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Sdk/Sdk.targets
+++ b/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/Sdk/Sdk.targets
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project InitialTargets="CheckPackageReferences" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Import a user extension if specified.
+  -->
+  <Import Project="$(CustomBeforeCentralPackageVersionsTargets)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And '$(CustomBeforeCentralPackageVersionsTargets)' != '' And Exists('$(CustomBeforeCentralPackageVersionsTargets)') " />
+
+  <PropertyGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Walk up the directory tree looking for a Packages.props, unless a user has already specified a path.
+    -->
+    <CentralPackagesFile Condition=" '$(CentralPackagesFile)' == '' ">$([MSBuild]::GetPathOfFileAbove('Packages.props', $(MSBuildProjectDirectory)))</CentralPackagesFile>
+
+    <!--
+      Disable all functionality if the central package management file does not exist.
+    -->
+    <EnableCentralPackageVersions Condition=" !Exists('$(CentralPackagesFile)') ">false</EnableCentralPackageVersions>
+
+    <!--
+      Include this file and the Packages.props file (if necessary) in MSBuildAllProjects so that rebuilds happen if the Packages.props changes.
+    -->
+    <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
+    <MSBuildAllProjects Condition=" '$(EnableCentralPackageVersions)' != 'false' ">$(CentralPackagesFile);$(MSBuildAllProjects)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <GlobalPackageReference Condition=" $([MSBuild]::ValueOrDefault('$(EnableGlobalPackageReferencePrivateAssetsAll)', 'true')) ">
+      <!--
+        Default global package references to only consume the Analyzers and Build logic in a package.
+        This helps ensure that the package assets are not passed to the compiler or copied to the
+        output directory.  Having a compile-time reference to a package for all projects in a tree
+        is not recommended.  You should only have "global" references to packages that are used for
+        build.
+      -->
+      <IncludeAssets>Analyzers;Build</IncludeAssets>
+      <!--
+        Default global package references to have all assets private.  This is because global package
+        references are generally stuff like versioning, signing, etc and should not flow to downstream
+        dependencies.  Also, global package references are already referenced by every project in the
+        tree so we don't need them to be transitive.
+      -->
+      <PrivateAssets>All</PrivateAssets>
+    </GlobalPackageReference>
+  </ItemDefinitionGroup>
+
+  <ItemGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Store a list of <PackageReference /> items that specified a Version so that an error can be displayed.
+    -->
+    <_PackageReferenceWithVersion Include="@(PackageReference->HasMetadata('Version'))" />
+
+    <!--
+      Store a list of the original <PackageReference /> items so later they can be checked for duplicates in
+      the <GlobalPackageReference /> items.  Clear the metadata to save some memory.
+    -->
+    <_OriginalPackageReference Include="@(PackageReference->ClearMetadata())" />
+  </ItemGroup>
+
+  <Import Project="$(CentralPackagesFile)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' " />
+
+  <ItemGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
+    <!--
+      Copy <GlobalPackageReference /> items to the list of <PackageReference /> items.
+    -->
+    <PackageReference Include="@(GlobalPackageReference)"
+                      Condition=" '$(EnableGlobalPackageReferences)' != 'false' " />
+
+    <!--
+      Get a list of <PackageReference /> items that specify the VersionOverride metadata and copy the value
+      to the Version metadata.  All other metadata is also copied.
+      
+      VersionOverride is important because it forces the user to opt-in to overriding a version at the project
+      level.
+    -->
+    <_PackageReferenceWithVersionOverride Include="@(PackageReference->HasMetadata('VersionOverride'))"
+                                          Version="%(VersionOverride)"
+                                          Condition=" '$(EnablePackageVersionOverride)' != 'false' "
+                                          />
+
+    <!--
+      Remove items in the original <PackageReference /> list that have a version override so that they can be
+      added back. The items being added have their Version set to the original VersionOverride.
+    -->
+    <PackageReference Remove="@(_PackageReferenceWithVersionOverride)"
+                      Condition=" '$(EnablePackageVersionOverride)' != 'false' "/>
+
+    <PackageReference Include="@(_PackageReferenceWithVersionOverride)"
+                      Condition=" '$(EnablePackageVersionOverride)' != 'false' "/>
+
+    <!--
+      Clear the temporary list of package references with VersionOverride to free up some memory.
+    -->
+    <_PackageReferenceWithVersionOverride Remove="@(_PackageReferenceWithVersionOverride)" />
+  </ItemGroup>
+
+  <Target Name="CheckPackageReferences"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And @(PackageReference->Count()) > 0 ">
+
+    <!--
+      Get a list of duplicate <PackageReference /> and <GlobalPackageReference /> items.  Users must be made aware
+      that this could cause strange behavior and they should not include a PackageReference if there's already a 
+      global PackageReference.
+    -->
+    <ItemGroup Condition=" '$(EnableGlobalPackageReferences)' != 'false' ">
+      <_DuplicateGlobalPackageReference Include="@(_OriginalPackageReference)"
+                                        Condition=" '@(GlobalPackageReference)' == '@(_OriginalPackageReference)' and '%(Identity)' != '' " />
+    </ItemGroup>
+
+    <!--
+      Log an error if there are any duplicate <PackageReference /> items where a <GlobalPackageReference /> is already defined.
+    -->
+    <Error
+      Text="The package reference '%(_DuplicateGlobalPackageReference.Identity)' is already defined as a GlobalPackageReference in '$(CentralPackagesFile)'.  Individual projects do not need to include a PackageReference if a GlobalPackageReference is declared."
+      Condition=" '$(EnableGlobalPackageReferences)' != 'false' And @(_DuplicateGlobalPackageReference->Count()) > 0"
+      File="$(MSBuildProjectFullPath)" />
+
+    <!--
+      Generate an error if any explicit PackageReference has a version specified in a project.  Users must specify a version in
+      the central pacakge management file or use VersionOverride.
+    -->
+    <Error
+      Text="The package reference '%(_PackageReferenceWithVersion.Identity)' should not specify a version.  Please specify the version in '$(CentralPackagesFile)' or set VersionOverride to override the centrally defined version."
+      Condition=" @(_PackageReferenceWithVersion->Count()) > 0 And '%(_PackageReferenceWithVersion.IsImplicitlyDefined)' != 'true' And '$(EnablePackageVersionOverride)' != 'false' "
+      File="$(MSBuildProjectFullPath) "/>
+
+    <Error
+      Text="The package reference '%(_PackageReferenceWithVersion.Identity)' should not specify a version.  Please specify the version in '$(CentralPackagesFile)'."
+      Condition=" @(_PackageReferenceWithVersion->Count()) > 0 And '%(_PackageReferenceWithVersion.IsImplicitlyDefined)' != 'true' And '$(EnablePackageVersionOverride)' == 'false'"
+      File="$(MSBuildProjectFullPath) "/>
+
+    <!--
+      Generate an error if any explicit PackageReference did not have Version specified in the central package management file.
+    -->
+    <Error
+      Text="The package reference '%(PackageReference.Identity)' must have a version defined in '$(CentralPackagesFile)'."
+      Condition=" '%(PackageReference.IsImplicitlyDefined)' != 'true' And '%(PackageReference.Version)' == '' "
+      File="$(MSBuildProjectFullPath)" />
+  </Target>
+
+  <!--
+    Import a user extension if specified.
+  -->
+  <Import Project="$(CustomAfterCentralPackageVersionsTargets)"
+          Condition=" '$(EnableCentralPackageVersions)' != 'false' And '$(CustomAfterCentralPackageVersionsTargets)' != '' And Exists('$(CustomAfterCentralPackageVersionsTargets)') " />
+
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/microsoft.build.centralpackageversions.2.0.1.csproj
+++ b/src/textOnlyPackages/src/microsoft.build.centralpackageversions/2.0.1/microsoft.build.centralpackageversions.2.0.1.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
This package was incorrect removed with the cleanup work performed in https://github.com/dotnet/source-build-reference-packages/pull/412.  This package gits [directly referenced outside of nuget ](https://github.com/dotnet/installer/blob/main/src/SourceBuild/tarball/content/repos/msbuild.proj#L65) which is why it was incorrectly flagged as something that was unreferenced.