### PR TITLE
Ignore external packages in package source generation

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -328,10 +328,16 @@
       <TargetingPackage Include="Microsoft.AspNetCore.App.Ref" />
       <TargetingPackage Include="Microsoft.WindowsDesktop.App.Ref" />
     </ItemGroup>
+    
+    <!-- External packages aren't visited as they shouldn't be added to SBRP. --> 
+    <ItemGroup>
+      <ExternalPackage Include="Newtonsoft.Json" />
+    </ItemGroup>
 
     <ItemGroup>
       <FilteredPackageDependency Include="@(PackageDependency)"
-                                 Exclude="@(TargetingPackage)" />
+                                 Exclude="@(TargetingPackage);
+                                          @(ExternalPackage)" />
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildThisFileFullPath)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/3364