### PR TITLE
Remove dir.props file and imports to it

### DIFF
--- a/src/referencePackages/src/dir.props
+++ b/src/referencePackages/src/dir.props
@@ -1,5 +1,0 @@
-<!--
-  This file exists for historical reasons: every csproj in this dir imports it. It can be removed if
-  every reference is removed from each csproj. Directory.Build.props has made this file obsolete.
--->
-<Project />

--- a/src/referencePackages/src/humanizer.core/2.2.0/Humanizer.Core.2.2.0.csproj
+++ b/src/referencePackages/src/humanizer.core/2.2.0/Humanizer.Core.2.2.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.0/Microsoft.Bcl.AsyncInterfaces.1.1.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/1.1.0/Microsoft.Bcl.AsyncInterfaces.1.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/5.0.0/Microsoft.Bcl.AsyncInterfaces.5.0.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/5.0.0/Microsoft.Bcl.AsyncInterfaces.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.bcl.hashcode/1.1.1/Microsoft.Bcl.HashCode.1.1.1.csproj
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/1.1.1/Microsoft.Bcl.HashCode.1.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;net461</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.build.framework/15.1.1012/Microsoft.Build.Framework.15.1.1012.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.1.1012/Microsoft.Build.Framework.15.1.1012.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.framework/15.1.1012/microsoft.build.framework.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.build.framework/15.3.409/Microsoft.Build.Framework.15.3.409.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.3.409/Microsoft.Build.Framework.15.3.409.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.build.framework/15.7.179/Microsoft.Build.Framework.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/15.7.179/Microsoft.Build.Framework.15.7.179.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.framework/15.7.179/microsoft.build.framework.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.build.framework/16.5.0/Microsoft.Build.Framework.16.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/16.5.0/Microsoft.Build.Framework.16.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.build.framework/16.7.0/Microsoft.Build.Framework.16.7.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/16.7.0/Microsoft.Build.Framework.16.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.build.framework/16.8.0/Microsoft.Build.Framework.16.8.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/16.8.0/Microsoft.Build.Framework.16.8.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build.tasks.core/15.7.179/Microsoft.Build.Tasks.Core.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/15.7.179/Microsoft.Build.Tasks.Core.15.7.179.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.tasks.core/15.7.179/microsoft.build.tasks.core.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.build.tasks.core/16.5.0/Microsoft.Build.Tasks.Core.16.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/16.5.0/Microsoft.Build.Tasks.Core.16.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build.tasks.core/16.7.0/Microsoft.Build.Tasks.Core.16.7.0.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/16.7.0/Microsoft.Build.Tasks.Core.16.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build.tasks.core/16.8.0/Microsoft.Build.Tasks.Core.16.8.0.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/16.8.0/Microsoft.Build.Tasks.Core.16.8.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.3.409/Microsoft.Build.Utilities.Core.15.3.409.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.3.409/Microsoft.Build.Utilities.Core.15.3.409.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.7.179/Microsoft.Build.Utilities.Core.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.7.179/Microsoft.Build.Utilities.Core.15.7.179.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build.utilities.core/15.7.179/microsoft.build.utilities.core.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.build.utilities.core/16.5.0/Microsoft.Build.Utilities.Core.16.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/16.5.0/Microsoft.Build.Utilities.Core.16.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>  

--- a/src/referencePackages/src/microsoft.build.utilities.core/16.7.0/Microsoft.Build.Utilities.Core.16.7.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/16.7.0/Microsoft.Build.Utilities.Core.16.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build.utilities.core/16.8.0/Microsoft.Build.Utilities.Core.16.8.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/16.8.0/Microsoft.Build.Utilities.Core.16.8.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
+++ b/src/referencePackages/src/microsoft.build/15.7.179/Microsoft.Build.15.7.179.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.build/15.7.179/microsoft.build.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.build/16.5.0/Microsoft.Build.16.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build/16.5.0/Microsoft.Build.16.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>

