### PR TITLE
Fix the order of the `FindReferenceAssembliesForReferences` and the `GetGenApiDlls` targets invocation.

### DIFF
--- a/src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj
+++ b/src/referencePackageSourceGenerator/GenerateSource/GenerateSource.proj
@@ -39,7 +39,7 @@
     <Message Importance="High" Text="Copy DummyFiles Complete."/>
   </Target>
 
-  <Target Name="SetupReferencePath" BeforeTargets="GenerateReferenceAssemblySource;GenAPIGenerateReferenceAssemblySource" DependsOnTargets="GetGenApiDlls">
+  <Target Name="SetupReferencePath" BeforeTargets="FindReferenceAssembliesForReferences;GenerateReferenceAssemblySource;GenAPIGenerateReferenceAssemblySource" DependsOnTargets="GetGenApiDlls">
     <!-- ReferencePath is used by the GenerateReferenceAsemblySource target to locate references -->
     <ItemGroup>
         <ReferencePath Include="@(GenApiDlls)" />


### PR DESCRIPTION
In order to have `@(ReferencePathWithRefAssemblies)` variable to be set correctly we must invoke the `FindReferenceAssembliesForReferences` target before the `GetGenApiDlls` target.