### PR TITLE
Make official builds faster

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -24,6 +24,7 @@ stages:
       enablePublishUsingPipelines: true
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
+      publishAssetsImmediately: true
       artifacts:
         publish:
           artifacts: true
@@ -35,7 +36,8 @@ stages:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       publishingInfraVersion: 3
-      enableSourceLinkValidation: true
+      publishAssetsImmediately: true
+      enableSourceLinkValidation: false
       #Nuget and Signing Validation are not needed as we only produce a transport package.
       enableSigningValidation: false
       enableNugetValidation: false


### PR DESCRIPTION
Disable source link validation and publish assets immediately in darc stage. Source link validation isn't necessary because this repo doesn't ship any packages (and gets rebuilt in the VMR)