### PR TITLE
Add the Roslyn-based GenAPI as a secondary backend. Introduce --genapi-backend option.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -14,6 +14,7 @@
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
+    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -6,7 +6,12 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(GeneratePackageSource)' == 'true' ">
+  <ItemGroup Condition=" '$(GeneratePackageSource)' == 'true' AND '$(GenAPIBackend)' == 'roslyn' ">
+    <PackageReference Include="Microsoft.DotNet.GenAPI.Task" Version="$(MicrosoftDotNetGenAPITaskPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(GeneratePackageSource)' == 'true' AND '$(GenAPIBackend)' == 'cci' ">
     <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
   </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,7 @@
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>
     <MicrosoftDotNetGenAPIPackageVersion>8.0.0-beta.22554.2</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPITaskPackageVersion>8.0.100-alpha.1.22573.3</MicrosoftDotNetGenAPITaskPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.20113.5</MicrosoftDotNetBuildTasksPackagingPackageVersion>
   </PropertyGroup>
 </Project>

--- a/generate.sh
+++ b/generate.sh
@@ -12,6 +12,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 RED='\033[0;31m'
 NC='\033[0m'
 
+backend="cci"
+
 usage() {
     echo "usage: $0 [options]"
     echo ""
@@ -35,6 +37,7 @@ usage() {
     echo "  --dest <pathToDestRepo>            A path to the root of the repo to copy source into."
     echo "  --type <packageType>               Type of the package to generate. Accepted values: ref (default) | text."
     echo "  --feeds <nugetFeeds>               A semicolon-separated list of additional NuGet feeds to use during restore."
+    echo "  --genapi-backend                   The GenAPI backend used to generate reference assemblies [cci|roslyn]. Default is '$backend'."
     echo ""
 }
 
@@ -86,6 +89,15 @@ while [ $# -gt 0 ]; do
             ;;
         --feeds)
             feeds="$2"
+            shift
+            ;;
+        --genapi-backend)
+            backend="$2"
+            if [[ ! "$backend" =~ ^(cci|roslyn)$ ]]; then
+                echo -e "${RED}ERROR: unknown backend type - $2${NC}"
+                usage
+                exit 1
+            fi
             shift
             ;;
         *)
@@ -151,7 +163,7 @@ if [[ "$packageType" == "ref" ]]; then
     pathToRepoSrc="$pathToDestRepo"
 
     # Build the projects to generate source and projects
-    "$scriptroot/eng/common/build.sh" --build --restore -bl /p:GeneratePackageSource=true /p:GeneratorVersion=2 /p:PathToRepoSrc="$pathToRepoSrc" /p:RestoreAdditionalProjectSources="\"$feeds\"" "$@"
+    "$scriptroot/eng/common/build.sh" --build --restore -bl /p:GeneratePackageSource=true /p:GenAPIBackend="\"$backend\"" /p:GeneratorVersion=2 /p:PathToRepoSrc="$pathToRepoSrc" /p:RestoreAdditionalProjectSources="\"$feeds\"" "$@"
 else
     # -p:RestoreAdditionalProjectSources -> specifies additional Nuget package sources, including feeds: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-properties
     # -p:RestoreUsingNuGetTargets -> switch that controls who will restore the project; if set to `false`, Arcade's Build.proj will execute the Restore target of the project itself.

--- a/generate.sh
+++ b/generate.sh
@@ -12,7 +12,6 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 RED='\033[0;31m'
 NC='\033[0m'
 
