### PR TITLE
Exclude net35 tfms during package source generation

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -8,7 +8,7 @@
     <PackagesTargetDirectory Condition="'$(PackageType)' == 'text'">$(RepoRoot)src\textOnlyPackages\src\</PackagesTargetDirectory>
     <!-- The following target frameworks aren't buildable with the current SDK and as they don't contribute to the set of
          source build target verticals, can be safely excluded. -->
-    <ExcludeTargetFrameworks>monoandroid*;monotouch*;net40;net463;netcore50;portable*;uap*;win8;wp8;wpa81;xamarin*</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks>monoandroid*;monotouch*;net35;net40;net463;netcore50;portable*;uap*;win8;wp8;wpa81;xamarin*</ExcludeTargetFrameworks>
     <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
          Only exclude them when target frameworks to include aren't provided. -->
     <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>


### PR DESCRIPTION
Microsoft.NET.StringTools/1.0.0 contains a net35 asset which we need to exclude (as there is no targeting pack and because we don't want to generate the net35 asset).

Fixes https://github.com/dotnet/source-build/issues/3346