### PR TITLE
Remove reserved "-e" bash shortcut

### DIFF
--- a/eng/generate.ps1
+++ b/eng/generate.ps1
@@ -32,7 +32,7 @@ function Get-Help() {
   Write-Host "                                               option above, one per line. If specified, the -package option is ignored."
   Write-Host "  -d|-destination                              A path to the root of the repo to copy source into."
   Write-Host "  -t|-type                                     Type of the package to generate. Accepted values: ref (default) | text."
-  Write-Host "  -x|-excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
+  Write-Host "  -x|-excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
   Write-Host "  -f|-feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
   Write-Host "  -h|-help                                     Print help and exit."
 }

--- a/eng/generate.ps1
+++ b/eng/generate.ps1
@@ -4,7 +4,7 @@ Param(
   [string][Alias('c')]$csv,
   [string][Alias('d')]$destination,
   [ValidateSet('ref','text')][string][Alias('t')]$type,
-  [switch][Alias('e')]$excludeDependencies,
+  [switch]$excludeDependencies,
   [string][Alias('f')]$feeds,
   [switch][Alias('h')]$help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties

--- a/eng/generate.ps1
+++ b/eng/generate.ps1
@@ -32,7 +32,7 @@ function Get-Help() {
   Write-Host "                                               option above, one per line. If specified, the -package option is ignored."
   Write-Host "  -d|-destination                              A path to the root of the repo to copy source into."
   Write-Host "  -t|-type                                     Type of the package to generate. Accepted values: ref (default) | text."
-  Write-Host "  -e|-excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
+  Write-Host "  -excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
   Write-Host "  -f|-feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
   Write-Host "  -h|-help                                     Print help and exit."
 }

--- a/eng/generate.ps1
+++ b/eng/generate.ps1
@@ -4,7 +4,7 @@ Param(
   [string][Alias('c')]$csv,
   [string][Alias('d')]$destination,
   [ValidateSet('ref','text')][string][Alias('t')]$type,
-  [switch]$excludeDependencies,
+  [switch][Alias('x')]$excludeDependencies,
   [string][Alias('f')]$feeds,
   [switch][Alias('h')]$help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
@@ -32,7 +32,7 @@ function Get-Help() {
   Write-Host "                                               option above, one per line. If specified, the -package option is ignored."
   Write-Host "  -d|-destination                              A path to the root of the repo to copy source into."
   Write-Host "  -t|-type                                     Type of the package to generate. Accepted values: ref (default) | text."
-  Write-Host "  -excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
+  Write-Host "  -x|-excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
   Write-Host "  -f|-feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
   Write-Host "  -h|-help                                     Print help and exit."
 }

--- a/generate.sh
+++ b/generate.sh
@@ -49,7 +49,17 @@ while [[ $# > 0 ]]; do
     opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
     case "$opt" in
         -p|-package)
+            if [ -z ${2+x} ]; then
+                echo -e "${RED}ERROR: No package information supplied.${NC}"
+                exit 1
+            fi
+
             IFS=, read -r packageName packageVersion packageTargetFrameworks <<< $2
+            if [ -z ${packageVersion} ]; then
+                echo -e "${RED}ERROR: No package version supplied.${NC}"
+                exit 1
+            fi
+
             arguments="$arguments /p:PackageName=$packageName /p:PackageVersion=$packageVersion"
             if [ -n "$packageTargetFrameworks" ]; then
                 arguments="$arguments /p:PackageTargetFrameworks=\"$packageTargetFrameworks\""
@@ -58,7 +68,7 @@ while [[ $# > 0 ]]; do
             ;;
         -c|-csv)
             if [ ! -f "$2" ]; then
-                echo -e "${RED}ERROR: CSV file not found - $2${NC}"
+                echo -e "${RED}ERROR: CSV file not found: '$2'${NC}"
                 exit 1
             fi
             packageCSV="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
@@ -67,7 +77,7 @@ while [[ $# > 0 ]]; do
             ;;
         -d|-destination)
             if [ ! -d "$2" ]; then
-                echo -e "${RED}ERROR: dest not found - $2${NC}"
+                echo -e "${RED}ERROR: Destination not found: '$2'${NC}"
                 exit 1
             fi
             packagesTargetDirectory="$(cd -P "$2" && pwd)"
@@ -77,8 +87,7 @@ while [[ $# > 0 ]]; do
         -t|-type)
             type="$2"
             if [[ ! "$type" =~ ^(text|ref)$ ]]; then
-                echo -e "${RED}ERROR: unknown package type - $2${NC}"
-                usage
+                echo -e "${RED}ERROR: Unknown package type: '$type'${NC}"
                 exit 1
             fi
             arguments="$arguments /p:PackageType=$type"
@@ -89,9 +98,12 @@ while [[ $# > 0 ]]; do
             shift 1
             ;;
         -f|-feeds)
+            if [ -z ${2+x} ]; then
+                echo -e "${RED}ERROR: No feed supplied.${NC}"
+                exit 1
+            fi
             # -p:RestoreAdditionalProjectSources -> specifies additional Nuget package sources, including feeds: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-properties
-            feeds="$2"
-            arguments="$arguments /p:RestoreAdditionalProjectSources=\"$feeds\""
+            arguments="$arguments /p:RestoreAdditionalProjectSources=\"$2\""
             shift 2
             ;;
         "-?"|-h|-help)

--- a/generate.sh
+++ b/generate.sh
@@ -32,7 +32,7 @@ usage() {
     echo "                                                option above, one per line.  If specified, the --package option is ignored."
     echo "  -d|--destination                              A path to the root of the repo to copy source into."
     echo "  -t|--type                                     Type of the package to generate. Accepted values: ref (default) | text."
-    echo "  --excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
+    echo "  -x|--excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
     echo "  -f|--feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
     echo "  -h|--help                                     Print help and exit."
 }
@@ -93,7 +93,7 @@ while [[ $# > 0 ]]; do
             arguments="$arguments /p:PackageType=$type"
             shift 2
             ;;
-        -e|-excludedependencies)
+        -x|-excludedependencies)
             arguments="$arguments /p:ExcludePackageDependencies=true"
             shift 1
             ;;

--- a/generate.sh
+++ b/generate.sh
@@ -32,7 +32,7 @@ usage() {
     echo "                                                option above, one per line.  If specified, the --package option is ignored."
     echo "  -d|--destination                              A path to the root of the repo to copy source into."
     echo "  -t|--type                                     Type of the package to generate. Accepted values: ref (default) | text."
-    echo "  -x|--excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
+    echo "  -x|--excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
     echo "  -f|--feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
     echo "  -h|--help                                     Print help and exit."
 }

--- a/generate.sh
+++ b/generate.sh
@@ -32,7 +32,7 @@ usage() {
     echo "                                                option above, one per line.  If specified, the --package option is ignored."
     echo "  -d|--destination                              A path to the root of the repo to copy source into."
     echo "  -t|--type                                     Type of the package to generate. Accepted values: ref (default) | text."
-    echo "  -e|--excludeDependencies                      Determines if package dependencies should be excluded. Default is false."
+    echo "  --excludeDependencies                         Determines if package dependencies should be excluded. Default is false."
     echo "  -f|--feeds                                    A semicolon-separated list of additional NuGet feeds to use during restore."
     echo "  -h|--help                                     Print help and exit."
 }


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3360

The "-e" option is a reserved argument and can't be used. I decided to just remove it and add some more error validation and logging for better UX. To keep both arguments in sync, I also decided to remove it from the Windows counterpart.