### PR TITLE
Updates to TFM support for reference pkg src generator

### DIFF
--- a/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
+++ b/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
@@ -9,7 +9,7 @@
     <OutputPath>$(ArtifactsBinDir)$$RelativePath$$/ref/</OutputPath>
     <IntermediateOutputPath>$(ArtifactsObjDir)$$RelativePath$$</IntermediateOutputPath>
   </PropertyGroup>
-$$PropertiesByTfm$$  <ItemGroup>
+$$TfmSpecificProperties$$  <ItemGroup>
     <Compile Include="**/ref/$(TargetFramework)/*.cs" />
     <Compile Include="**/lib/$(TargetFramework)/*.cs" />
   </ItemGroup>

--- a/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
+++ b/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>$$TargetFrameworks$$</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)$$RelativePath$$/$$LowerCaseFileName$$.nuspec</NuspecFile>$$KeyFileTag$$$$EnableImplicitReferencesTag$$
+    <NuspecFile>$(ArtifactsBinDir)$$RelativePath$$/$$LowerCaseFileName$$.nuspec</NuspecFile>$$KeyFileTag$$
   </PropertyGroup>
 
   <PropertyGroup>
     <OutputPath>$(ArtifactsBinDir)$$RelativePath$$/ref/</OutputPath>
     <IntermediateOutputPath>$(ArtifactsObjDir)$$RelativePath$$</IntermediateOutputPath>
   </PropertyGroup>
-$$OutputPathByTfm$$  <ItemGroup>
+$$PropertiesByTfm$$  <ItemGroup>
     <Compile Include="**/ref/$(TargetFramework)/*.cs" />
     <Compile Include="**/lib/$(TargetFramework)/*.cs" />
   </ItemGroup>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,7 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>netcoreapp3.1;netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageName)' != '' and '$(PackageVersion)' != ''">

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,10 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcoreapp3.1;netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
+    <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
+         Only exclude them when target frameworks to include aren't provided. -->
+    <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageName)' != '' and '$(PackageVersion)' != ''">

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceTask/GenerateProject.cs
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceTask/GenerateProject.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             string projectTemplateContent = File.ReadAllText(ProjectTemplate);
             string pkgProjectOutput = projectTemplateContent;
             string packageReferenceIncludes = "\n";
-            string propertiesByTfm = "\n";
+            string tfmSpecificProperties = "\n";
 
             // Make sure that we always use the same directory separator.
             string relativePath = Path.GetRelativePath(BaseTargetPath, Path.GetDirectoryName(TargetPath)).Replace('\\', '/');
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                 string packageReferences = "";
                 string netStandardTag = "NETStandardImplicitPackageVersion";
 
-                if (targetFramework == "netstandard2.0" && !includesNetStandard21 && !includesNetCoreApp30)
+                if (targetFramework == "netstandard2.0")
                 {
                     packageReferences += $"    <PackageReference Include=\"NETStandard.Library\" Version=\"$({netStandardTag})\" />\n";
                 }
@@ -135,19 +135,18 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                     }
                 }
 
-                propertiesByTfm += $"  <PropertyGroup Condition=\" '$(TargetFramework)' == '{targetFramework}' \">\n";
+                tfmSpecificProperties += $"  <PropertyGroup Condition=\" '$(TargetFramework)' == '{targetFramework}' \">\n";
                 if (subPath == "lib")
                 {
-                    propertiesByTfm += $"    <OutputPath>$(ArtifactsBinDir){relativePath}/{subPath}/</OutputPath>\n";
+                    tfmSpecificProperties += $"    <OutputPath>$(ArtifactsBinDir){relativePath}/{subPath}/</OutputPath>\n";
                 }
-                if (targetFramework == "netstandard2.0" ||
-                    targetFramework == "netstandard2.1" ||
+                if (targetFramework == "netstandard2.1" ||
                     targetFramework == "netcoreapp3.0" ||
                     targetFramework == "net6.0")
                 {
-                    propertiesByTfm += "    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>\n";
+                    tfmSpecificProperties += "    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>\n";
                 }
-                propertiesByTfm += $"  </PropertyGroup>\n\n";
+                tfmSpecificProperties += $"  </PropertyGroup>\n\n";
             }
 
             // If necessary, write the strong name key into the project file.
@@ -159,7 +158,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             }
 
             pkgProjectOutput = pkgProjectOutput.Replace("$$LowerCaseFileName$$", PackageId.ToLowerInvariant());
-            pkgProjectOutput = pkgProjectOutput.Replace("$$PropertiesByTfm$$", propertiesByTfm);
+            pkgProjectOutput = pkgProjectOutput.Replace("$$TfmSpecificProperties$$", tfmSpecificProperties);
             pkgProjectOutput = pkgProjectOutput.Replace("$$RelativePath$$", relativePath);
             pkgProjectOutput = pkgProjectOutput.Replace("$$PackageReferences$$", packageReferenceIncludes);
             pkgProjectOutput = pkgProjectOutput.Replace("$$TargetFrameworks$$", string.Join(';', orderedTargetFrameworks));


### PR DESCRIPTION
In order to support packages with net6.0 TFM, we need to ensure that `DisableImplicitFrameworkReferences` is set to false (it's set to true by default) so that it compile against the existing targeting pack. There already existed code to set this to false but it was done globally for the entire project based on the presence of certain TFMs. But applying it for all TFMs is problematic because it can lead to build errors. For example, if applied to a `netstandard2.0` TFM, you can get this error:

```
 error NETSDK1023: A PackageReference for 'NETStandard.Library' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs
```

The solution is to conditionally apply the setting of the `DisableImplicitFrameworkReferences` property based on the target framework. I've made changes to incorporate this with an existing `PropertyGroup` that sets the output path.

One additional change was made to add `netcoreapp3.1` to the excluded TFMs.

Fixes https://github.com/dotnet/source-build/issues/3251