### PR TITLE
[source-build/3084] Bump GenAPI version 7.0.0-beta.22166.1 -> 8.0.0-beta.22526.10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>7.0.0-beta.22166.1</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>8.0.0-beta.22526.10</MicrosoftDotNetGenAPIPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.20113.5</MicrosoftDotNetBuildTasksPackagingPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Issue: https://github.com/dotnet/source-build/issues/3084
After the [commit](https://github.com/dotnet/source-build-reference-packages/commit/1f8037df094f11e7ab0422cbe514726ccc920d78), where dotnet version was upgraded from 7.0 preview.5 to 7.0 preview.7 SBRP generator tool starts failing saying:
> Could not load file or assembly 'Microsoft.Cci.Extensions, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.\n

Updating version of GenAPI to newer fix this problem.