### PR TITLE
remove readme tag from nuspec files

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -295,6 +295,7 @@
                    IncludeTargetFrameworks="$(PackageTargetFrameworks)"
                    ExcludeTargetFrameworks="$(ExcludeTargetFrameworks)"
                    RemoveIcon="true"
+                   RemoveReadMe="true"
                    RemoveRuntimeSpecificDependencies="true" />
 
     <Message Text="$(MSBuildProjectName) -> $(NuspecTargetPath)"

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs
@@ -24,6 +24,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 
         public bool RemoveIcon { get; set; }
 
+        public bool RemoveReadMe { get; set; }
+
         public bool RemoveRuntimeSpecificDependencies { get; set; }
 
         public override bool Execute()
@@ -62,6 +64,11 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
                 nuspecContent = GetIconRegex().Replace(nuspecContent, string.Empty);
             }
 
+            if (RemoveReadMe)
+            {
+                nuspecContent = GetReadMeRegex().Replace(nuspecContent, string.Empty);
+            }
+
             if (RemoveRuntimeSpecificDependencies)
             {
                 nuspecContent = GetRuntimeSpecificDependenciesRegex().Replace(nuspecContent, string.Empty);
@@ -73,6 +80,9 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 
         [GeneratedRegex(" *<icon>.+</icon>\r?\n")]
         private static partial Regex GetIconRegex();
+
+        [GeneratedRegex(" *<readme>.+</readme>\r?\n")]
+        private static partial Regex GetReadMeRegex();
 
         [GeneratedRegex(@" *<dependency id=""runtime.native.+?"".+? />\r?\n")]
         private static partial Regex GetRuntimeSpecificDependenciesRegex();


### PR DESCRIPTION
When generating an SBRP, the tooling copies the `*.nuspec` file with some minor changes. The file in question can contain a `<readme>` tag pointing to the the `README.md` file.

Since the tooling does not copy the `README.md` file itself, when the project is build an exception is thrown (specifically, [NU5039](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5039)). Example of this exception for `Microsoft.Build: 17.3.2`:
```
error NU5039: The readme file 'README.md' does not exist in the package.
```

To address this exception, this PR add functionality for removing the tag from the `*.nuspec`