### PR TITLE
Clean-up generated project file & avoid unnecessary D.B.props file

### DIFF
--- a/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
+++ b/src/referencePackageSourceGenerator/ReferencePackageProjectTemplate.xml
@@ -2,16 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$$TargetFrameworks$$</TargetFrameworks>
-    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
-    <NuspecFile>$(ArtifactsBinDir)$$RelativePath$$/$$LowerCaseFileName$$.nuspec</NuspecFile>$$KeyFileTag$$
+    <AssemblyName>$$AssemblyName$$</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>$$KeyFileTag$$
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)$$RelativePath$$/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)$$RelativePath$$</IntermediateOutputPath>
-  </PropertyGroup>
-$$TfmSpecificProperties$$  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
 $$PackageReferences$$</Project>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -91,8 +91,7 @@
           DependsOnTargets="GenerateAndInvokeGenerateSourceProject;
                             GenerateReferencePackageProject;
                             CopyPlaceholderFiles;
-                            RewriteNuspec;
-                            CreateDirectoryBuildPropsFile" />
+                            RewriteNuspec" />
 
   <!-- Generate an intermediate multi-targeting wrapper project that retrieves the reference assemblies and invokes GenAPI. -->
   <Target Name="GenerateAndInvokeGenerateSourceProject"
@@ -153,7 +152,6 @@
                      CompileItems="@(PackageCompileItem)"
                      PackageDependencies="@(PackageDependency)"
                      FrameworkReferences="@(PackageFrameworkReference)"
-                     BaseTargetPath="$(PackagesTargetDirectory)"
                      TargetPath="$(ReferencePackageProjectTargetPath)"
                      ProjectTemplate="$(ReferencePackageProjectTemplate)" />
 
@@ -189,34 +187,6 @@
                    RemoveRuntimeSpecificDependencies="true" />
 
     <Message Text="$(MSBuildProjectName) -> $(NuspecTargetPath)"
-             Importance="high" />
-  </Target>
-
-  <!-- Generate Directory.Build.props supplemental build file. -->
-  <Target Name="CreateDirectoryBuildPropsFile"
-          DependsOnTargets="GetPackageItems">
-    <PropertyGroup>
-      <DirectoryBuildPropsTemplate>DirectoryBuildPropsTemplate.xml</DirectoryBuildPropsTemplate>
-      <DirectoryBuildPropsTargetPath>$(BasePackageTargetDirectory)Directory.Build.props</DirectoryBuildPropsTargetPath>
-    </PropertyGroup>
-
-    <!-- Calculate the assembly name from the compile items assembly name metadata. If more than one
-         distinct name is found (i.e. multi assembly package), use the PackageId instead. -->
-    <ItemGroup>
-      <PackageAssemblyName Include="@(PackageCompileItem->Metadata('AssemblyName')->Distinct())" />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <PackageAssemblyName Condition="@(PackageAssemblyName->Count()) > 1">$(RealPackageId)</PackageAssemblyName>
-      <PackageAssemblyName Condition="'$(PackageAssemblyName)' == ''">%(PackageAssemblyName.Identity)</PackageAssemblyName>
-    </PropertyGroup>
-
-    <WriteLinesToFile File="$(DirectoryBuildPropsTargetPath)"
-                      Lines="$([System.IO.File]::ReadAllText('$(DirectoryBuildPropsTemplate)')
-                               .Replace('$$AssemblyName$$', '$(PackageAssemblyName)'))"
-                      Overwrite="true" />
-
-    <Message Text="$(MSBuildProjectName) -> $(DirectoryBuildPropsTargetPath)"
              Importance="high" />
   </Target>
 

--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -1,19 +1,5 @@
 <Project>
 
