### PR TITLE
Include net7.0 for TargetingPackVersion mapping

### DIFF
--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -33,11 +33,13 @@
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">3.1.0</TargetingPackVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net5.0'">5.0.0</TargetingPackVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net7.0'">7.0.0</TargetingPackVersion>
     </KnownFrameworkReference>
 
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))">
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">3.1.10</TargetingPackVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.0</TargetingPackVersion>
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net7.0'">7.0.0</TargetingPackVersion>
     </KnownFrameworkReference>
 
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'NETStandard.Library'))">


### PR DESCRIPTION
The addition of net7.0 packages (#604) are causing a build failure in the bootstrap build of the VMR:

```
/vmr/src/source-build-reference-packages/artifacts/source-build/self/src/src/referencePackages/src/system.text.encodings.web/7.0.0/System.Text.Encodings.Web.7.0.0.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Ref with version (= 7.0.5) [/vmr/prereqs/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/8.0.0-beta.23211.8/tools/Build.proj]
```

These changes include net7.0 in the mapping to set the `TargetingPackVersion` property that will allow the targeting pack to be used. Even though we don't have 7.0 targeting pack defined in SBRP, it will at least be able to pull them and these can be defined as prebuilts.