### PR TITLE
Update SBRP intermediate reference to address CG alert

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,9 +8,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="7.0.0-alpha.1.22504.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.22531.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>8366acfc3e0660ceef6bddbe7794044e5d503521</Sha>
+      <Sha>3a28951c30c0346168dbfe2c55ec1d41c5f70b60</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.22524.5">


### PR DESCRIPTION
There are two component governance alerts in main in which the underlying issues have been fixed by:

https://github.com/dotnet/source-build-reference-packages/pull/473
https://github.com/dotnet/source-build-reference-packages/pull/472

The SBRP intermediate reference needs to be updated to include these fixes in order to fully address the alert.  The old SBRP reference is still bringing in the older SBRP packages.