-  <!--
-    The project name uses {AssemblyName}.{Version}.csproj format to be unqiue, because we build
-    multiple versions of the same package IDs. This means the AssemblyName will include the version
-    in the name, unlike the real packages. To fix this, use the parent parent dir name as the
-    assembly name, as it has the correct versionless name and capitalization.
-
-    If this doesn't work in a specific case, manually define AssemblyName in the project, or in a
-    Directory.Build.props for that whole package ID.
-  -->
-  <PropertyGroup>
-    <ProjectParentDir>$([System.IO.Directory]::GetParent('$(MSBuildProjectDirectory)'))</ProjectParentDir>
-    <AssemblyName Condition="'$(AssemblyName)' == ''">$([MSBuild]::MakeRelative('$(MSBuildThisFileDirectory)src', '$(ProjectParentDir)'))</AssemblyName>
-  </PropertyGroup>
-
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -2,6 +2,20 @@
 
   <Import Project="..\Directory.Build.targets" />
 
+  <!-- Setting that are dependent on the project template version. -->
+  <Choose>
+    <When Condition="'$(ProjectTemplateVersion)' == '2'">
+      <PropertyGroup>
+        <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <Compile Include="ref/$(TargetFramework)/*$(DefaultLanguageSourceExtension)" />
+        <Compile Include="lib/$(TargetFramework)/*$(DefaultLanguageSourceExtension)" />
+      </ItemGroup>
+    </When>
+  </Choose>
+
   <!--
     ### Targeting Packs section ###
     Keep in sync with available targeting packs under src/targetPacks/ILsrc.


### PR DESCRIPTION
The following changes are a continuation of my previous work:
- Move common settings (i.e. compile item includes & DisableImplicitFrameworkReferences) out of the project files into the Directory.Build.targets file
- Add a ProjectTemplateVersion marker property to identify projects that use the new format. This can removed in the future when all packages got re-generated.
- Avoid the unnecessary Directory.Build.props file per package and instead emit the AssemblyName into the project file.
- Avoid the unnecessary NuspecFile property which was already set in a src/Directory.Build.targets for all projects.

Example: System.Text.Json/6.0.0
### Before
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>net461;net6.0;netstandard2.0</TargetFrameworks>
    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
    <NuspecFile>$(ArtifactsBinDir)system.text.json/6.0.0/system.text.json.nuspec</NuspecFile>
    <StrongNameKeyId>Open</StrongNameKeyId>
  </PropertyGroup>

  <PropertyGroup>
    <OutputPath>$(ArtifactsBinDir)system.text.json/6.0.0/ref/</OutputPath>
    <IntermediateOutputPath>$(ArtifactsObjDir)system.text.json/6.0.0</IntermediateOutputPath>
  </PropertyGroup>

  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
    <OutputPath>$(ArtifactsBinDir)system.text.json/6.0.0/lib/</OutputPath>
  </PropertyGroup>

  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
    <OutputPath>$(ArtifactsBinDir)system.text.json/6.0.0/lib/</OutputPath>
  </PropertyGroup>

  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
    <OutputPath>$(ArtifactsBinDir)system.text.json/6.0.0/lib/</OutputPath>
  </PropertyGroup>

  <ItemGroup>
    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
  </ItemGroup>

  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Memory" Version="4.5.4" />
    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
  </ItemGroup>

  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
  </ItemGroup>

  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Memory" Version="4.5.4" />
    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
  </ItemGroup>

</Project>
```

### After
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFrameworks>net461;net6.0;netstandard2.0</TargetFrameworks>
    <AssemblyName>System.Text.Json</AssemblyName>
    <ProjectTemplateVersion>2</ProjectTemplateVersion>
    <StrongNameKeyId>Open</StrongNameKeyId>
  </PropertyGroup>

  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Memory" Version="4.5.4" />
    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
  </ItemGroup>

  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
  </ItemGroup>

  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
    <PackageReference Include="System.Buffers" Version="4.5.1" />
    <PackageReference Include="System.Memory" Version="4.5.4" />
    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
  </ItemGroup>

</Project>
```