### PR TITLE
Delete DirectoryBuildPropsTemplate.xml

### DIFF
--- a/src/referencePackageSourceGenerator/DirectoryBuildPropsTemplate.xml
+++ b/src/referencePackageSourceGenerator/DirectoryBuildPropsTemplate.xml
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>$$AssemblyName$$</AssemblyName>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
I forgot to delete this file when I made the Directory.Build.props file obsolete in https://github.com/dotnet/source-build-reference-packages/commit/353be38d22373b6e5bb76d88e8653916174f6606