### PR TITLE
Exclude uap* and portable* TFMs from being generated

### DIFF
--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,7 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81;uap*</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>netcore50;net463;portable*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81;uap*</ExcludeTargetFrameworks>
     <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
          Only exclude them when target frameworks to include aren't provided. -->
     <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,7 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcore50;net463;portable*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81;uap*</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>monoandroid*;monotouch*;net463;netcore50;portable*;uap*;win8;wp8;wpa81;xamarin*</ExcludeTargetFrameworks>
     <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
          Only exclude them when target frameworks to include aren't provided. -->
     <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>

--- a/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
+++ b/src/referencePackageSourceGenerator/ReferencePackageSourceGenerator.proj
@@ -7,7 +7,7 @@
     <PackagesTargetDirectory>$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>netcore50;net463;portable-*;xamarin*;monotouch*;monoandroid*;win8;wp8;wpa81;uap*</ExcludeTargetFrameworks>
     <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
          Only exclude them when target frameworks to include aren't provided. -->
     <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3326

When testing the uap change, I noticed `.NETPortable4.5-Profile259` was appearing in the nuspec of system.valuetype,4.5.0.  Talking with @ViktorHofer, this was intended to be filtered out by the existing `portable-*` filter so I adjusted the filter to be `portable*`

The list is getting long enough so I decided to sort it.