-backend="cci"
 
 usage() {
     echo "usage: $0 [options]"
@@ -37,10 +36,11 @@ usage() {
     echo "  --dest <pathToDestRepo>            A path to the root of the repo to copy source into."
     echo "  --type <packageType>               Type of the package to generate. Accepted values: ref (default) | text."
     echo "  --feeds <nugetFeeds>               A semicolon-separated list of additional NuGet feeds to use during restore."
-    echo "  --genapi-backend                   The GenAPI backend used to generate reference assemblies [cci|roslyn]. Default is '$backend'."
+    echo "  --genapi-backend                   The GenAPI backend used to generate reference assemblies. Accepted values: cci (default) | roslyn."
     echo ""
 }
 
+backend="cci"
 packageVersion=
 defaultPathToCSV="$scriptroot/artifacts/targetPackages.csv"
 pathToCSV=

--- a/src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj
+++ b/src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj
@@ -9,6 +9,11 @@
 
   <Import Project="../../common/RestoreProjects.proj"/>
 
+  <ItemGroup>
+    <GenAPIInputAssembly Include="$(_GenAPIInputAssembly)" />
+    <GenAPIExcludeAttributesList Include="$(_GenAPIExcludeAttributesList)" />
+  </ItemGroup>
+
   <Target Name="CopyNuspecFiles" BeforeTargets="CoreCompile">
     <Message Importance="High" Text="==> Copying all target package nuspec files to generated source" />
     <Copy SourceFiles="@(NuspecFiles)" DestinationFiles="@(NuspecFiles->'$(GeneratedSourcePath)%(RecursiveDir)%(Filename)%(Extension)')" />
@@ -22,7 +27,7 @@
     <Message Importance="High" Text="Copy DummyFiles Complete."/>
   </Target>
 
-  <Target Name="SetupReferencePath" BeforeTargets="GenerateReferenceAssemblySource" DependsOnTargets="GetGenApiDlls">
+  <Target Name="SetupReferencePath" BeforeTargets="GenerateReferenceAssemblySource;GenAPIGenerateReferenceAssemblySource" DependsOnTargets="GetGenApiDlls">
     <!-- ReferencePath is used by the GenerateReferenceAsemblySource target to locate references -->
     <ItemGroup>
         <ReferencePath Include="@(GenApiDlls)" />
@@ -31,10 +36,16 @@
   </Target>
 
   <Target Name="CoreCompile" DependsOnTargets="GetGenApiDlls" >
-    <Message Importance="High" Text="==> Generating source for all target package dlls" />
+    <Message Importance="High" Text="==> Generating source for all target package dlls with $(GenAPIBackend) backend" />
     <MakeDir Directories="$(GeneratedSourcePath)%(GenApiDlls.RecursiveDir)" />
 
-    <MSBuild Projects="$(RepoRoot)src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj" 
+    <MSBuild Projects="$(RepoRoot)src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj;"
+        Condition=" '$(GenAPIBackend)' == 'roslyn' "
+        Targets="GenAPIGenerateReferenceAssemblySource"
+        Properties="_GenAPIInputAssembly=%(GenApiDlls.Identity);_GenAPIExcludeAttributesList=$(RepoRoot)src/referencePackageSourceGenerator/DefaultGenApiDocIds.txt;GenAPITargetPath=$(GeneratedSourcePath)%(GenApiDlls.RecursiveDir)%(GenApiDlls.Filename).cs;GenAPIHeaderFile=$(RepoRoot)src/referencePackageSourceGenerator/LicenseHeader.txt" />
+
+    <MSBuild Projects="$(RepoRoot)src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj"
+        Condition=" '$(GenAPIBackend)' == 'cci' "
         Targets="GenerateReferenceAssemblySource"
         Properties="GenAPIInputAssembly=%(GenApiDlls.Identity);GenAPITargetPath=$(GeneratedSourcePath)%(GenApiDlls.RecursiveDir)%(GenApiDlls.Filename).cs;GenAPIHeaderFile=$(RepoRoot)src/referencePackageSourceGenerator/LicenseHeader.txt;GenAPIExcludeAttributesList=$(RepoRoot)src/referencePackageSourceGenerator/DefaultGenApiDocIds.txt;" />
 


### PR DESCRIPTION
* Add `dotnet8-transport` to a list of package sources
* Add `--genapi-backend` option [cci|roslyn] with the default value `cci`
* Based on parameters either the Roslyn-based or the Cci-based GenAPI is used to generate reference assemblies.

https://github.com/dotnet/arcade/issues/11726

p.s. The Roslyn-based GenAPI (based on SyntaxGenerator and CSharpSyntaxRewriter) is in testing phase. I created this PR to communicate the changes and usage of the tooling. We can merge it or wait till the Testing is finished.