### PR TITLE
Update versioning in main to be 8.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MajorVersion>7</MajorVersion>
+    <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>


### PR DESCRIPTION
After branching for [release/7.0](https://github.com/dotnet/source-build-reference-packages/tree/release/7.0), main should be versioned 8.0.