--- a/src/referencePackages/src/microsoft.codeanalysis.common/4.0.1/Microsoft.CodeAnalysis.Common.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/4.0.1/Microsoft.CodeAnalysis.Common.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.codeanalysis.csharp.workspaces/4.0.1/Microsoft.CodeAnalysis.CSharp.Workspaces.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.csharp.workspaces/4.0.1/Microsoft.CodeAnalysis.CSharp.Workspaces.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.codeanalysis.csharp/4.0.1/Microsoft.CodeAnalysis.CSharp.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.csharp/4.0.1/Microsoft.CodeAnalysis.CSharp.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.codeanalysis.workspaces.common/4.0.1/Microsoft.CodeAnalysis.Workspaces.Common.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.workspaces.common/4.0.1/Microsoft.CodeAnalysis.Workspaces.Common.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.csharp/4.0.1/Microsoft.CSharp.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.0.1/Microsoft.CSharp.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.csharp/4.0.1/microsoft.csharp.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.csharp/4.3.0/Microsoft.CSharp.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.3.0/Microsoft.CSharp.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.csharp/4.3.0/microsoft.csharp.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.csharp/4.7.0/Microsoft.CSharp.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.7.0/Microsoft.CSharp.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.configuration.abstractions/2.1.1/Microsoft.Extensions.Configuration.Abstractions.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.configuration.abstractions/2.1.1/Microsoft.Extensions.Configuration.Abstractions.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.configuration.binder/2.1.1/Microsoft.Extensions.Configuration.Binder.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.configuration.binder/2.1.1/Microsoft.Extensions.Configuration.Binder.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.configuration/2.1.1/Microsoft.Extensions.Configuration.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.configuration/2.1.1/Microsoft.Extensions.Configuration.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.dependencyinjection.abstractions/2.1.1/Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.dependencyinjection.abstractions/2.1.1/Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.1/Microsoft.Extensions.Logging.Abstractions.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/2.1.1/Microsoft.Extensions.Logging.Abstractions.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/7.0.0/Microsoft.Extensions.Logging.Abstractions.7.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/7.0.0/Microsoft.Extensions.Logging.Abstractions.7.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.logging/2.1.1/Microsoft.Extensions.Logging.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging/2.1.1/Microsoft.Extensions.Logging.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.objectpool/6.0.0/Microsoft.Extensions.ObjectPool.6.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.options/2.1.1/Microsoft.Extensions.Options.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.options/2.1.1/Microsoft.Extensions.Options.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.extensions.primitives/2.1.1/Microsoft.Extensions.Primitives.2.1.1.csproj
+++ b/src/referencePackages/src/microsoft.extensions.primitives/2.1.1/Microsoft.Extensions.Primitives.2.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.visualbasic/10.3.0/Microsoft.VisualBasic.10.3.0.csproj
+++ b/src/referencePackages/src/microsoft.visualbasic/10.3.0/Microsoft.VisualBasic.10.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.win32.primitives/4.0.1/Microsoft.Win32.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/microsoft.win32.primitives/4.0.1/Microsoft.Win32.Primitives.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.primitives/4.0.1/microsoft.win32.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.win32.primitives/4.3.0/Microsoft.Win32.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.primitives/4.3.0/Microsoft.Win32.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.win32.registry/4.0.0/Microsoft.Win32.Registry.4.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.0.0/Microsoft.Win32.Registry.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.registry/4.0.0/microsoft.win32.registry.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.win32.registry/4.3.0/Microsoft.Win32.Registry.4.3.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.3.0/Microsoft.Win32.Registry.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)microsoft.win32.registry/4.3.0/microsoft.win32.registry.nuspec</NuspecFile>

--- a/src/referencePackages/src/microsoft.win32.registry/4.7.0/Microsoft.Win32.Registry.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/4.7.0/Microsoft.Win32.Registry.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461;net472</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.win32.registry/5.0.0/Microsoft.Win32.Registry.5.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/5.0.0/Microsoft.Win32.Registry.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/microsoft.win32.systemevents/4.7.0/Microsoft.Win32.SystemEvents.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.systemevents/4.7.0/Microsoft.Win32.SystemEvents.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;net472</TargetFrameworks>

--- a/src/referencePackages/src/system.appcontext/4.1.0/System.AppContext.4.1.0.csproj
+++ b/src/referencePackages/src/system.appcontext/4.1.0/System.AppContext.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.6;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.appcontext/4.1.0/system.appcontext.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.appcontext/4.3.0/System.AppContext.4.3.0.csproj
+++ b/src/referencePackages/src/system.appcontext/4.3.0/System.AppContext.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.6;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.appcontext/4.3.0/system.appcontext.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.buffers/4.3.0/System.Buffers.4.3.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.3.0/System.Buffers.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>

--- a/src/referencePackages/src/system.buffers/4.4.0/System.Buffers.4.4.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.4.0/System.Buffers.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.4.0/system.buffers.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.buffers/4.5.0/System.Buffers.4.5.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.5.0/System.Buffers.4.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.5.0/system.buffers.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
+++ b/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.buffers/4.5.1/system.buffers.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.codedom/4.4.0/System.CodeDom.4.4.0.csproj
+++ b/src/referencePackages/src/system.codedom/4.4.0/System.CodeDom.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.codedom/4.4.0/system.codedom.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.concurrent/4.0.12/system.collections.concurrent.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.2.0/system.collections.immutable.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.0/system.collections.immutable.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.1/system.collections.immutable.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.5.0/system.collections.immutable.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.immutable/1.7.0/System.Collections.Immutable.1.7.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.7.0/System.Collections.Immutable.1.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.collections.immutable/6.0.0/System.Collections.Immutable.6.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/6.0.0/System.Collections.Immutable.6.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.collections.nongeneric/4.0.1/System.Collections.NonGeneric.4.0.1.csproj
+++ b/src/referencePackages/src/system.collections.nongeneric/4.0.1/System.Collections.NonGeneric.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.nongeneric/4.0.1/system.collections.nongeneric.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.nongeneric/4.3.0/system.collections.nongeneric.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections.specialized/4.3.0/system.collections.specialized.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
+++ b/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.collections/4.0.11/system.collections.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.componentmodel.annotations/5.0.0/System.ComponentModel.Annotations.5.0.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.annotations/5.0.0/System.ComponentModel.Annotations.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard1.4;netstandard2.0;netstandard2.1;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.componentmodel.primitives/4.3.0/System.ComponentModel.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.primitives/4.3.0/System.ComponentModel.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.primitives/4.3.0/system.componentmodel.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.componentmodel.typeconverter/4.3.0/System.ComponentModel.TypeConverter.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.typeconverter/4.3.0/System.ComponentModel.TypeConverter.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.5;net45;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel.typeconverter/4.3.0/system.componentmodel.typeconverter.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.componentmodel/4.3.0/System.ComponentModel.4.3.0.csproj
+++ b/src/referencePackages/src/system.componentmodel/4.3.0/System.ComponentModel.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.componentmodel/4.3.0/system.componentmodel.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.composition.attributedmodel/1.0.31/System.Composition.AttributedModel.1.0.31.csproj
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.0.31/System.Composition.AttributedModel.1.0.31.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.composition.convention/1.0.31/System.Composition.Convention.1.0.31.csproj
+++ b/src/referencePackages/src/system.composition.convention/1.0.31/System.Composition.Convention.1.0.31.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.composition.hosting/1.0.31/System.Composition.Hosting.1.0.31.csproj
+++ b/src/referencePackages/src/system.composition.hosting/1.0.31/System.Composition.Hosting.1.0.31.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.composition.runtime/1.0.31/System.Composition.Runtime.1.0.31.csproj
+++ b/src/referencePackages/src/system.composition.runtime/1.0.31/System.Composition.Runtime.1.0.31.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.composition.typedparts/1.0.31/System.Composition.TypedParts.1.0.31.csproj
+++ b/src/referencePackages/src/system.composition.typedparts/1.0.31/System.Composition.TypedParts.1.0.31.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.console/4.0.0/System.Console.4.0.0.csproj
+++ b/src/referencePackages/src/system.console/4.0.0/System.Console.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.console/4.0.0/system.console.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.console/4.3.0/System.Console.4.3.0.csproj
+++ b/src/referencePackages/src/system.console/4.3.0/System.Console.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.console/4.3.0/system.console.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.data.common/4.3.0/System.Data.Common.4.3.0.csproj
+++ b/src/referencePackages/src/system.data.common/4.3.0/System.Data.Common.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;net451</TargetFrameworks>

