### PR TITLE
Add Microsoft.Extensions.ObjectPool 6.0.0

### DIFF
--- a/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.6.0.0.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <NuspecFile>$(ArtifactsBinDir)microsoft.extensions.objectpool/6.0.0/microsoft.extensions.objectpool.nuspec</NuspecFile>
+    <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>$(ArtifactsBinDir)microsoft.extensions.objectpool/6.0.0/ref/</OutputPath>
+    <IntermediateOutputPath>$(ArtifactsObjDir)microsoft.extensions.objectpool/6.0.0</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <OutputPath>$(ArtifactsBinDir)microsoft.extensions.objectpool/6.0.0/lib/</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <OutputPath>$(ArtifactsBinDir)microsoft.extensions.objectpool/6.0.0/lib/</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
+    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.nuspec
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Extensions.ObjectPool</id>
+    <version>6.0.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://asp.net/</projectUrl>
+    <description>A simple object pool implementation.
+
+This package was built from the source code at https://github.com/dotnet/aspnetcore/tree/ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>pooling</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/aspnetcore" commit="ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.1" />
+      <group targetFramework="net6.0" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/lib/net461/Microsoft.Extensions.ObjectPool.cs
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/lib/net461/Microsoft.Extensions.ObjectPool.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyDescription("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyDefaultAlias("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("6.0.21.52608")]
+[assembly: AssemblyInformationalVersion("6.0.21.52608 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("6.0.0.0")]
+
+
+
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    public partial class DefaultObjectPoolProvider : Microsoft.Extensions.ObjectPool.ObjectPoolProvider
+    {
+        public DefaultObjectPoolProvider() { }
+        public int MaximumRetained { get { throw null; } set { } }
+        public override Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { throw null; }
+    }
+    public partial class DefaultObjectPool<T> : Microsoft.Extensions.ObjectPool.ObjectPool<T> where T : class
+    {
+        public DefaultObjectPool(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { }
+        public DefaultObjectPool(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy, int maximumRetained) { }
+        public override T Get() { throw null; }
+        public override void Return(T obj) { }
+    }
+    public partial class DefaultPooledObjectPolicy<T> : Microsoft.Extensions.ObjectPool.PooledObjectPolicy<T> where T : class, new()
+    {
+        public DefaultPooledObjectPolicy() { }
+        public override T Create() { throw null; }
+        public override bool Return(T obj) { throw null; }
+    }
+    public partial interface IPooledObjectPolicy<T> where T : notnull
+    {
+        T Create();
+        bool Return(T obj);
+    }
+    public partial class LeakTrackingObjectPoolProvider : Microsoft.Extensions.ObjectPool.ObjectPoolProvider
+    {
+        public LeakTrackingObjectPoolProvider(Microsoft.Extensions.ObjectPool.ObjectPoolProvider inner) { }
+        public override Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { throw null; }
+    }
+    public partial class LeakTrackingObjectPool<T> : Microsoft.Extensions.ObjectPool.ObjectPool<T> where T : class
+    {
+        public LeakTrackingObjectPool(Microsoft.Extensions.ObjectPool.ObjectPool<T> inner) { }
+        public override T Get() { throw null; }
+        public override void Return(T obj) { }
+    }
+    public static partial class ObjectPool
+    {
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T>? policy = null) where T : class, new() { throw null; }
+    }
+    public abstract partial class ObjectPoolProvider
+    {
+        protected ObjectPoolProvider() { }
+        public Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>() where T : class, new() { throw null; }
+        public abstract Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) where T : class;
+    }
+    public static partial class ObjectPoolProviderExtensions
+    {
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<System.Text.StringBuilder> CreateStringBuilderPool(this Microsoft.Extensions.ObjectPool.ObjectPoolProvider provider) { throw null; }
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<System.Text.StringBuilder> CreateStringBuilderPool(this Microsoft.Extensions.ObjectPool.ObjectPoolProvider provider, int initialCapacity, int maximumRetainedCapacity) { throw null; }
+    }
+    public abstract partial class ObjectPool<T> where T : class
+    {
+        protected ObjectPool() { }
+        public abstract T Get();
+        public abstract void Return(T obj);
+    }
+    public abstract partial class PooledObjectPolicy<T> : Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> where T : notnull
+    {
+        protected PooledObjectPolicy() { }
+        public abstract T Create();
+        public abstract bool Return(T obj);
+    }
+    public partial class StringBuilderPooledObjectPolicy : Microsoft.Extensions.ObjectPool.PooledObjectPolicy<System.Text.StringBuilder>
+    {
+        public StringBuilderPooledObjectPolicy() { }
+        public int InitialCapacity { get { throw null; } set { } }
+        public int MaximumRetainedCapacity { get { throw null; } set { } }
+        public override System.Text.StringBuilder Create() { throw null; }
+        public override bool Return(System.Text.StringBuilder obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/lib/netstandard2.0/Microsoft.Extensions.ObjectPool.cs
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/lib/netstandard2.0/Microsoft.Extensions.ObjectPool.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: ReferenceAssembly]
+[assembly: AssemblyTitle("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyDescription("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyDefaultAlias("Microsoft.Extensions.ObjectPool")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: AssemblyFileVersion("6.0.21.52608")]
+[assembly: AssemblyInformationalVersion("6.0.21.52608 built by: SOURCEBUILD")]
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyMetadata("", "")]
+[assembly: AssemblyVersion("6.0.0.0")]
+
+
+
+
+namespace Microsoft.Extensions.ObjectPool
+{
+    public partial class DefaultObjectPoolProvider : Microsoft.Extensions.ObjectPool.ObjectPoolProvider
+    {
+        public DefaultObjectPoolProvider() { }
+        public int MaximumRetained { get { throw null; } set { } }
+        public override Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { throw null; }
+    }
+    public partial class DefaultObjectPool<T> : Microsoft.Extensions.ObjectPool.ObjectPool<T> where T : class
+    {
+        public DefaultObjectPool(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { }
+        public DefaultObjectPool(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy, int maximumRetained) { }
+        public override T Get() { throw null; }
+        public override void Return(T obj) { }
+    }
+    public partial class DefaultPooledObjectPolicy<T> : Microsoft.Extensions.ObjectPool.PooledObjectPolicy<T> where T : class, new()
+    {
+        public DefaultPooledObjectPolicy() { }
+        public override T Create() { throw null; }
+        public override bool Return(T obj) { throw null; }
+    }
+    public partial interface IPooledObjectPolicy<T> where T : notnull
+    {
+        T Create();
+        bool Return(T obj);
+    }
+    public partial class LeakTrackingObjectPoolProvider : Microsoft.Extensions.ObjectPool.ObjectPoolProvider
+    {
+        public LeakTrackingObjectPoolProvider(Microsoft.Extensions.ObjectPool.ObjectPoolProvider inner) { }
+        public override Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) { throw null; }
+    }
+    public partial class LeakTrackingObjectPool<T> : Microsoft.Extensions.ObjectPool.ObjectPool<T> where T : class
+    {
+        public LeakTrackingObjectPool(Microsoft.Extensions.ObjectPool.ObjectPool<T> inner) { }
+        public override T Get() { throw null; }
+        public override void Return(T obj) { }
+    }
+    public static partial class ObjectPool
+    {
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T>? policy = null) where T : class, new() { throw null; }
+    }
+    public abstract partial class ObjectPoolProvider
+    {
+        protected ObjectPoolProvider() { }
+        public Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>() where T : class, new() { throw null; }
+        public abstract Microsoft.Extensions.ObjectPool.ObjectPool<T> Create<T>(Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> policy) where T : class;
+    }
+    public static partial class ObjectPoolProviderExtensions
+    {
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<System.Text.StringBuilder> CreateStringBuilderPool(this Microsoft.Extensions.ObjectPool.ObjectPoolProvider provider) { throw null; }
+        public static Microsoft.Extensions.ObjectPool.ObjectPool<System.Text.StringBuilder> CreateStringBuilderPool(this Microsoft.Extensions.ObjectPool.ObjectPoolProvider provider, int initialCapacity, int maximumRetainedCapacity) { throw null; }
+    }
+    public abstract partial class ObjectPool<T> where T : class
+    {
+        protected ObjectPool() { }
+        public abstract T Get();
+        public abstract void Return(T obj);
+    }
+    public abstract partial class PooledObjectPolicy<T> : Microsoft.Extensions.ObjectPool.IPooledObjectPolicy<T> where T : notnull
+    {
+        protected PooledObjectPolicy() { }
+        public abstract T Create();
+        public abstract bool Return(T obj);
+    }
+    public partial class StringBuilderPooledObjectPolicy : Microsoft.Extensions.ObjectPool.PooledObjectPolicy<System.Text.StringBuilder>
+    {
+        public StringBuilderPooledObjectPolicy() { }
+        public int InitialCapacity { get { throw null; } set { } }
+        public int MaximumRetainedCapacity { get { throw null; } set { } }
+        public override System.Text.StringBuilder Create() { throw null; }
+        public override bool Return(System.Text.StringBuilder obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.extensions.objectpool/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Extensions.ObjectPool</AssemblyName>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Adds Microsoft.Extensions.ObjectPool 6.0.0 due to prebuilt being introduced for this package from https://github.com/dotnet/razor. This looks to have been caused by https://github.com/dotnet/razor/pull/8289.