### PR TITLE
Use ImplicitFrameworkReferences & update GenAPI & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ After generating new reference packages, all new projects must be referenced as 
 These must be defined in dependency order. There is a [tracking issue](https://github.com/dotnet/source-build/issues/1690)
 to address this manual step.
 
-The tooling will not pull in icons referenced by the nuspec so they will have to be manually removed. There is a
-[tracking issue](https://github.com/dotnet/source-build/issues/1957) to address this manual step.
-
 The tooling does not handle all situations and sometimes the generated code will need manual tweeks to get it to compile.
 If this occurs when generating a newer version of an existing package, it can be helpful to regenerate the older version
 to see what changes were made.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ when it was originally generated.
 * Run build with the `./build.sh -sb` command.
 * If the compilation produces numerous compilation issue - run the `./build.sh --projects <path to .csproj file>` command for each generated reference package separately.
 
-You can search for known issues in the `docs/known_generator_issues.md`.
+You can search for known issues in the [Known Generator Issues Markdown file](docs/known_generator_issues.md).
 
 ### Targeting
 

--- a/docs/known_generator_issues.md
+++ b/docs/known_generator_issues.md
@@ -1,22 +1,5 @@
 # Known issues
 
-## Unsupported `netcoreapp3.1` TFM
-
-Tracking [issue](https://github.com/dotnet/source-build/issues/3251)
-
-Reference packages for TFM `netcoreapp3.1` are not supported. You may get numerous compilation issues like:
-
-```text
-*/lib/netcoreapp3.1/*: error CS0246: The type or namespace name 'DebuggableAttribute' could not be found
-*/lib/netcoreapp3.1/*: error CS0518: Predefined type 'System.String' is not defined or imported
-```
-
-Workaround: update the `*.csproj` file:
-
-* remove the `netcoreapp3.1` TFM from the `<TargetFrameworks>` list.
-* remove `<PropertyGroup>` and `<ItemGroup>` with the `netcoreapp3.1` condition.
-* remove the `lib\netcoreapp3.1` folder.
-
 ## The explicit declaration of `TupleElementNamesAttribute` attribute
 
 ```text

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,9 +11,9 @@
       <Sha>cb64095ec45ac34378a1a26db9932a3b561f9e4e</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI.Task" Version="8.0.100-preview.3.23162.7">
+    <Dependency Name="Microsoft.DotNet.GenAPI.Task" Version="8.0.100-preview.3.23164.38">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>04c86729462625b60304075962ac201a0d93a133</Sha>
+      <Sha>83971ae73e9a40583d4648ab746e0c44bd03572d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.SourceLink.GitHub" Version="1.2.0-beta-23151-02" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/sourcelink</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,6 @@
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>
     <!-- SDK dependencies -->
-    <MicrosoftDotNetGenAPITaskPackageVersion>8.0.100-preview.3.23162.7</MicrosoftDotNetGenAPITaskPackageVersion>
+    <MicrosoftDotNetGenAPITaskPackageVersion>8.0.100-preview.3.23164.38</MicrosoftDotNetGenAPITaskPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
+++ b/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$$TargetFrameworks$$</TargetFrameworks>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
     <NuspecFile>$(ArtifactsBinDir)$$RelativePath$$/$$LowerCaseFileName$$.nuspec</NuspecFile>$$KeyFileTag$$
   </PropertyGroup>
 

--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -14,7 +14,7 @@
     <AssemblyName Condition="'$(AssemblyName)' == ''">$([MSBuild]::MakeRelative('$(MSBuildThisFileDirectory)src', '$(ProjectParentDir)'))</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+  <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
     <!-- Common properties for all Reference Packages -->

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -13,14 +13,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))" TargetingPackVersion="3.0.0" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))" TargetingPackVersion="3.1.0" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'net5.0'))" TargetingPackVersion="5.0.0" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'net6.0'))" TargetingPackVersion="6.0.0" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))" TargetingPackVersion="3.0.1" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))" TargetingPackVersion="3.1.10" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'net6.0'))" TargetingPackVersion="6.0.0" />
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'NETStandard.Library')->WithMetadataValue('TargetFramework', 'netstandard2.1'))" TargetingPackVersion="2.1.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App'))">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.0'">3.0.0</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">3.1.0</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net5.0'">5.0.0</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
+    </KnownFrameworkReference>
+
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.0'">3.0.1</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">3.1.10</TargetingPackVersion>
+    </KnownFrameworkReference>
+
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'NETStandard.Library'))">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'netstandard2.1'">2.1.0</TargetingPackVersion>
+    </KnownFrameworkReference>
   </ItemGroup>
 
   <!-- Filter out conflicting implicit assembly references. -->

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -1,4 +1,46 @@
 <Project>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
+  <Import Project="..\Directory.Build.targets" />
+
+  <!--
+    ### Targeting Packs section ###
+    Keep in sync with available targeting packs under src/targetPacks/ILsrc.
+  -->
+
+  <PropertyGroup>
+    <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
+    <NETStandardImplicitPackageVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'">2.0.3</NETStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))" TargetingPackVersion="3.0.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))" TargetingPackVersion="3.1.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'net5.0'))" TargetingPackVersion="5.0.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', 'net6.0'))" TargetingPackVersion="6.0.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.0'))" TargetingPackVersion="3.0.1" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'netcoreapp3.1'))" TargetingPackVersion="3.1.10" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')->WithMetadataValue('TargetFramework', 'net6.0'))" TargetingPackVersion="6.0.0" />
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'NETStandard.Library')->WithMetadataValue('TargetFramework', 'netstandard2.1'))" TargetingPackVersion="2.1.0" />
+  </ItemGroup>
+
+  <!-- Filter out conflicting implicit assembly references. -->
+  <Target Name="FilterImplicitAssemblyReferences"
+          Condition="'$(DisableImplicitFrameworkReferences)' != 'true'"
+          DependsOnTargets="ResolveProjectReferences"
+          AfterTargets="ResolveTargetingPackAssets">
+    <ItemGroup>
+      <_targetingPackReferenceExclusion Include="$(TargetName)" />
+      <_targetingPackReferenceExclusion Include="@(_ResolvedProjectReferencePaths->Metadata('Filename'))" />
+    </ItemGroup>
+    <ItemGroup>
+      <_targetingPackReferenceWithProjectName Include="@(Reference->WithMetadataValue('ExternallyResolved', 'true')->Metadata('Filename'))"
+                                              OriginalIdentity="%(Identity)" />
+      <_targetingPackIncludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
+                                                      Exclude="@(_targetingPackReferenceExclusion)" />
+      <_targetingPackExcludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
+                                                      Exclude="@(_targetingPackIncludedReferenceWithProjectName)" />
+      <Reference Remove="@(_targetingPackExcludedReferenceWithProjectName->Metadata('OriginalIdentity'))" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' And '$(_TargetFrameworkVersionWithoutV)' &lt; '2.1'">2.0.3</NETStandardImplicitPackageVersion>
+    <!-- The SDK already sets the NETStandardImplicitPackageVersion and we don't expect it to change anymore. Hence, we don't encode it here. -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use ImplicitFrameworkReferences for all target frameworks and define a lookup table that specifies the TargetingPackVersion for each locally available targeting pack.
That removes the hardcoded list of tfms in the project generator.
Also update GenAPI manually, which includes two fixes:
- https://github.com/dotnet/sdk/commit/56034855fd06f95edcc6580d58a344004d3555ca
- https://github.com/dotnet/sdk/commit/fda0d039903a4b77b86c1504f8f3201c9dc5862a

@mthalman that unblocks your PR: https://github.com/dotnet/source-build-reference-packages/pull/568. I decided to open a separate PR as the scope of the fix slightly changed.