--- a/src/referencePackages/src/system.data.sqlclient/4.8.5/System.Data.SqlClient.4.8.5.csproj
+++ b/src/referencePackages/src/system.data.sqlclient/4.8.5/System.Data.SqlClient.4.8.5.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2;netstandard1.3;netstandard2.0;netcoreapp2.1;net451;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.diagnostics.debug/4.0.11/System.Diagnostics.Debug.4.0.11.csproj
+++ b/src/referencePackages/src/system.diagnostics.debug/4.0.11/System.Diagnostics.Debug.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.debug/4.0.11/system.diagnostics.debug.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.debug/4.3.0/System.Diagnostics.Debug.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.debug/4.3.0/System.Diagnostics.Debug.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/4.3.0/System.Diagnostics.DiagnosticSource.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/4.3.0/System.Diagnostics.DiagnosticSource.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/4.7.0/System.Diagnostics.DiagnosticSource.4.7.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/4.7.0/System.Diagnostics.DiagnosticSource.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net45;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/5.0.0/System.Diagnostics.DiagnosticSource.5.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/5.0.0/System.Diagnostics.DiagnosticSource.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net45;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.diagnostics.eventlog/5.0.0/System.Diagnostics.EventLog.5.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.eventlog/5.0.0/System.Diagnostics.EventLog.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.diagnostics.fileversioninfo/4.3.0/System.Diagnostics.FileVersionInfo.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.fileversioninfo/4.3.0/System.Diagnostics.FileVersionInfo.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.fileversioninfo/4.3.0/system.diagnostics.fileversioninfo.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.process/4.1.0/System.Diagnostics.Process.4.1.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.process/4.1.0/System.Diagnostics.Process.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.process/4.1.0/system.diagnostics.process.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.tools/4.0.1/System.Diagnostics.Tools.4.0.1.csproj
+++ b/src/referencePackages/src/system.diagnostics.tools/4.0.1/System.Diagnostics.Tools.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tools/4.0.1/system.diagnostics.tools.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.tools/4.3.0/System.Diagnostics.Tools.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tools/4.3.0/System.Diagnostics.Tools.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tools/4.3.0/system.diagnostics.tools.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.tracesource/4.0.0/System.Diagnostics.TraceSource.4.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracesource/4.0.0/System.Diagnostics.TraceSource.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracesource/4.0.0/system.diagnostics.tracesource.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.tracing/4.1.0/System.Diagnostics.Tracing.4.1.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracing/4.1.0/System.Diagnostics.Tracing.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.diagnostics.tracing/4.1.0/system.diagnostics.tracing.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.diagnostics.tracing/4.3.0/System.Diagnostics.Tracing.4.3.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.tracing/4.3.0/System.Diagnostics.Tracing.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.drawing.common/4.7.2/System.Drawing.Common.4.7.2.csproj
+++ b/src/referencePackages/src/system.drawing.common/4.7.2/System.Drawing.Common.4.7.2.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.dynamic.runtime/4.0.11/System.Dynamic.Runtime.4.0.11.csproj
+++ b/src/referencePackages/src/system.dynamic.runtime/4.0.11/System.Dynamic.Runtime.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.dynamic.runtime/4.0.11/system.dynamic.runtime.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.dynamic.runtime/4.3.0/System.Dynamic.Runtime.4.3.0.csproj
+++ b/src/referencePackages/src/system.dynamic.runtime/4.3.0/System.Dynamic.Runtime.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.dynamic.runtime/4.3.0/system.dynamic.runtime.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.formats.asn1/5.0.0/System.Formats.Asn1.5.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/5.0.0/System.Formats.Asn1.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.globalization.calendars/4.3.0/System.Globalization.Calendars.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization.calendars/4.3.0/System.Globalization.Calendars.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.calendars/4.3.0/system.globalization.calendars.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.globalization.extensions/4.3.0/System.Globalization.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization.extensions/4.3.0/System.Globalization.Extensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization.extensions/4.3.0/system.globalization.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.globalization/4.0.11/System.Globalization.4.0.11.csproj
+++ b/src/referencePackages/src/system.globalization/4.0.11/System.Globalization.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.globalization/4.0.11/system.globalization.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.globalization/4.3.0/System.Globalization.4.3.0.csproj
+++ b/src/referencePackages/src/system.globalization/4.3.0/System.Globalization.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.io.compression.zipfile/4.3.0/System.IO.Compression.ZipFile.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.compression.zipfile/4.3.0/System.IO.Compression.ZipFile.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io.compression/4.3.0/System.IO.Compression.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.compression/4.3.0/System.IO.Compression.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.compression/4.3.0/system.io.compression.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io.filesystem.accesscontrol/5.0.0/System.IO.FileSystem.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem.accesscontrol/5.0.0/System.IO.FileSystem.AccessControl.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.io.filesystem.primitives/4.0.1/System.IO.FileSystem.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/system.io.filesystem.primitives/4.0.1/System.IO.FileSystem.Primitives.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io.filesystem.primitives/4.3.0/System.IO.FileSystem.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem.primitives/4.3.0/System.IO.FileSystem.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.io.filesystem/4.0.1/System.IO.FileSystem.4.0.1.csproj
+++ b/src/referencePackages/src/system.io.filesystem/4.0.1/System.IO.FileSystem.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.filesystem/4.0.1/system.io.filesystem.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io.filesystem/4.3.0/System.IO.FileSystem.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem/4.3.0/System.IO.FileSystem.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.io.pipelines/5.0.1/System.IO.Pipelines.5.0.1.csproj
+++ b/src/referencePackages/src/system.io.pipelines/5.0.1/System.IO.Pipelines.5.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard1.3;netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/4.3.0/System.IO.Pipes.AccessControl.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/4.3.0/System.IO.Pipes.AccessControl.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.pipes.accesscontrol/4.3.0/system.io.pipes.accesscontrol.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/System.IO.Pipes.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.io.pipes.accesscontrol/5.0.0/System.IO.Pipes.AccessControl.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.io.pipes/4.3.0/System.IO.Pipes.4.3.0.csproj
+++ b/src/referencePackages/src/system.io.pipes/4.3.0/System.IO.Pipes.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io.pipes/4.3.0/system.io.pipes.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io/4.1.0/System.IO.4.1.0.csproj
+++ b/src/referencePackages/src/system.io/4.1.0/System.IO.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.io/4.1.0/system.io.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.io/4.3.0/System.IO.4.3.0.csproj
+++ b/src/referencePackages/src/system.io/4.3.0/System.IO.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.linq.expressions/4.1.0/System.Linq.Expressions.4.1.0.csproj
+++ b/src/referencePackages/src/system.linq.expressions/4.1.0/System.Linq.Expressions.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.expressions/4.1.0/system.linq.expressions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.linq.expressions/4.3.0/System.Linq.Expressions.4.3.0.csproj
+++ b/src/referencePackages/src/system.linq.expressions/4.3.0/System.Linq.Expressions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.expressions/4.3.0/system.linq.expressions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.linq.parallel/4.0.1/System.Linq.Parallel.4.0.1.csproj
+++ b/src/referencePackages/src/system.linq.parallel/4.0.1/System.Linq.Parallel.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq.parallel/4.0.1/system.linq.parallel.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.linq/4.1.0/System.Linq.4.1.0.csproj
+++ b/src/referencePackages/src/system.linq/4.1.0/System.Linq.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.linq/4.1.0/system.linq.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.linq/4.3.0/System.Linq.4.3.0.csproj
+++ b/src/referencePackages/src/system.linq/4.3.0/System.Linq.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.6;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.memory/4.5.1/System.Memory.4.5.1.csproj
+++ b/src/referencePackages/src/system.memory/4.5.1/System.Memory.4.5.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.memory/4.5.3/System.Memory.4.5.3.csproj
+++ b/src/referencePackages/src/system.memory/4.5.3/System.Memory.4.5.3.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.3/system.memory.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
+++ b/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.memory/4.5.4/system.memory.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.memory/4.5.5/System.Memory.4.5.5.csproj
+++ b/src/referencePackages/src/system.memory/4.5.5/System.Memory.4.5.5.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.net.http/4.3.0/System.Net.Http.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.0/System.Net.Http.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.0/system.net.http.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.net.http/4.3.4/System.Net.Http.4.3.4.csproj
+++ b/src/referencePackages/src/system.net.http/4.3.4/System.Net.Http.4.3.4.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.http/4.3.4/system.net.http.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.net.nameresolution/4.3.0/System.Net.NameResolution.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.nameresolution/4.3.0/System.Net.NameResolution.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.net.primitives/4.3.0/System.Net.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.primitives/4.3.0/System.Net.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.primitives/4.3.0/system.net.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.net.security/4.3.1/System.Net.Security.4.3.1.csproj
+++ b/src/referencePackages/src/system.net.security/4.3.1/System.Net.Security.4.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.net.sockets/4.3.0/System.Net.Sockets.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.sockets/4.3.0/System.Net.Sockets.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.sockets/4.3.0/system.net.sockets.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.net.webheadercollection/4.3.0/System.Net.WebHeaderCollection.4.3.0.csproj
+++ b/src/referencePackages/src/system.net.webheadercollection/4.3.0/System.Net.WebHeaderCollection.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.net.webheadercollection/4.3.0/system.net.webheadercollection.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.numerics.vectors/4.4.0/system.numerics.vectors.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net45;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.numerics.vectors/4.5.0/system.numerics.vectors.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.objectmodel/4.0.12/System.ObjectModel.4.0.12.csproj
+++ b/src/referencePackages/src/system.objectmodel/4.0.12/System.ObjectModel.4.0.12.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.objectmodel/4.0.12/system.objectmodel.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.objectmodel/4.3.0/System.ObjectModel.4.3.0.csproj
+++ b/src/referencePackages/src/system.objectmodel/4.3.0/System.ObjectModel.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.objectmodel/4.3.0/system.objectmodel.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.private.datacontractserialization/4.1.1/System.Private.DataContractSerialization.4.1.1.csproj
+++ b/src/referencePackages/src/system.private.datacontractserialization/4.1.1/System.Private.DataContractSerialization.4.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.private.datacontractserialization/4.1.1/system.private.datacontractserialization.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.0.1/System.Reflection.Emit.ILGeneration.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.3.0/System.Reflection.Emit.ILGeneration.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.3.0/System.Reflection.Emit.ILGeneration.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.ilgeneration/4.3.0/system.reflection.emit.ilgeneration.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.7.0/System.Reflection.Emit.ILGeneration.4.7.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.7.0/System.Reflection.Emit.ILGeneration.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.0.1/System.Reflection.Emit.Lightweight.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit.lightweight/4.3.0/System.Reflection.Emit.Lightweight.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/4.3.0/System.Reflection.Emit.Lightweight.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit.lightweight/4.3.0/system.reflection.emit.lightweight.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.0.1/System.Reflection.Emit.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit/4.0.1/system.reflection.emit.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit/4.3.0/System.Reflection.Emit.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.3.0/System.Reflection.Emit.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.emit/4.3.0/system.reflection.emit.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.emit/4.7.0/System.Reflection.Emit.4.7.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.7.0/System.Reflection.Emit.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.extensions/4.0.1/System.Reflection.Extensions.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.extensions/4.0.1/System.Reflection.Extensions.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.extensions/4.0.1/system.reflection.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.extensions/4.3.0/System.Reflection.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.extensions/4.3.0/System.Reflection.Extensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.extensions/4.3.0/system.reflection.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.metadata/1.3.0/System.Reflection.Metadata.1.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.3.0/System.Reflection.Metadata.1.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.3.0/system.reflection.metadata.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.metadata/1.4.1/System.Reflection.Metadata.1.4.1.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.4.1/System.Reflection.Metadata.1.4.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.4.1/system.reflection.metadata.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.metadata/1.4.2/System.Reflection.Metadata.1.4.2.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.4.2/System.Reflection.Metadata.1.4.2.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.4.2/system.reflection.metadata.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.metadata/1.6.0/System.Reflection.Metadata.1.6.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/1.6.0/System.Reflection.Metadata.1.6.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.metadata/1.6.0/system.reflection.metadata.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.metadata/5.0.0/System.Reflection.Metadata.5.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/5.0.0/System.Reflection.Metadata.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.metadata/6.0.0/System.Reflection.Metadata.6.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/6.0.0/System.Reflection.Metadata.6.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.metadata/6.0.1/System.Reflection.Metadata.6.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/6.0.1/System.Reflection.Metadata.6.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.primitives/4.0.1/System.Reflection.Primitives.4.0.1.csproj
+++ b/src/referencePackages/src/system.reflection.primitives/4.0.1/System.Reflection.Primitives.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.primitives/4.0.1/system.reflection.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.primitives/4.3.0/System.Reflection.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.primitives/4.3.0/System.Reflection.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.1.0/System.Reflection.TypeExtensions.4.1.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.1.0/System.Reflection.TypeExtensions.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.3.0/System.Reflection.TypeExtensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.3.0/System.Reflection.TypeExtensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;net46;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection.typeextensions/4.3.0/system.reflection.typeextensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.4.0/System.Reflection.TypeExtensions.4.4.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.4.0/System.Reflection.TypeExtensions.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection.typeextensions/4.7.0/System.Reflection.TypeExtensions.4.7.0.csproj
+++ b/src/referencePackages/src/system.reflection.typeextensions/4.7.0/System.Reflection.TypeExtensions.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.5;netstandard2.0;net46;net461;net472</TargetFrameworks>

