### PR TITLE
Remove excluded tfms from nuspec & update list of exclusions

### DIFF
--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -170,7 +170,7 @@
              Condition="'@(PackagePlaceholderFile)' != ''" />
   </Target>
 
-  <!-- Copy nuspec to target directory and remove icon element from it. -->
+  <!-- Rewrite nuspec and copy to target directory. -->
   <UsingTask TaskName="RewriteNuspec" AssemblyFile="$(ReferencePackageSourceTaskAssembly)" />
   <Target Name="RewriteNuspec">
     <PropertyGroup>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,7 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;MonoTouch</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageName)' != '' and '$(PackageVersion)' != ''">
@@ -53,7 +53,7 @@
   <!-- Emit a log message that indicates the start of the package source generation. -->
   <Target Name="BeginGeneratePackageSource">
     <PropertyGroup>
-      <PackageTargetFrameworksMessage Condition="'$(PackageType)' != 'text' and '$(PackageTargetFrameworks)' != ''">, Filtered TFMs: $(PackageTargetFrameworks)</PackageTargetFrameworksMessage>
+      <PackageTargetFrameworksMessage Condition="'$(PackageType)' != 'text' and '$(PackageTargetFrameworks)' != ''">, TFMs: $(PackageTargetFrameworks)</PackageTargetFrameworksMessage>
     </PropertyGroup>
 
     <Message Text="%0D%0A$(MSBuildProjectName) -> Generating package source for $(PackageName) (v$(PackageVersion)$(PackageTargetFrameworksMessage))..."
@@ -171,26 +171,19 @@
   </Target>
 
   <!-- Copy nuspec to target directory and remove icon element from it. -->
+  <UsingTask TaskName="RewriteNuspec" AssemblyFile="$(ReferencePackageSourceTaskAssembly)" />
   <Target Name="CopyNuspec">
     <PropertyGroup>
-      <!-- Regex for '<icon>{icon_file_name}</icon>' + line spacing before the attribute (\s) -->
-      <IconRegex>\s+&lt;icon&gt;.+&lt;\/icon&gt;</IconRegex>
-
       <NuspecPath>$(PackageSourceDirectory)$(PackageName.ToLowerInvariant()).nuspec</NuspecPath>
       <NuspecTargetPath>$(PackageTargetDirectory)$([System.IO.Path]::GetFileName('$(NuspecPath)'))</NuspecTargetPath>
     </PropertyGroup>
 
-    <Copy SourceFiles="$(NuspecPath)"
-          DestinationFiles="$(NuspecTargetPath)"
-          SkipUnchangedFiles="true" />
-
-    <PropertyGroup>
-      <NuspecContent>$([System.IO.File]::ReadAllText('$(NuspecTargetPath)'))</NuspecContent>
-    </PropertyGroup>
-
-    <WriteLinesToFile File="$(NuspecTargetPath)"
-                      Lines="$([System.Text.RegularExpressions.Regex]::Replace('$(NuspecContent)', '$(IconRegex)', ''))"
-                      Overwrite="true" />
+    <RewriteNuspec NuspecPath="$(NuspecPath)"
+                   TargetPath="$(NuspecTargetPath)"
+                   IncludeTargetFrameworks="$(PackageTargetFrameworks)"
+                   ExcludeTargetFrameworks="$(ExcludeTargetFrameworks)"
+                   RemoveIcon="true"
+                   RemoveRuntimeSpecificDependencies="true" />
 
     <Message Text="$(MSBuildProjectName) -> $(NuspecTargetPath)"
              Importance="high" />

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -88,7 +88,7 @@
           DependsOnTargets="GenerateAndInvokeGenerateSourceProject;
                             GenerateReferencePackageProject;
                             CopyPlaceholderFiles;
-                            CopyNuspec;
+                            RewriteNuspec;
                             CreateDirectoryBuildPropsFile" />
 
   <!-- Generate an intermediate multi-targeting wrapper project that retrieves the reference assemblies and invokes GenAPI. -->
@@ -172,7 +172,7 @@
 
   <!-- Copy nuspec to target directory and remove icon element from it. -->
   <UsingTask TaskName="RewriteNuspec" AssemblyFile="$(ReferencePackageSourceTaskAssembly)" />
