### PR TITLE
Turn off full signing on non-Windows platforms

### DIFF
--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -25,6 +25,7 @@
     <KeyFileDir>$(RepoRoot)src/referencePackages/snk/</KeyFileDir>
     <SignAssembly>true</SignAssembly>
     <PublicSign>true</PublicSign>
+    <FullAssemblySigningSupported Condition="('$(FullAssemblySigningSupported)' == '') and ('$(OS)' != 'Windows_NT')">false</FullAssemblySigningSupported>
 
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
 


### PR DESCRIPTION
Full Signing doesn't work on some platforms (eg RHEL 9, which disables RSA+SHA1 which Full Signing needs). Full Signing is also really on required for .NET Framework support. It should not be needed on modern .NET (5 and later).

More details at https://github.com/dotnet/runtime/issues/65874