--- a/src/referencePackages/src/system.reflection/4.1.0/System.Reflection.4.1.0.csproj
+++ b/src/referencePackages/src/system.reflection/4.1.0/System.Reflection.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.reflection/4.1.0/system.reflection.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.reflection/4.3.0/System.Reflection.4.3.0.csproj
+++ b/src/referencePackages/src/system.reflection/4.3.0/System.Reflection.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.resources.extensions/4.6.0/System.Resources.Extensions.4.6.0.csproj
+++ b/src/referencePackages/src/system.resources.extensions/4.6.0/System.Resources.Extensions.4.6.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.resources.reader/4.0.0/System.Resources.Reader.4.0.0.csproj
+++ b/src/referencePackages/src/system.resources.reader/4.0.0/System.Resources.Reader.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.reader/4.0.0/system.resources.reader.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.resources.resourcemanager/4.0.1/System.Resources.ResourceManager.4.0.1.csproj
+++ b/src/referencePackages/src/system.resources.resourcemanager/4.0.1/System.Resources.ResourceManager.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.resources.resourcemanager/4.3.0/System.Resources.ResourceManager.4.3.0.csproj
+++ b/src/referencePackages/src/system.resources.resourcemanager/4.3.0/System.Resources.ResourceManager.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>

--- a/src/referencePackages/src/system.resources.writer/4.0.0/System.Resources.Writer.4.0.0.csproj
+++ b/src/referencePackages/src/system.resources.writer/4.0.0/System.Resources.Writer.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.resources.writer/4.0.0/system.resources.writer.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.0/System.Runtime.CompilerServices.Unsafe.4.5.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.0/System.Runtime.CompilerServices.Unsafe.4.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.1/System.Runtime.CompilerServices.Unsafe.4.5.1.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.1/System.Runtime.CompilerServices.Unsafe.4.5.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.compilerservices.unsafe/4.5.3/system.runtime.compilerservices.unsafe.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.7.0/System.Runtime.CompilerServices.Unsafe.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netcoreapp2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/5.0.0/System.Runtime.CompilerServices.Unsafe.5.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/5.0.0/System.Runtime.CompilerServices.Unsafe.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard2.1;net461;netcoreapp2.0;net45</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.6.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.6.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.extensions/4.1.0/System.Runtime.Extensions.4.1.0.csproj
+++ b/src/referencePackages/src/system.runtime.extensions/4.1.0/System.Runtime.Extensions.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.extensions/4.1.0/system.runtime.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.extensions/4.3.0/System.Runtime.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.extensions/4.3.0/System.Runtime.Extensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.extensions/4.3.1/System.Runtime.Extensions.4.3.1.csproj
+++ b/src/referencePackages/src/system.runtime.extensions/4.3.1/System.Runtime.Extensions.4.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.handles/4.0.1/System.Runtime.Handles.4.0.1.csproj
+++ b/src/referencePackages/src/system.runtime.handles/4.0.1/System.Runtime.Handles.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.handles/4.0.1/system.runtime.handles.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.handles/4.3.0/System.Runtime.Handles.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.handles/4.3.0/System.Runtime.Handles.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.0.0/System.Runtime.InteropServices.RuntimeInformation.4.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.0.0/System.Runtime.InteropServices.RuntimeInformation.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices.runtimeinformation/4.0.0/system.runtime.interopservices.runtimeinformation.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.3.0/System.Runtime.InteropServices.RuntimeInformation.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/4.3.0/System.Runtime.InteropServices.RuntimeInformation.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.interopservices/4.1.0/System.Runtime.InteropServices.4.1.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices/4.1.0/System.Runtime.InteropServices.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.interopservices/4.1.0/system.runtime.interopservices.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.5;netcoreapp1.1;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.loader/4.0.0/System.Runtime.Loader.4.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.loader/4.0.0/System.Runtime.Loader.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.loader/4.0.0/system.runtime.loader.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.loader/4.3.0/System.Runtime.Loader.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.loader/4.3.0/System.Runtime.Loader.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.loader/4.3.0/system.runtime.loader.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.numerics/4.3.0/System.Runtime.Numerics.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.numerics/4.3.0/System.Runtime.Numerics.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime.serialization.formatters/4.3.0/System.Runtime.Serialization.Formatters.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.formatters/4.3.0/System.Runtime.Serialization.Formatters.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46;netstandard1.4</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.formatters/4.3.0/system.runtime.serialization.formatters.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.serialization.primitives/4.1.1/System.Runtime.Serialization.Primitives.4.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.primitives/4.1.1/System.Runtime.Serialization.Primitives.4.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.serialization.primitives/4.3.0/System.Runtime.Serialization.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.primitives/4.3.0/System.Runtime.Serialization.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime.serialization.xml/4.1.1/System.Runtime.Serialization.Xml.4.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.serialization.xml/4.1.1/System.Runtime.Serialization.Xml.4.1.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.runtime.serialization.xml/4.1.1/system.runtime.serialization.xml.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.runtime/4.3.0/System.Runtime.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime/4.3.0/System.Runtime.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.runtime/4.3.1/System.Runtime.4.3.1.csproj
+++ b/src/referencePackages/src/system.runtime/4.3.1/System.Runtime.4.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.2;netstandard1.3;netstandard1.5;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.security.accesscontrol/4.3.0/System.Security.AccessControl.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/4.3.0/System.Security.AccessControl.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.accesscontrol/4.3.0/system.security.accesscontrol.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.accesscontrol/4.7.0/System.Security.AccessControl.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/4.7.0/System.Security.AccessControl.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.accesscontrol/5.0.0/System.Security.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/5.0.0/System.Security.AccessControl.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.accesscontrol/6.0.0/System.Security.AccessControl.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/6.0.0/System.Security.AccessControl.6.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.claims/4.3.0/System.Security.Claims.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.claims/4.3.0/System.Security.Claims.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.claims/4.3.0/system.security.claims.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.0/System.Security.Cryptography.Algorithms.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.0/System.Security.Cryptography.Algorithms.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/System.Security.Cryptography.Algorithms.4.3.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/4.3.1/System.Security.Cryptography.Algorithms.4.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.cng/4.3.0/System.Security.Cryptography.Cng.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/4.3.0/System.Security.Cryptography.Cng.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;net46;net461;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.cng/4.7.0/System.Security.Cryptography.Cng.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/4.7.0/System.Security.Cryptography.Cng.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;net46;net461;net462;net47</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.cng/5.0.0/System.Security.Cryptography.Cng.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/5.0.0/System.Security.Cryptography.Cng.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;net46;net461;net462;net47</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.csp/4.3.0/System.Security.Cryptography.Csp.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.csp/4.3.0/System.Security.Cryptography.Csp.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.encoding/4.3.0/System.Security.Cryptography.Encoding.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.encoding/4.3.0/System.Security.Cryptography.Encoding.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.openssl/4.3.0/System.Security.Cryptography.OpenSsl.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/System.Security.Cryptography.Pkcs.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/4.7.0/System.Security.Cryptography.Pkcs.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/System.Security.Cryptography.Pkcs.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/5.0.0/System.Security.Cryptography.Pkcs.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/System.Security.Cryptography.Primitives.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/System.Security.Cryptography.Primitives.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.cryptography.x509certificates/4.3.0/System.Security.Cryptography.X509Certificates.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.x509certificates/4.3.0/System.Security.Cryptography.X509Certificates.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard1.4;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.cryptography.xml/4.7.1/System.Security.Cryptography.Xml.4.7.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/4.7.1/System.Security.Cryptography.Xml.4.7.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.permissions/4.7.0/System.Security.Permissions.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.permissions/4.7.0/System.Security.Permissions.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.principal.windows/4.3.0/System.Security.Principal.Windows.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/4.3.0/System.Security.Principal.Windows.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal.windows/4.3.0/system.security.principal.windows.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.security.principal.windows/4.7.0/System.Security.Principal.Windows.4.7.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/4.7.0/System.Security.Principal.Windows.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp3.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.principal.windows/5.0.0/System.Security.Principal.Windows.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/5.0.0/System.Security.Principal.Windows.5.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp3.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.security.principal/4.3.0/System.Security.Principal.4.3.0.csproj
+++ b/src/referencePackages/src/system.security.principal/4.3.0/System.Security.Principal.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.security.principal/4.3.0/system.security.principal.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.0.1/System.Text.Encoding.CodePages.4.0.1.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.0.1/System.Text.Encoding.CodePages.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.codepages/4.0.1/system.text.encoding.codepages.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.4.0/System.Text.Encoding.CodePages.4.4.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.4.0/System.Text.Encoding.CodePages.4.4.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.codepages/4.4.0/system.text.encoding.codepages.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.5.1/System.Text.Encoding.CodePages.4.5.1.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.5.1/System.Text.Encoding.CodePages.4.5.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.text.encoding.codepages/4.7.0/System.Text.Encoding.CodePages.4.7.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.7.0/System.Text.Encoding.CodePages.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.text.encoding.extensions/4.0.11/System.Text.Encoding.Extensions.4.0.11.csproj
+++ b/src/referencePackages/src/system.text.encoding.extensions/4.0.11/System.Text.Encoding.Extensions.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding.extensions/4.3.0/System.Text.Encoding.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.extensions/4.3.0/System.Text.Encoding.Extensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding/4.0.11/System.Text.Encoding.4.0.11.csproj
+++ b/src/referencePackages/src/system.text.encoding/4.0.11/System.Text.Encoding.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.encoding/4.0.11/system.text.encoding.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.encoding/4.3.0/System.Text.Encoding.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.encoding/4.3.0/System.Text.Encoding.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.text.encodings.web/4.7.0/System.Text.Encodings.Web.4.7.0.csproj
+++ b/src/referencePackages/src/system.text.encodings.web/4.7.0/System.Text.Encodings.Web.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard2.1</TargetFrameworks>

