### PR TITLE
Fix package source generator nodes lock

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/GetPackageItems.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/GetPackageItems.cs
@@ -131,6 +131,12 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 
                 foreach (ContentItem compileItem in compileItems.Items)
                 {
+                    // Skip duplicate compile items. That can happen when different target frameworks choose
+                    // the same asset as best compatible. E.g. System.Runtime.CompilerServices.Unsafe/4.7.0
+                    // netcoreapp2.0 and netstandard2.0 TFMs both choose the netstandard2.0 compile asset.
+                    if (compileTaskItems.Any(compileTaskItem => compileTaskItem.ItemSpec == compileItem.Path))
+                        continue;
+
                     TaskItem compileTaskItem = new(compileItem.Path);
                     compileTaskItem.SetMetadata(SharedMetadata.TargetFrameworkMetadataName, targetFramework);
 


### PR DESCRIPTION
The inner builds of the generated multi-targeting source projects that invoke GenAPI collide with each other when different tfms choose the same best compatible package tfm. I.e. `netstandard2.0` and `netcoreapp2.0` in System.Runtime.CompilerServices.Unsafe/4.7.0 both pick the `netstandard2.0` asset as best compatible.

When retrieving the compile items, distinct the item set to avoid duplicates that would then result in inner build nodes locking each other.

Fixes https://github.com/dotnet/source-build/issues/3345

cc @mthalman 