### PR TITLE
Add a Windows generate.cmd/ps1 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ to time in issues and some documentation.
 
 ## Supported Platforms
 
-.NET source build currently only supports Linux.
+.NET source build currently only supports Linux but generating a source-build reference or text-only package is supported on both Windows and Unix based operating systems.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ New packages are needed from time to time as
 [existing dependency versions are upgraded](https://github.com/dotnet/source-build/blob/main/Documentation/sourcebuild-in-repos/update-dependencies.md)
 and [new dependencies are added](https://github.com/dotnet/source-build/blob/main/Documentation/sourcebuild-in-repos/new-dependencies.md)
 to .NET. The [generate script](https://github.com/dotnet/source-build-reference-packages/blob/main/generate.sh) supports
-generating new packages. Run `generate.sh -h` for usage details.
+generating new packages. Run `generate.sh --help` for usage details.
 
 When generating a package(s), the tooling will detect and generate all dependent packages.
 
 ### Reference
 
 ``` bash
-./generate.sh --pkg system.buffers,4.5.1
+./generate.sh --package system.buffers,4.5.1
 ```
 
 After generating new reference packages, all new projects must be referenced as a
@@ -56,7 +56,7 @@ when it was originally generated.
 
 #### Workflow
 
-* Generate reference package and its depencencies running the `./generate.sh --pkg <package>,<version>` script.
+* Generate reference package and its depencencies running the `./generate.sh --package <package>,<version>` script.
 * Revert changes for packages that were already existed in the repository.
 * Run build with the `./build.sh -sb` command.
 * If the compilation produces numerous compilation issue - run the `./build.sh --projects <path to .csproj file>` command for each generated reference package separately.
@@ -71,7 +71,7 @@ targeting pack is needed, please [open a new issue](#filing-issues) to discuss.
 ### Text Only
 
 ``` bash
-./generate.sh --type text --pkg microsoft.build.traversal,3.1.6
+./generate.sh --type text --package microsoft.build.traversal,3.1.6
 ```
 
 ## Filing Issues

--- a/eng/generate.ps1
+++ b/eng/generate.ps1
@@ -1,0 +1,71 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [string[]][Alias('p')]$package,
+  [string][Alias('c')]$csv,
+  [string][Alias('d')]$destination,
+  [ValidateSet('ref','text')][string][Alias('t')]$type,
+  [switch][Alias('e')]$excludeDependencies,
+  [string][Alias('f')]$feeds,
+  [switch][Alias('h')]$help,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
+)
+
+function Get-Help() {
+  Write-Host "usage: $(split-path $MyInvocation.PSCommandPath -Leaf) [options]"
+  Write-Host ""
+  Write-Host "Generates a reference package or a text-only package from the specified packages and versions. The"
+  Write-Host "type of the generated package is controlled via the --type option."
+  Write-Host ""
+  Write-Host "Reference package generation will restore reference package(s) and dependencies and generate cs files"
+  Write-Host "and with accompanying projects into the specified destination ('./src/referencePackages/' by default)."
+  Write-Host "Text-only package generation will restore the specified package and copy the source-build-usable content"
+  Write-Host "into the provided directory ('./src/textOnlyPackages/' by default)."
+  Write-Host ""
+  Write-Host "Either -package or -csv must be specified"
+  Write-Host ""
+  Write-Host "options:"
+  Write-Host "  -p|-package <name,version[,tfms]>            A package and version, no spaces, separated by comma. If an optional TFM is"
+  Write-Host "                                               specified, it will be used to filter the project's target frameworks."
+  Write-Host "                                               Examples: System.Collections,4.3.0"
+  Write-Host "                                                         System.Text.Json,4.7.0,netstandard2.0"
+  Write-Host "  -c|-csv                                      A path to a csv file of packages to generate. Format is the same as the -package"
+  Write-Host "                                               option above, one per line. If specified, the -package option is ignored."
+  Write-Host "  -d|-destination                              A path to the root of the repo to copy source into."
+  Write-Host "  -t|-type                                     Type of the package to generate. Accepted values: ref (default) | text."
+  Write-Host "  -e|-excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
+  Write-Host "  -f|-feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
+  Write-Host "  -h|-help                                     Print help and exit."
+}
+
+if ($help -or $($PSBoundParameters.Count) -eq 0) {
+  Get-Help
+  exit 0
+}
+
+foreach ($argument in $PSBoundParameters.Keys)
+{
+  switch($argument)
+  {
+    "package"
+    { 
+        if ($package.Length -lt 2 -or $package.Length -gt 3) {
+            Write-Error "Cannot parse -package argument. Format: <name,version[,tfms]>"
+            exit -1
+        }
+
+        $arguments += " /p:PackageName=$($package[0]) /p:PackageVersion=$($package[1])"
+        if ($package.Length -eq 3) {
+            $arguments += " /p:PackageTargetFrameworks=`"$($package[2])`""
+        }
+    }
+    "csv"                        { $arguments += " /p:PackageCSV=`"$($PSBoundParameters[$argument])`"" }
+    "destination"                { $arguments += " /p:PackagesTargetDirectory=`"$($PSBoundParameters[$argument])`"" }
+    "type"                       { $arguments += " /p:PackageType=$($PSBoundParameters[$argument])" }
+    "excludeDependencies"        { $arguments += " /p:ExcludePackageDependencies=true" }
+    "feeds"                      { $arguments += " /p:RestoreAdditionalProjectSources=`"$($PSBoundParameters[$argument])`"" }
+    default                      { $arguments += " $($PSBoundParameters[$argument])" }
+  }
+}
+
+Invoke-Expression "& `"$PSScriptRoot\common\build.ps1`" -restore -build -warnaserror 0 /p:GeneratePackageSource=true $arguments"
+exit 0

--- a/generate.cmd
+++ b/generate.cmd
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+set _args=%*
+if "%~1"=="-?" set _args=-help
+if "%~1"=="/?" set _args=-help
+
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\generate.ps1'" %_args%
+exit /b %ERRORLEVEL%

--- a/generate.sh
+++ b/generate.sh
@@ -21,38 +21,34 @@ usage() {
     echo "  Text-only package generation will restore the specified package and copy the source-build-usable content"
     echo "  into the provided directory ('./src/textOnlyPackages/' by default)."
     echo ""
-    echo "  Either --pkg or --pkgcsv must be specified"
+    echo "  Either --package or --csv must be specified"
     echo ""
     echo "options:"
-    echo "  --pkg|--package <packageName,version[,tfms]>      A package and version, no spaces, separated by comma.  If optional semicolon-separated"
-    echo "                                                    TFMs are specified, they will be used in the project that restores the package."
-    echo "                                                    Examples: System.Collections,4.3.0"
-    echo "                                                              System.Text.Json,4.7.0,nestandard2.0;net461"
-    echo "  --pkgcsv|--package-csv                            A path to a csv file of packages to generate. Format is the same as the --pkg"
-    echo "                                                    option above, one per line.  If specified, the --pkg option is ignored."
-    echo "  --dest|--destination                              A path to the root of the repo to copy source into."
-    echo "  --type|--package-type                             Type of the package to generate. Accepted values: ref (default) | text."
-    echo "  --exclude-deps|--exclude-package-dependencies     Determines if package dependencies should be excluded. Default is false."
-    echo "  --feeds                                           A semicolon-separated list of additional NuGet feeds to use during restore."
-    echo ""
+    echo "  -p|--package <name,version[,tfms]>            A package and version, no spaces, separated by comma. If optional semicolon-separated"
+    echo "                                                TFMs are specified, they will be used to filter the project's target frameworks."
+    echo "                                                Examples: System.Collections,4.3.0"
+    echo "                                                          System.Text.Json,4.7.0,netstandard2.0;net461"
+    echo "  --csv                                         A path to a csv file of packages to generate. Format is the same as the --package"
+    echo "                                                option above, one per line.  If specified, the --package option is ignored."
+    echo "  -d|--destination                              A path to the root of the repo to copy source into."
+    echo "  -t|--type                                     Type of the package to generate. Accepted values: ref (default) | text."
+    echo "  -e|--excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
+    echo "  -f|--feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
+    echo "  -h|--help                                     Print help and exit."
 }
-
-arguments=''
-extraArgs=''
 
 if [[ $# -le 0 ]]; then
 	usage
 	exit 0
 fi
 
+arguments=''
+extraArgs=''
+
 while [[ $# > 0 ]]; do
     opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
     case "$opt" in
-        "-?"|-h|-help)
-            usage
-            exit 0
-            ;;
-        -pkg|-package)
+        -p|-package)
             IFS=, read -r packageName packageVersion packageTargetFrameworks <<< $2
             arguments="$arguments /p:PackageName=$packageName /p:PackageVersion=$packageVersion"
             if [ -n "$packageTargetFrameworks" ]; then
@@ -60,7 +56,7 @@ while [[ $# > 0 ]]; do
             fi
             shift 2
             ;;
-        -pkgcsv|-package-csv)
+        -c|-csv)
             if [ ! -f "$2" ]; then
                 echo -e "${RED}ERROR: CSV file not found - $2${NC}"
                 exit 1
@@ -69,7 +65,7 @@ while [[ $# > 0 ]]; do
             arguments="$arguments /p:PackageCSV=\"$packageCSV\""
             shift 2
             ;;
-        -dest|-destination)
+        -d|-destination)
             if [ ! -d "$2" ]; then
                 echo -e "${RED}ERROR: dest not found - $2${NC}"
                 exit 1
@@ -78,25 +74,29 @@ while [[ $# > 0 ]]; do
             arguments="$arguments /p:PackagesTargetDirectory=\"$packagesTargetDirectory\""
             shift 2
             ;;
-        -type|-package-type)
-            packageType="$2"
-            if [[ ! "$packageType" =~ ^(text|ref)$ ]]; then
+        -t|-type)
+            type="$2"
+            if [[ ! "$type" =~ ^(text|ref)$ ]]; then
                 echo -e "${RED}ERROR: unknown package type - $2${NC}"
                 usage
                 exit 1
             fi
-            arguments="$arguments /p:PackageType=$packageType"
+            arguments="$arguments /p:PackageType=$type"
             shift 2
             ;;
-        -exclude-deps|-exclude-package-dependencies)
+        -e|-excludedependencies)
             arguments="$arguments /p:ExcludePackageDependencies=true"
             shift 1
             ;;
-        -feeds)
+        -f|-feeds)
             # -p:RestoreAdditionalProjectSources -> specifies additional Nuget package sources, including feeds: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-properties
             feeds="$2"
             arguments="$arguments /p:RestoreAdditionalProjectSources=\"$feeds\""
             shift 2
+            ;;
+        "-?"|-h|-help)
+            usage
+            exit 0
             ;;
         *)
             extraArgs="$extraArgs $1"


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3329

Make it possible to generate SBRP packages on Windows by providing an entry point generate.cmd script and the underlying eng/generate.ps1 script.

Rename a few arguments that didn't work on Windows based on the powershell syntax and make them consistent between Windows and Unix. Add aliases for less typing.