--- a/src/referencePackages/src/system.text.json/4.7.0/System.Text.Json.4.7.0.csproj
+++ b/src/referencePackages/src/system.text.json/4.7.0/System.Text.Json.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net461</TargetFrameworks>

--- a/src/referencePackages/src/system.text.regularexpressions/4.1.0/System.Text.RegularExpressions.4.1.0.csproj
+++ b/src/referencePackages/src/system.text.regularexpressions/4.1.0/System.Text.RegularExpressions.4.1.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;net462</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.text.regularexpressions/4.1.0/system.text.regularexpressions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.text.regularexpressions/4.3.0/System.Text.RegularExpressions.4.3.0.csproj
+++ b/src/referencePackages/src/system.text.regularexpressions/4.3.0/System.Text.RegularExpressions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;netcoreapp1.1;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.text.regularexpressions/4.3.1/System.Text.RegularExpressions.4.3.1.csproj
+++ b/src/referencePackages/src/system.text.regularexpressions/4.3.1/System.Text.RegularExpressions.4.3.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard1.6;netcoreapp1.1;net462</TargetFrameworks>

--- a/src/referencePackages/src/system.threading.overlapped/4.3.0/System.Threading.Overlapped.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.overlapped/4.3.0/System.Threading.Overlapped.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.overlapped/4.3.0/system.threading.overlapped.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/4.6.0/System.Threading.Tasks.Dataflow.4.6.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/4.6.0/System.Threading.Tasks.Dataflow.4.6.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.dataflow/4.6.0/system.threading.tasks.dataflow.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/4.9.0/System.Threading.Tasks.Dataflow.4.9.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/4.9.0/System.Threading.Tasks.Dataflow.4.9.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.1;netstandard2.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.dataflow/4.9.0/system.threading.tasks.dataflow.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.0.0/System.Threading.Tasks.Extensions.4.0.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.0.0/System.Threading.Tasks.Extensions.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.3.0/System.Threading.Tasks.Extensions.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.3.0/System.Threading.Tasks.Extensions.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.2/System.Threading.Tasks.Extensions.4.5.2.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.2/System.Threading.Tasks.Extensions.4.5.2.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net461</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/System.Threading.Tasks.Parallel.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/System.Threading.Tasks.Parallel.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks.parallel/4.3.0/system.threading.tasks.parallel.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks/4.0.11/System.Threading.Tasks.4.0.11.csproj
+++ b/src/referencePackages/src/system.threading.tasks/4.0.11/System.Threading.Tasks.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.tasks/4.0.11/system.threading.tasks.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.tasks/4.3.0/System.Threading.Tasks.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks/4.3.0/System.Threading.Tasks.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.threading.thread/4.0.0/System.Threading.Thread.4.0.0.csproj
+++ b/src/referencePackages/src/system.threading.thread/4.0.0/System.Threading.Thread.4.0.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.thread/4.0.0/system.threading.thread.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.thread/4.3.0/System.Threading.Thread.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.thread/4.3.0/System.Threading.Thread.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.thread/4.3.0/system.threading.thread.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.threadpool/4.0.10/System.Threading.ThreadPool.4.0.10.csproj
+++ b/src/referencePackages/src/system.threading.threadpool/4.0.10/System.Threading.ThreadPool.4.0.10.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.threadpool/4.0.10/system.threading.threadpool.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.threadpool/4.3.0/System.Threading.ThreadPool.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.threadpool/4.3.0/System.Threading.ThreadPool.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.threadpool/4.3.0/system.threading.threadpool.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.timer/4.0.1/System.Threading.Timer.4.0.1.csproj
+++ b/src/referencePackages/src/system.threading.timer/4.0.1/System.Threading.Timer.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.timer/4.0.1/system.threading.timer.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading.timer/4.3.0/System.Threading.Timer.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading.timer/4.3.0/System.Threading.Timer.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.2</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading.timer/4.3.0/system.threading.timer.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj
+++ b/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.threading/4.0.11/system.threading.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.threading/4.3.0/System.Threading.4.3.0.csproj
+++ b/src/referencePackages/src/system.threading/4.3.0/System.Threading.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>

