### PR TITLE
Fix use of targeting pack for dependency project build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -16,7 +16,7 @@
              Directories="$(LocalNuGetPackageCacheDirectory)" />
 
     <Exec
-      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true"
+      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>


### PR DESCRIPTION
As a result of the changes in https://github.com/dotnet/source-build-reference-packages/pull/636, we're now building a targeting pack as part of the dependency project build. This caused the following error in the stage 2 build of this repo in the VMR:

```
##[error]/vmr/src/source-build-reference-packages/artifacts/source-build/self/src/src/targetPacks/ILsrc/microsoft.netcore.app.ref/7.0.0/Microsoft.NETCore.App.Ref.7.0.0.csproj(0,0): error NU1101: Unable to find package runtime.linux-x64.microsoft.netcore.ilasm. No packages exist with this id in source(s): prebuilt, previously-source-built, reference-packages, source-build-reference-package-cache, source-built
```

What's happening is that the stage 1 build is producing a package name of `runtime.fedora-x64.microsoft.netcore.ilasm` but the stage 2 build is expecting a name of `runtime.linux-x64.microsoft.netcore.ilasm`. This is because the [`MicrosoftNetCoreIlasmPackageRuntimeId` property](https://github.com/dotnet/source-build-reference-packages/blob/05b4fdac346e01716abda4c92fcf0b7880e73792/src/targetPacks/Directory.Build.targets#L84) is not set correctly in the stage 2 build.

This is fixed by flowing the value of the `MicrosoftNetCoreIlasmPackageRuntimeId` to the dependency projects build.