-  <Target Name="CopyNuspec">
+  <Target Name="RewriteNuspec">
     <PropertyGroup>
       <NuspecPath>$(PackageSourceDirectory)$(PackageName.ToLowerInvariant()).nuspec</NuspecPath>
       <NuspecTargetPath>$(PackageTargetDirectory)$([System.IO.Path]::GetFileName('$(NuspecPath)'))</NuspecTargetPath>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceTask/RewriteNuspec.cs
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceTask/RewriteNuspec.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks
+{
+    public partial class RewriteNuspec : Task
+    {
+        [Required]
+        public string NuspecPath { get; set; }
+
+        [Required]
+        public string TargetPath { get; set; }
+
+        public string IncludeTargetFrameworks { get; set; }
+
+        public string ExcludeTargetFrameworks { get; set; }
+
+        public bool RemoveIcon { get; set; }
+
+        public bool RemoveRuntimeSpecificDependencies { get; set; }
+
+        public override bool Execute()
+        {
+            string nuspecContent = File.ReadAllText(NuspecPath);
+            NuspecReader nuspecReader = new(NuspecPath);
+            TargetFrameworkRegexFilter targetFrameworkRegexFilter = new(IncludeTargetFrameworks,
+                ExcludeTargetFrameworks);
+
+            IEnumerable<FrameworkSpecificGroup> frameworkAssemblyGroups = nuspecReader.GetFrameworkAssemblyGroups();
+            foreach (FrameworkSpecificGroup frameworkSpecificGroup in frameworkAssemblyGroups)
+            {
+                string targetFramework = frameworkSpecificGroup.TargetFramework.GetShortFolderName();
+                if (targetFrameworkRegexFilter.IsIncludedAndNotExcluded(targetFramework))
+                    continue;
+
+                string framework = frameworkSpecificGroup.TargetFramework.GetFrameworkString();
+                string pattern = $@" *<frameworkAssembly.*?targetFramework=""{framework}"" />\r?\n";
+                nuspecContent = Regex.Replace(nuspecContent, pattern, string.Empty);
+            }
+
+            IEnumerable<PackageDependencyGroup> dependencyGroups = nuspecReader.GetDependencyGroups();
+            foreach (PackageDependencyGroup dependencyGroup in dependencyGroups)
+            {
+                string targetFramework = dependencyGroup.TargetFramework.GetShortFolderName();
+                if (targetFrameworkRegexFilter.IsIncludedAndNotExcluded(targetFramework))
+                    continue;
+
+                string framework = dependencyGroup.TargetFramework.GetFrameworkString();
+                string pattern = @$" *<group targetFramework=""{framework}""(?:>.+?</group>| />)\r?\n";
+                nuspecContent = Regex.Replace(nuspecContent, pattern, string.Empty, RegexOptions.Singleline);
+            }
+
+            if (RemoveIcon)
+            {
+                nuspecContent = GetIconRegex().Replace(nuspecContent, string.Empty);
+            }
+
+            if (RemoveRuntimeSpecificDependencies)
+            {
+                nuspecContent = GetRuntimeSpecificDependenciesRegex().Replace(nuspecContent, string.Empty);
+            }
+
+            File.WriteAllText(TargetPath, nuspecContent);
+            return true;
+        }
+
+        [GeneratedRegex(" *<icon>.+</icon>\r?\n")]
+        private static partial Regex GetIconRegex();
+
+        [GeneratedRegex(@" *<dependency id=""runtime.native.+?"".+? />\r?\n")]
+        private static partial Regex GetRuntimeSpecificDependenciesRegex();
+    }
+}

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceTask/TargetFrameworkRegexFilter.cs
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceTask/TargetFrameworkRegexFilter.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.DotNet.SourceBuild.Tasks
+{
+    internal class TargetFrameworkRegexFilter
+    {
+        private const char TargetFrameworkDelimiter = ';';
+        private readonly Regex _includeTargetFrameworks;
+        private readonly Regex _excludeTargetFrameworks;
+        private readonly HashSet<string> _foundExcludedTargetFrameworks = new();
+
+        /// <summary>
+        /// The list of found excluded target frameworks.
+        /// </summary>
+        public IReadOnlySet<string> FoundExcludedTargetFrameworks => _foundExcludedTargetFrameworks;
+
+        public TargetFrameworkRegexFilter(string includeTargetFrameworks,
+            string excludeTargetFrameworks)
+        {
+            _includeTargetFrameworks = TransformPatternsToRegexList(includeTargetFrameworks);
+            _excludeTargetFrameworks = TransformPatternsToRegexList(excludeTargetFrameworks);
+        }
+
+        /// <summary>
+        /// Skip target frameworks that aren't included in the IncludeTargetFrameworks filter and that
+        /// are excluded in the ExcludeTargetFrameworks filter.
+        /// </summary>
+        public bool IsIncludedAndNotExcluded(string targetFramework)
+        {
+            // Skip empty target frameworks.
+            if (string.IsNullOrWhiteSpace(targetFramework))
+                return false;
+
+            // Skip target frameworks that aren't included in the IncludeTargetFrameworks filter.
+            if (_includeTargetFrameworks != null && !_includeTargetFrameworks.IsMatch(targetFramework))
+                return false;
+
+            // Skip target frameworks that are excluded.
+            if (_excludeTargetFrameworks != null && _excludeTargetFrameworks.IsMatch(targetFramework))
+            {
+                _foundExcludedTargetFrameworks.Add(targetFramework);
+                return false;
+            }
+
+            return true;
+        }
+
+        private static Regex TransformPatternsToRegexList(string patterns)
+        {
+            if (string.IsNullOrWhiteSpace(patterns))
+                return null;
+
+            string pattern = patterns.Split(TargetFrameworkDelimiter, StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => Regex.Escape(p).Replace("\\*", ".*"))
+                .Aggregate((p1, p2) => p1 + "|" + p2);
+            pattern = $"^(?:{pattern})$";
+
+            return new Regex(pattern, RegexOptions.NonBacktracking | RegexOptions.Compiled);
+        }
+    }
+}


### PR DESCRIPTION
1. Remove excluded tfms from the copied nuspec (in addition to the already removed icon element)
2. Remove "runtime.native" dependencies from the nuspec
3. Update the list of default excluded tfms
4. Small nit changes