--- a/src/referencePackages/src/system.valuetuple/4.5.0/System.ValueTuple.4.5.0.csproj
+++ b/src/referencePackages/src/system.valuetuple/4.5.0/System.ValueTuple.4.5.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>net461;net47;netstandard1.0</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.valuetuple/4.5.0/system.valuetuple.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.windows.extensions/4.7.0/System.Windows.Extensions.4.7.0.csproj
+++ b/src/referencePackages/src/system.windows.extensions/4.7.0/System.Windows.Extensions.4.7.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0</TargetFrameworks>

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.readerwriter/4.0.11/system.xml.readerwriter.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.readerwriter/4.3.0/System.Xml.ReaderWriter.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.readerwriter/4.3.0/System.Xml.ReaderWriter.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.readerwriter/4.3.0/system.xml.readerwriter.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.xdocument/4.0.11/System.Xml.XDocument.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.xdocument/4.0.11/System.Xml.XDocument.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xdocument/4.0.11/system.xml.xdocument.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.xdocument/4.3.0/System.Xml.XDocument.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xdocument/4.3.0/System.Xml.XDocument.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xdocument/4.3.0/system.xml.xdocument.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.xmldocument/4.0.1/System.Xml.XmlDocument.4.0.1.csproj
+++ b/src/referencePackages/src/system.xml.xmldocument/4.0.1/System.Xml.XmlDocument.4.0.1.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmldocument/4.0.1/system.xml.xmldocument.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.xmldocument/4.3.0/System.Xml.XmlDocument.4.3.0.csproj
+++ b/src/referencePackages/src/system.xml.xmldocument/4.3.0/System.Xml.XmlDocument.4.3.0.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmldocument/4.3.0/system.xml.xmldocument.nuspec</NuspecFile>

--- a/src/referencePackages/src/system.xml.xmlserializer/4.0.11/System.Xml.XmlSerializer.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.xmlserializer/4.0.11/System.Xml.XmlSerializer.4.0.11.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     <NuspecFile>$(ArtifactsBinDir)system.xml.xmlserializer/4.0.11/system.xml.xmlserializer.nuspec</NuspecFile>


### PR DESCRIPTION
As mentioned in the file, it doesn't serve any purpose anymore as it got replaced by Directory.Build.props/targets and can be removed:

> This file exists for historical reasons: every csproj in this dir imports it. It can be removed if
  every reference is removed from each csproj. Directory.Build.props has made this file obsolete.