### PR TITLE
Fix GenerateProject

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/GenerateProject.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/GenerateProject.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 
             // Calculate the assembly name from the compile items assembly name metadata. If more than one
             // distinct name is found (i.e. multi assembly package), use the PackageId instead.
-            ITaskItem[] assemblyNames = CompileItems
+            string[] assemblyNames = CompileItems
                 .Select(compileItem => compileItem.GetMetadata(SharedMetadata.AssemblyNameMetadataName))
                 .Distinct()
                 .ToArray();


### PR DESCRIPTION
Unfortunately I missed that in https://github.com/dotnet/source-build-reference-packages/commit/ae9290b703015cb0d607207d59dc002053663e35

cc @NikolaMilosavljevic 