### PR TITLE
Add AssemblyKeyFile and AssemblyDelaySign attributes to the exclusion list.

### DIFF
--- a/src/referencePackageSourceGenerator/DefaultGenApiDocIds.txt
+++ b/src/referencePackageSourceGenerator/DefaultGenApiDocIds.txt
@@ -48,3 +48,5 @@ T:System.Xml.Serialization.XmlEnumAttribute
 T:System.Xml.Serialization.XmlIgnoreAttribute
 T:System.Xml.Serialization.XmlRootAttribute
 T:System.Windows.Markup.ContentPropertyAttribute
+T:System.Reflection.AssemblyKeyFileAttribute
+T:System.Reflection.AssemblyDelaySignAttribute


### PR DESCRIPTION
The reference package for the System.Threading,4.0.11 package and the netstandard1.0 TFM contains two assembly attributes that produces errors:

>   CSC : error CS1616: Option 'PublicSign' overrides attribute '**System.Reflection.AssemblyDelaySignAttribute**' given in a source file or added module [/__w/1/s/artifacts/source-build/self/src/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj::TargetFramework=**netstandard1.0**] [/__w/1/s/.packages/microsoft.dotnet.arcade.sdk/8.0.0-beta.23153.1/tools/Build.proj]
  CSC : error CS1616: Option 'CryptoKeyFile' overrides attribute '**System.Reflection.AssemblyKeyFileAttribute**' given in a source file or added module [/__w/1/s/artifacts/source-build/self/src/src/referencePackages/src/system.threading/4.0.11/System.Threading.4.0.11.csproj::TargetFramework=**netstandard1.0**] [/__w/1/s/.packages/microsoft.dotnet.arcade.sdk/8.0.0-beta.23153.1/tools/Build.proj]

**AssemblyKeyFileAttribute** - specifies the name of a file containing the key pair used to generate a strong name. As the public key is not present in the reference package - it's OK to filter out such attribute.
**AssemblyDelaySignAttribute** - attribute is used on an assembly, space is reserved for the signature which is later filled by a signing tool such as the Sn.exe utility.
