### PR TITLE
SBRP packages for fsharp pre-built detection work

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -188,6 +188,11 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Options.7.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Diagnostics.DiagnosticSource.7.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Logging.7.0.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.NET.StringTools.17.5.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Build.Framework.17.5.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Build.Utilities.Core.17.5.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Build.Tasks.Core.17.5.0.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/microsoft.build.framework/17.5.0/Microsoft.Build.Framework.17.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/17.5.0/Microsoft.Build.Framework.17.5.0.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Build.Framework</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.build.framework/17.5.0/microsoft.build.framework.nuspec
+++ b/src/referencePackages/src/microsoft.build.framework/17.5.0/microsoft.build.framework.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Build.Framework</id>
+    <version>17.5.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
+    <description>This package contains the Microsoft.Build.Framework assembly which is a common assembly used by other MSBuild assemblies.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>MSBuild</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/msbuild" commit="6f08c67f3ed838dccfbcdab91e6bebc54a26fd94" />
+    <dependencies>
+      <group targetFramework="net7.0">
+        <dependency id="System.Security.Permissions" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Permissions" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.build.framework/17.5.0/ref/net7.0/Microsoft.Build.Framework.cs
+++ b/src/referencePackages/src/microsoft.build.framework/17.5.0/ref/net7.0/Microsoft.Build.Framework.cs
@@ -1,0 +1,1168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Framework.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("MSBuild, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Conversion.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Engine.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Engine.OM.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.CommandLine.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Framework.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Framework.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Framework
+{
+    public delegate void AnyEventHandler(object sender, BuildEventArgs e);
+    public partial struct BuildEngineResult
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public BuildEngineResult(bool result, System.Collections.Generic.List<System.Collections.Generic.IDictionary<string, ITaskItem[]>> targetOutputsPerProject) { }
+
+        public bool Result { get { throw null; } }
+
+        public System.Collections.Generic.IList<System.Collections.Generic.IDictionary<string, ITaskItem[]>> TargetOutputsPerProject { get { throw null; } }
+    }
+
+    public partial class BuildErrorEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildErrorEventArgs() { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public string HelpLink { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildErrorEventHandler(object sender, BuildErrorEventArgs e);
+    public abstract partial class BuildEventArgs : System.EventArgs
+    {
+        protected BuildEventArgs() { }
+
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp) { }
+
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName) { }
+
+        public BuildEventContext? BuildEventContext { get { throw null; } set { } }
+
+        public string? HelpKeyword { get { throw null; } }
+
+        public virtual string? Message { get { throw null; } protected set { } }
+
+        protected internal string? RawMessage { get { throw null; } set { } }
+
+        protected internal System.DateTime RawTimestamp { get { throw null; } set { } }
+
+        public string? SenderName { get { throw null; } }
+
+        public int ThreadId { get { throw null; } }
+
+        public System.DateTime Timestamp { get { throw null; } }
+    }
+
+    public partial class BuildEventContext
+    {
+        public const int InvalidEvaluationId = -1;
+        public const int InvalidNodeId = -2;
+        public const int InvalidProjectContextId = -2;
+        public const int InvalidProjectInstanceId = -1;
+        public const int InvalidSubmissionId = -1;
+        public const int InvalidTargetId = -1;
+        public const int InvalidTaskId = -1;
+        public BuildEventContext(int submissionId, int nodeId, int evaluationId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
+
+        public long BuildRequestId { get { throw null; } }
+
+        public int EvaluationId { get { throw null; } }
+
+        public static BuildEventContext Invalid { get { throw null; } }
+
+        public int NodeId { get { throw null; } }
+
+        public int ProjectContextId { get { throw null; } }
+
+        public int ProjectInstanceId { get { throw null; } }
+
+        public int SubmissionId { get { throw null; } }
+
+        public int TargetId { get { throw null; } }
+
+        public int TaskId { get { throw null; } }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildEventContext? left, BuildEventContext? right) { throw null; }
+
+        public static bool operator !=(BuildEventContext? left, BuildEventContext? right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected BuildFinishedEventArgs() { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded) { }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public delegate void BuildFinishedEventHandler(object sender, BuildFinishedEventArgs e);
+    public partial class BuildMessageEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildMessageEventArgs() { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public MessageImportance Importance { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildMessageEventHandler(object sender, BuildMessageEventArgs e);
+    public partial class BuildStartedEventArgs : BuildStatusEventArgs
+    {
+        protected BuildStartedEventArgs() { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.Collections.Generic.IDictionary<string, string> environmentOfBuild) { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.DateTime eventTimestamp) { }
+
+        public BuildStartedEventArgs(string message, string helpKeyword) { }
+
+        public System.Collections.Generic.IDictionary<string, string>? BuildEnvironment { get { throw null; } }
+    }
+
+    public delegate void BuildStartedEventHandler(object sender, BuildStartedEventArgs e);
+    public abstract partial class BuildStatusEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildStatusEventArgs() { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp) { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName) { }
+    }
+
+    public delegate void BuildStatusEventHandler(object sender, BuildStatusEventArgs e);
+    public partial class BuildWarningEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildWarningEventArgs() { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public string HelpLink { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildWarningEventHandler(object sender, BuildWarningEventArgs e);
+    public partial class CriticalBuildMessageEventArgs : BuildMessageEventArgs
+    {
+        protected CriticalBuildMessageEventArgs() { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+    }
+
+    public abstract partial class CustomBuildEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected CustomBuildEventArgs() { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName) { }
+    }
+
+    public delegate void CustomBuildEventHandler(object sender, CustomBuildEventArgs e);
+    public abstract partial class EngineServices
+    {
+        public const int Version1 = 1;
+        public virtual bool IsTaskInputLoggingEnabled { get { throw null; } }
+
+        public virtual int Version { get { throw null; } }
+
+        public virtual bool LogsMessagesOfImportance(MessageImportance importance) { throw null; }
+    }
+
+    public partial class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
+
+    public partial class ExternalProjectFinishedEventArgs : CustomBuildEventArgs
+    {
+        protected ExternalProjectFinishedEventArgs() { }
+
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded) { }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public partial class ExternalProjectStartedEventArgs : CustomBuildEventArgs
+    {
+        protected ExternalProjectStartedEventArgs() { }
+
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames, System.DateTime eventTimestamp) { }
+
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames) { }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TargetNames { get { throw null; } }
+    }
+
+    public partial interface IBuildEngine
+    {
+        int ColumnNumberOfTaskNode { get; }
+
+        bool ContinueOnError { get; }
+
+        int LineNumberOfTaskNode { get; }
+
+        string ProjectFileOfTaskNode { get; }
+
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs);
+        void LogCustomEvent(CustomBuildEventArgs e);
+        void LogErrorEvent(BuildErrorEventArgs e);
+        void LogMessageEvent(BuildMessageEventArgs e);
+        void LogWarningEvent(BuildWarningEventArgs e);
+    }
+
+    public partial interface IBuildEngine10 : IBuildEngine9, IBuildEngine8, IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        EngineServices EngineServices { get; }
+    }
+
+    public partial interface IBuildEngine2 : IBuildEngine
+    {
+        bool IsRunningMultipleNodes { get; }
+
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs, string toolsVersion);
+        bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion);
+    }
+
+    public partial interface IBuildEngine3 : IBuildEngine2, IBuildEngine
+    {
+        BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.Generic.IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs);
+        void Reacquire();
+        void Yield();
+    }
+
+    public partial interface IBuildEngine4 : IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime);
+        void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection);
+        object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime);
+    }
+
+    public partial interface IBuildEngine5 : IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties);
+    }
+
+    public partial interface IBuildEngine6 : IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        System.Collections.Generic.IReadOnlyDictionary<string, string> GetGlobalProperties();
+    }
+
+    public partial interface IBuildEngine7 : IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        bool AllowFailureWithoutError { get; set; }
+    }
+
+    public partial interface IBuildEngine8 : IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        bool ShouldTreatWarningAsError(string warningCode);
+    }
+
+    public partial interface IBuildEngine9 : IBuildEngine8, IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        void ReleaseCores(int coresToRelease);
+        int RequestCores(int requestedCores);
+    }
+
+    public partial interface ICancelableTask : ITask
+    {
+        void Cancel();
+    }
+
+    public partial interface IEventRedirector
+    {
+        void ForwardEvent(BuildEventArgs buildEvent);
+    }
+
+    public partial interface IEventSource
+    {
+        event AnyEventHandler AnyEventRaised;
+        event BuildFinishedEventHandler BuildFinished;
+        event BuildStartedEventHandler BuildStarted;
+        event CustomBuildEventHandler CustomEventRaised;
+        event BuildErrorEventHandler ErrorRaised;
+        event BuildMessageEventHandler MessageRaised;
+        event ProjectFinishedEventHandler ProjectFinished;
+        event ProjectStartedEventHandler ProjectStarted;
+        event BuildStatusEventHandler StatusEventRaised;
+        event TargetFinishedEventHandler TargetFinished;
+        event TargetStartedEventHandler TargetStarted;
+        event TaskFinishedEventHandler TaskFinished;
+        event TaskStartedEventHandler TaskStarted;
+        event BuildWarningEventHandler WarningRaised;
+    }
+
+    public partial interface IEventSource2 : IEventSource
+    {
+        event TelemetryEventHandler TelemetryLogged;
+    }
+
+    public partial interface IEventSource3 : IEventSource2, IEventSource
+    {
+        void IncludeEvaluationMetaprojects();
+        void IncludeEvaluationProfiles();
+        void IncludeTaskInputs();
+    }
+
+    public partial interface IEventSource4 : IEventSource3, IEventSource2, IEventSource
+    {
+        void IncludeEvaluationPropertiesAndItems();
+    }
+
+    public partial interface IForwardingLogger : INodeLogger, ILogger
+    {
+        IEventRedirector BuildEventRedirector { get; set; }
+
+        int NodeId { get; set; }
+    }
+
+    public partial interface IGeneratedTask : ITask
+    {
+        object GetPropertyValue(TaskPropertyInfo property);
+        void SetPropertyValue(TaskPropertyInfo property, object value);
+    }
+
+    public partial interface ILogger
+    {
+        string Parameters { get; set; }
+
+        LoggerVerbosity Verbosity { get; set; }
+
+        void Initialize(IEventSource eventSource);
+        void Shutdown();
+    }
+
+    public partial interface INodeLogger : ILogger
+    {
+        void Initialize(IEventSource eventSource, int nodeCount);
+    }
+
+    public partial interface IProjectElement
+    {
+        string ElementName { get; }
+
+        string OuterElement { get; }
+    }
+
+    public partial interface ITask
+    {
+        IBuildEngine BuildEngine { get; set; }
+
+        ITaskHost HostObject { get; set; }
+
+        bool Execute();
+    }
+
+    public partial interface ITaskFactory
+    {
+        string FactoryName { get; }
+
+        System.Type TaskType { get; }
+
+        void CleanupTask(ITask task);
+        ITask CreateTask(IBuildEngine taskFactoryLoggingHost);
+        TaskPropertyInfo[] GetTaskParameters();
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
+    }
+
+    public partial interface ITaskFactory2 : ITaskFactory
+    {
+        ITask CreateTask(IBuildEngine taskFactoryLoggingHost, System.Collections.Generic.IDictionary<string, string> taskIdentityParameters);
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, string> factoryIdentityParameters, System.Collections.Generic.IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
+    }
+
+    public partial interface ITaskHost
+    {
+    }
+
+    public partial interface ITaskItem
+    {
+        string ItemSpec { get; set; }
+
+        int MetadataCount { get; }
+
+        System.Collections.ICollection MetadataNames { get; }
+
+        System.Collections.IDictionary CloneCustomMetadata();
+        void CopyMetadataTo(ITaskItem destinationItem);
+        string GetMetadata(string metadataName);
+        void RemoveMetadata(string metadataName);
+        void SetMetadata(string metadataName, string metadataValue);
+    }
+
+    public partial interface ITaskItem2 : ITaskItem
+    {
+        string EvaluatedIncludeEscaped { get; set; }
+
+        System.Collections.IDictionary CloneCustomMetadataEscaped();
+        string GetMetadataValueEscaped(string metadataName);
+        void SetMetadataValueLiteral(string metadataName, string metadataValue);
+    }
+
+    public partial class LazyFormattedBuildEventArgs : BuildEventArgs
+    {
+        protected LazyFormattedBuildEventArgs() { }
+
+        public LazyFormattedBuildEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public LazyFormattedBuildEventArgs(string? message, string? helpKeyword, string? senderName) { }
+
+        public override string? Message { get { throw null; } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class LoadInSeparateAppDomainAttribute : System.Attribute
+    {
+    }
+
+    public partial class LoggerException : System.Exception
+    {
+        public LoggerException() { }
+
+        protected LoggerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+
+        public LoggerException(string message, System.Exception innerException, string errorCode, string helpKeyword) { }
+
+        public LoggerException(string message, System.Exception innerException) { }
+
+        public LoggerException(string message) { }
+
+        public string ErrorCode { get { throw null; } }
+
+        public string HelpKeyword { get { throw null; } }
+
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public enum LoggerVerbosity
+    {
+        Quiet = 0,
+        Minimal = 1,
+        Normal = 2,
+        Detailed = 3,
+        Diagnostic = 4
+    }
+
+    public enum MessageImportance
+    {
+        High = 0,
+        Normal = 1,
+        Low = 2
+    }
+
+    public partial class MetaprojectGeneratedEventArgs : BuildMessageEventArgs
+    {
+        public string metaprojectXml;
+        public MetaprojectGeneratedEventArgs(string metaprojectXml, string metaprojectPath, string message) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed partial class OutputAttribute : System.Attribute
+    {
+    }
+
+    public sealed partial class ProjectEvaluationFinishedEventArgs : BuildStatusEventArgs
+    {
+        public ProjectEvaluationFinishedEventArgs() { }
+
+        public ProjectEvaluationFinishedEventArgs(string? message, params object[]? messageArgs) { }
+
+        public System.Collections.IEnumerable? GlobalProperties { get { throw null; } set { } }
+
+        public System.Collections.IEnumerable? Items { get { throw null; } set { } }
+
+        public Profiler.ProfilerResult? ProfilerResult { get { throw null; } set { } }
+
+        public string? ProjectFile { get { throw null; } set { } }
+
+        public System.Collections.IEnumerable? Properties { get { throw null; } set { } }
+    }
+
+    public partial class ProjectEvaluationStartedEventArgs : BuildStatusEventArgs
+    {
+        public ProjectEvaluationStartedEventArgs() { }
+
+        public ProjectEvaluationStartedEventArgs(string? message, params object[]? messageArgs) { }
+
+        public string? ProjectFile { get { throw null; } set { } }
+    }
+
+    public partial class ProjectFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected ProjectFinishedEventArgs() { }
+
+        public ProjectFinishedEventArgs(string? message, string? helpKeyword, string? projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public ProjectFinishedEventArgs(string? message, string? helpKeyword, string? projectFile, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string? ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public delegate void ProjectFinishedEventHandler(object sender, ProjectFinishedEventArgs e);
+    public partial class ProjectImportedEventArgs : BuildMessageEventArgs
+    {
+        public ProjectImportedEventArgs() { }
+
+        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
+
+        public string ImportedProjectFile { get { throw null; } set { } }
+
+        public bool ImportIgnored { get { throw null; } set { } }
+
+        public string UnexpandedProject { get { throw null; } set { } }
+    }
+
+    public partial class ProjectStartedEventArgs : BuildStatusEventArgs
+    {
+        public const int InvalidProjectId = -1;
+        protected ProjectStartedEventArgs() { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext, System.DateTime eventTimestamp) { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext) { }
+
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, System.DateTime eventTimestamp) { }
+
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items) { }
+
+        public System.Collections.Generic.IDictionary<string, string>? GlobalProperties { get { throw null; } }
+
+        public System.Collections.IEnumerable? Items { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public BuildEventContext? ParentProjectBuildEventContext { get { throw null; } }
+
+        public string? ProjectFile { get { throw null; } }
+
+        public int ProjectId { get { throw null; } }
+
+        public System.Collections.IEnumerable? Properties { get { throw null; } }
+
+        public string? TargetNames { get { throw null; } }
+
+        public string? ToolsVersion { get { throw null; } }
+    }
+
+    public delegate void ProjectStartedEventHandler(object sender, ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string PropertyName { get { throw null; } set { } }
+
+        public string PropertySource { get { throw null; } set { } }
+
+        public string PropertyValue { get { throw null; } set { } }
+    }
+
+    public partial class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string Location { get { throw null; } set { } }
+
+        public override string Message { get { throw null; } }
+
+        public string NewValue { get { throw null; } set { } }
+
+        public string PreviousValue { get { throw null; } set { } }
+
+        public string PropertyName { get { throw null; } set { } }
+    }
+
+    public enum RegisteredTaskObjectLifetime
+    {
+        Build = 0,
+        AppDomain = 1
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RequiredAttribute : System.Attribute
+    {
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RequiredRuntimeAttribute : System.Attribute
+    {
+        public RequiredRuntimeAttribute(string runtimeVersion) { }
+
+        public string RuntimeVersion { get { throw null; } }
+    }
+
+    public partial class ResponseFileUsedEventArgs : BuildMessageEventArgs
+    {
+        public ResponseFileUsedEventArgs() { }
+
+        public ResponseFileUsedEventArgs(string responseFilePath) { }
+
+        public string? ResponseFilePath { get { throw null; } set { } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RunInMTAAttribute : System.Attribute
+    {
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RunInSTAAttribute : System.Attribute
+    {
+    }
+
+    public abstract partial class SdkLogger
+    {
+        public abstract void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low);
+    }
+
+    public sealed partial class SdkReference : System.IEquatable<SdkReference>
+    {
+        public SdkReference(string name, string version, string minimumVersion) { }
+
+        public string MinimumVersion { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string Version { get { throw null; } }
+
+        public bool Equals(SdkReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static bool TryParse(string sdk, out SdkReference sdkReference) { throw null; }
+    }
+
+    public abstract partial class SdkResolver
+    {
+        public abstract string Name { get; }
+        public abstract int Priority { get; }
+
+        public abstract SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory);
+    }
+
+    public abstract partial class SdkResolverContext
+    {
+        public virtual bool Interactive { get { throw null; } protected set { } }
+
+        public virtual bool IsRunningInVisualStudio { get { throw null; } protected set { } }
+
+        public virtual SdkLogger Logger { get { throw null; } protected set { } }
+
+        public virtual System.Version MSBuildVersion { get { throw null; } protected set { } }
+
+        public virtual string ProjectFilePath { get { throw null; } protected set { } }
+
+        public virtual string SolutionFilePath { get { throw null; } protected set { } }
+
+        public virtual object State { get { throw null; } set { } }
+    }
+
+    public abstract partial class SdkResult
+    {
+        public virtual System.Collections.Generic.IList<string> AdditionalPaths { get { throw null; } set { } }
+
+        public virtual System.Collections.Generic.IDictionary<string, SdkResultItem> ItemsToAdd { get { throw null; } protected set { } }
+
+        public virtual string Path { get { throw null; } protected set { } }
+
+        public virtual System.Collections.Generic.IDictionary<string, string> PropertiesToAdd { get { throw null; } protected set { } }
+
+        public virtual SdkReference SdkReference { get { throw null; } protected set { } }
+
+        public virtual bool Success { get { throw null; } protected set { } }
+
+        public virtual string Version { get { throw null; } protected set { } }
+    }
+
+    public abstract partial class SdkResultFactory
+    {
+        public abstract SdkResult IndicateFailure(System.Collections.Generic.IEnumerable<string> errors, System.Collections.Generic.IEnumerable<string> warnings = null);
+        public virtual SdkResult IndicateSuccess(System.Collections.Generic.IEnumerable<string> paths, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd = null, System.Collections.Generic.IDictionary<string, SdkResultItem> itemsToAdd = null, System.Collections.Generic.IEnumerable<string> warnings = null) { throw null; }
+
+        public virtual SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd, System.Collections.Generic.IDictionary<string, SdkResultItem> itemsToAdd, System.Collections.Generic.IEnumerable<string> warnings = null) { throw null; }
+
+        public abstract SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IEnumerable<string> warnings = null);
+    }
+
+    public partial class SdkResultItem
+    {
+        public SdkResultItem() { }
+
+        public SdkResultItem(string itemSpec, System.Collections.Generic.Dictionary<string, string>? metadata) { }
+
+        public string ItemSpec { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string>? Metadata { get { throw null; } }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum TargetBuiltReason
+    {
+        None = 0,
+        BeforeTargets = 1,
+        DependsOn = 2,
+        AfterTargets = 3
+    }
+
+    public partial class TargetFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected TargetFinishedEventArgs() { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.Collections.IEnumerable targetOutputs) { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.DateTime eventTimestamp, System.Collections.IEnumerable targetOutputs) { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+
+        public string TargetFile { get { throw null; } }
+
+        public string TargetName { get { throw null; } }
+
+        public System.Collections.IEnumerable TargetOutputs { get { throw null; } set { } }
+    }
+
+    public delegate void TargetFinishedEventHandler(object sender, TargetFinishedEventArgs e);
+    public partial class TargetSkippedEventArgs : BuildMessageEventArgs
+    {
+        public TargetSkippedEventArgs() { }
+
+        public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
+
+        public TargetBuiltReason BuildReason { get { throw null; } set { } }
+
+        public string Condition { get { throw null; } set { } }
+
+        public string EvaluatedCondition { get { throw null; } set { } }
+
+        public override string Message { get { throw null; } }
+
+        public BuildEventContext OriginalBuildEventContext { get { throw null; } set { } }
+
+        public bool OriginallySucceeded { get { throw null; } set { } }
+
+        public string ParentTarget { get { throw null; } set { } }
+
+        public TargetSkipReason SkipReason { get { throw null; } set { } }
+
+        public string TargetFile { get { throw null; } set { } }
+
+        public string TargetName { get { throw null; } set { } }
+    }
+
+    public enum TargetSkipReason
+    {
+        None = 0,
+        PreviouslyBuiltSuccessfully = 1,
+        PreviouslyBuiltUnsuccessfully = 2,
+        OutputsUpToDate = 3,
+        ConditionWasFalse = 4
+    }
+
+    public partial class TargetStartedEventArgs : BuildStatusEventArgs
+    {
+        protected TargetStartedEventArgs() { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, TargetBuiltReason buildReason, System.DateTime eventTimestamp) { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, System.DateTime eventTimestamp) { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile) { }
+
+        public TargetBuiltReason BuildReason { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string ParentTarget { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TargetFile { get { throw null; } }
+
+        public string TargetName { get { throw null; } }
+    }
+
+    public delegate void TargetStartedEventHandler(object sender, TargetStartedEventArgs e);
+    public partial class TaskCommandLineEventArgs : BuildMessageEventArgs
+    {
+        protected TaskCommandLineEventArgs() { }
+
+        public TaskCommandLineEventArgs(string commandLine, string taskName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public TaskCommandLineEventArgs(string commandLine, string taskName, MessageImportance importance) { }
+
+        public string CommandLine { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public partial class TaskFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected TaskFinishedEventArgs() { }
+
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+
+        public string TaskFile { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public delegate void TaskFinishedEventHandler(object sender, TaskFinishedEventArgs e);
+    public partial class TaskParameterEventArgs : BuildMessageEventArgs
+    {
+        public TaskParameterEventArgs(TaskParameterMessageKind kind, string itemType, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
+
+        public System.Collections.IList Items { get { throw null; } }
+
+        public string ItemType { get { throw null; } }
+
+        public TaskParameterMessageKind Kind { get { throw null; } }
+
+        public bool LogItemMetadata { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+    }
+
+    public enum TaskParameterMessageKind
+    {
+        TaskInput = 0,
+        TaskOutput = 1,
+        AddItem = 2,
+        RemoveItem = 3,
+        SkippedTargetInputs = 4,
+        SkippedTargetOutputs = 5
+    }
+
+    public partial class TaskPropertyInfo
+    {
+        public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+
+        public bool Log { get { throw null; } set { } }
+
+        public bool LogItemMetadata { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public bool Output { get { throw null; } }
+
+        public System.Type PropertyType { get { throw null; } }
+
+        public bool Required { get { throw null; } }
+    }
+
+    public partial class TaskStartedEventArgs : BuildStatusEventArgs
+    {
+        protected TaskStartedEventArgs() { }
+
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, System.DateTime eventTimestamp) { }
+
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName) { }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TaskFile { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public delegate void TaskStartedEventHandler(object sender, TaskStartedEventArgs e);
+    public sealed partial class TelemetryEventArgs : BuildEventArgs
+    {
+        public string EventName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
+    }
+
+    public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string PropertyName { get { throw null; } set { } }
+    }
+}
+
+namespace Microsoft.Build.Framework.Profiler
+{
+    public partial struct EvaluationLocation
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public EvaluationLocation(EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public EvaluationLocation(long id, long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public EvaluationLocation(long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public string ElementDescription { get { throw null; } }
+
+        public string ElementName { get { throw null; } }
+
+        public static EvaluationLocation EmptyLocation { get { throw null; } }
+
+        public EvaluationPass EvaluationPass { get { throw null; } }
+
+        public string EvaluationPassDescription { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public long Id { get { throw null; } }
+
+        public bool IsEvaluationPass { get { throw null; } }
+
+        public EvaluationLocationKind Kind { get { throw null; } }
+
+        public int? Line { get { throw null; } }
+
+        public long? ParentId { get { throw null; } }
+
+        public static EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
+
+        public static EvaluationLocation CreateLocationForCondition(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, string condition) { throw null; }
+
+        public static EvaluationLocation CreateLocationForGlob(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, string globDescription) { throw null; }
+
+        public static EvaluationLocation CreateLocationForProject(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, IProjectElement element) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public EvaluationLocation WithEvaluationPass(EvaluationPass evaluationPass, string passDescription = null) { throw null; }
+
+        public EvaluationLocation WithFile(string file) { throw null; }
+
+        public EvaluationLocation WithFileLineAndCondition(string file, int? line, string condition) { throw null; }
+
+        public EvaluationLocation WithFileLineAndElement(string file, int? line, IProjectElement element) { throw null; }
+
+        public EvaluationLocation WithGlob(string globDescription) { throw null; }
+
+        public EvaluationLocation WithParentId(long? parentId) { throw null; }
+    }
+
+    public enum EvaluationLocationKind : byte
+    {
+        Element = 0,
+        Condition = 1,
+        Glob = 2
+    }
+
+    public enum EvaluationPass : byte
+    {
+        TotalEvaluation = 0,
+        TotalGlobbing = 1,
+        InitialProperties = 2,
+        Properties = 3,
+        ItemDefinitionGroups = 4,
+        Items = 5,
+        LazyItems = 6,
+        UsingTasks = 7,
+        Targets = 8
+    }
+
+    public partial struct ProfiledLocation
+    {
+        private int _dummyPrimitive;
+        public ProfiledLocation(System.TimeSpan inclusiveTime, System.TimeSpan exclusiveTime, int numberOfHits) { }
+
+        public System.TimeSpan ExclusiveTime { get { throw null; } }
+
+        public System.TimeSpan InclusiveTime { get { throw null; } }
+
+        public int NumberOfHits { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial struct ProfilerResult
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public ProfilerResult(System.Collections.Generic.IDictionary<EvaluationLocation, ProfiledLocation> profiledLocations) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<EvaluationLocation, ProfiledLocation> ProfiledLocations { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.build.framework/17.5.0/ref/netstandard2.0/Microsoft.Build.Framework.cs
+++ b/src/referencePackages/src/microsoft.build.framework/17.5.0/ref/netstandard2.0/Microsoft.Build.Framework.cs
@@ -1,0 +1,1168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Framework.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("MSBuild, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Conversion.Core, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Engine.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Engine.OM.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.CommandLine.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Framework.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Framework.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Framework
+{
+    public delegate void AnyEventHandler(object sender, BuildEventArgs e);
+    public partial struct BuildEngineResult
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public BuildEngineResult(bool result, System.Collections.Generic.List<System.Collections.Generic.IDictionary<string, ITaskItem[]>> targetOutputsPerProject) { }
+
+        public bool Result { get { throw null; } }
+
+        public System.Collections.Generic.IList<System.Collections.Generic.IDictionary<string, ITaskItem[]>> TargetOutputsPerProject { get { throw null; } }
+    }
+
+    public partial class BuildErrorEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildErrorEventArgs() { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildErrorEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public string HelpLink { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildErrorEventHandler(object sender, BuildErrorEventArgs e);
+    public abstract partial class BuildEventArgs : System.EventArgs
+    {
+        protected BuildEventArgs() { }
+
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp) { }
+
+        protected BuildEventArgs(string? message, string? helpKeyword, string? senderName) { }
+
+        public BuildEventContext? BuildEventContext { get { throw null; } set { } }
+
+        public string? HelpKeyword { get { throw null; } }
+
+        public virtual string? Message { get { throw null; } protected set { } }
+
+        protected internal string? RawMessage { get { throw null; } set { } }
+
+        protected internal System.DateTime RawTimestamp { get { throw null; } set { } }
+
+        public string? SenderName { get { throw null; } }
+
+        public int ThreadId { get { throw null; } }
+
+        public System.DateTime Timestamp { get { throw null; } }
+    }
+
+    public partial class BuildEventContext
+    {
+        public const int InvalidEvaluationId = -1;
+        public const int InvalidNodeId = -2;
+        public const int InvalidProjectContextId = -2;
+        public const int InvalidProjectInstanceId = -1;
+        public const int InvalidSubmissionId = -1;
+        public const int InvalidTargetId = -1;
+        public const int InvalidTaskId = -1;
+        public BuildEventContext(int submissionId, int nodeId, int evaluationId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int submissionId, int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int nodeId, int projectInstanceId, int projectContextId, int targetId, int taskId) { }
+
+        public BuildEventContext(int nodeId, int targetId, int projectContextId, int taskId) { }
+
+        public long BuildRequestId { get { throw null; } }
+
+        public int EvaluationId { get { throw null; } }
+
+        public static BuildEventContext Invalid { get { throw null; } }
+
+        public int NodeId { get { throw null; } }
+
+        public int ProjectContextId { get { throw null; } }
+
+        public int ProjectInstanceId { get { throw null; } }
+
+        public int SubmissionId { get { throw null; } }
+
+        public int TargetId { get { throw null; } }
+
+        public int TaskId { get { throw null; } }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildEventContext? left, BuildEventContext? right) { throw null; }
+
+        public static bool operator !=(BuildEventContext? left, BuildEventContext? right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected BuildFinishedEventArgs() { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public BuildFinishedEventArgs(string? message, string? helpKeyword, bool succeeded) { }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public delegate void BuildFinishedEventHandler(object sender, BuildFinishedEventArgs e);
+    public partial class BuildMessageEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildMessageEventArgs() { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public BuildMessageEventArgs(string message, string helpKeyword, string senderName, MessageImportance importance) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public BuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, MessageImportance importance) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public MessageImportance Importance { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildMessageEventHandler(object sender, BuildMessageEventArgs e);
+    public partial class BuildStartedEventArgs : BuildStatusEventArgs
+    {
+        protected BuildStartedEventArgs() { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.Collections.Generic.IDictionary<string, string> environmentOfBuild) { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public BuildStartedEventArgs(string? message, string? helpKeyword, System.DateTime eventTimestamp) { }
+
+        public BuildStartedEventArgs(string message, string helpKeyword) { }
+
+        public System.Collections.Generic.IDictionary<string, string>? BuildEnvironment { get { throw null; } }
+    }
+
+    public delegate void BuildStartedEventHandler(object sender, BuildStartedEventArgs e);
+    public abstract partial class BuildStatusEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildStatusEventArgs() { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp) { }
+
+        protected BuildStatusEventArgs(string? message, string? helpKeyword, string? senderName) { }
+    }
+
+    public delegate void BuildStatusEventHandler(object sender, BuildStatusEventArgs e);
+    public partial class BuildWarningEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected BuildWarningEventArgs() { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, string helpLink, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public BuildWarningEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+
+        public string Code { get { throw null; } }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } }
+
+        public int EndLineNumber { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public string HelpLink { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } set { } }
+
+        public string Subcategory { get { throw null; } }
+    }
+
+    public delegate void BuildWarningEventHandler(object sender, BuildWarningEventArgs e);
+    public partial class CriticalBuildMessageEventArgs : BuildMessageEventArgs
+    {
+        protected CriticalBuildMessageEventArgs() { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        public CriticalBuildMessageEventArgs(string subcategory, string code, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, string helpKeyword, string senderName) { }
+    }
+
+    public abstract partial class CustomBuildEventArgs : LazyFormattedBuildEventArgs
+    {
+        protected CustomBuildEventArgs() { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp) { }
+
+        protected CustomBuildEventArgs(string message, string helpKeyword, string senderName) { }
+    }
+
+    public delegate void CustomBuildEventHandler(object sender, CustomBuildEventArgs e);
+    public abstract partial class EngineServices
+    {
+        public const int Version1 = 1;
+        public virtual bool IsTaskInputLoggingEnabled { get { throw null; } }
+
+        public virtual int Version { get { throw null; } }
+
+        public virtual bool LogsMessagesOfImportance(MessageImportance importance) { throw null; }
+    }
+
+    public partial class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
+
+    public partial class ExternalProjectFinishedEventArgs : CustomBuildEventArgs
+    {
+        protected ExternalProjectFinishedEventArgs() { }
+
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public ExternalProjectFinishedEventArgs(string message, string helpKeyword, string senderName, string projectFile, bool succeeded) { }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public partial class ExternalProjectStartedEventArgs : CustomBuildEventArgs
+    {
+        protected ExternalProjectStartedEventArgs() { }
+
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames, System.DateTime eventTimestamp) { }
+
+        public ExternalProjectStartedEventArgs(string message, string helpKeyword, string senderName, string projectFile, string targetNames) { }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TargetNames { get { throw null; } }
+    }
+
+    public partial interface IBuildEngine
+    {
+        int ColumnNumberOfTaskNode { get; }
+
+        bool ContinueOnError { get; }
+
+        int LineNumberOfTaskNode { get; }
+
+        string ProjectFileOfTaskNode { get; }
+
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs);
+        void LogCustomEvent(CustomBuildEventArgs e);
+        void LogErrorEvent(BuildErrorEventArgs e);
+        void LogMessageEvent(BuildMessageEventArgs e);
+        void LogWarningEvent(BuildWarningEventArgs e);
+    }
+
+    public partial interface IBuildEngine10 : IBuildEngine9, IBuildEngine8, IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        EngineServices EngineServices { get; }
+    }
+
+    public partial interface IBuildEngine2 : IBuildEngine
+    {
+        bool IsRunningMultipleNodes { get; }
+
+        bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs, string toolsVersion);
+        bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion);
+    }
+
+    public partial interface IBuildEngine3 : IBuildEngine2, IBuildEngine
+    {
+        BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, System.Collections.IDictionary[] globalProperties, System.Collections.Generic.IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs);
+        void Reacquire();
+        void Yield();
+    }
+
+    public partial interface IBuildEngine4 : IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime);
+        void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection);
+        object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime);
+    }
+
+    public partial interface IBuildEngine5 : IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties);
+    }
+
+    public partial interface IBuildEngine6 : IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        System.Collections.Generic.IReadOnlyDictionary<string, string> GetGlobalProperties();
+    }
+
+    public partial interface IBuildEngine7 : IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        bool AllowFailureWithoutError { get; set; }
+    }
+
+    public partial interface IBuildEngine8 : IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        bool ShouldTreatWarningAsError(string warningCode);
+    }
+
+    public partial interface IBuildEngine9 : IBuildEngine8, IBuildEngine7, IBuildEngine6, IBuildEngine5, IBuildEngine4, IBuildEngine3, IBuildEngine2, IBuildEngine
+    {
+        void ReleaseCores(int coresToRelease);
+        int RequestCores(int requestedCores);
+    }
+
+    public partial interface ICancelableTask : ITask
+    {
+        void Cancel();
+    }
+
+    public partial interface IEventRedirector
+    {
+        void ForwardEvent(BuildEventArgs buildEvent);
+    }
+
+    public partial interface IEventSource
+    {
+        event AnyEventHandler AnyEventRaised;
+        event BuildFinishedEventHandler BuildFinished;
+        event BuildStartedEventHandler BuildStarted;
+        event CustomBuildEventHandler CustomEventRaised;
+        event BuildErrorEventHandler ErrorRaised;
+        event BuildMessageEventHandler MessageRaised;
+        event ProjectFinishedEventHandler ProjectFinished;
+        event ProjectStartedEventHandler ProjectStarted;
+        event BuildStatusEventHandler StatusEventRaised;
+        event TargetFinishedEventHandler TargetFinished;
+        event TargetStartedEventHandler TargetStarted;
+        event TaskFinishedEventHandler TaskFinished;
+        event TaskStartedEventHandler TaskStarted;
+        event BuildWarningEventHandler WarningRaised;
+    }
+
+    public partial interface IEventSource2 : IEventSource
+    {
+        event TelemetryEventHandler TelemetryLogged;
+    }
+
+    public partial interface IEventSource3 : IEventSource2, IEventSource
+    {
+        void IncludeEvaluationMetaprojects();
+        void IncludeEvaluationProfiles();
+        void IncludeTaskInputs();
+    }
+
+    public partial interface IEventSource4 : IEventSource3, IEventSource2, IEventSource
+    {
+        void IncludeEvaluationPropertiesAndItems();
+    }
+
+    public partial interface IForwardingLogger : INodeLogger, ILogger
+    {
+        IEventRedirector BuildEventRedirector { get; set; }
+
+        int NodeId { get; set; }
+    }
+
+    public partial interface IGeneratedTask : ITask
+    {
+        object GetPropertyValue(TaskPropertyInfo property);
+        void SetPropertyValue(TaskPropertyInfo property, object value);
+    }
+
+    public partial interface ILogger
+    {
+        string Parameters { get; set; }
+
+        LoggerVerbosity Verbosity { get; set; }
+
+        void Initialize(IEventSource eventSource);
+        void Shutdown();
+    }
+
+    public partial interface INodeLogger : ILogger
+    {
+        void Initialize(IEventSource eventSource, int nodeCount);
+    }
+
+    public partial interface IProjectElement
+    {
+        string ElementName { get; }
+
+        string OuterElement { get; }
+    }
+
+    public partial interface ITask
+    {
+        IBuildEngine BuildEngine { get; set; }
+
+        ITaskHost HostObject { get; set; }
+
+        bool Execute();
+    }
+
+    public partial interface ITaskFactory
+    {
+        string FactoryName { get; }
+
+        System.Type TaskType { get; }
+
+        void CleanupTask(ITask task);
+        ITask CreateTask(IBuildEngine taskFactoryLoggingHost);
+        TaskPropertyInfo[] GetTaskParameters();
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
+    }
+
+    public partial interface ITaskFactory2 : ITaskFactory
+    {
+        ITask CreateTask(IBuildEngine taskFactoryLoggingHost, System.Collections.Generic.IDictionary<string, string> taskIdentityParameters);
+        bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, string> factoryIdentityParameters, System.Collections.Generic.IDictionary<string, TaskPropertyInfo> parameterGroup, string taskBody, IBuildEngine taskFactoryLoggingHost);
+    }
+
+    public partial interface ITaskHost
+    {
+    }
+
+    public partial interface ITaskItem
+    {
+        string ItemSpec { get; set; }
+
+        int MetadataCount { get; }
+
+        System.Collections.ICollection MetadataNames { get; }
+
+        System.Collections.IDictionary CloneCustomMetadata();
+        void CopyMetadataTo(ITaskItem destinationItem);
+        string GetMetadata(string metadataName);
+        void RemoveMetadata(string metadataName);
+        void SetMetadata(string metadataName, string metadataValue);
+    }
+
+    public partial interface ITaskItem2 : ITaskItem
+    {
+        string EvaluatedIncludeEscaped { get; set; }
+
+        System.Collections.IDictionary CloneCustomMetadataEscaped();
+        string GetMetadataValueEscaped(string metadataName);
+        void SetMetadataValueLiteral(string metadataName, string metadataValue);
+    }
+
+    public partial class LazyFormattedBuildEventArgs : BuildEventArgs
+    {
+        protected LazyFormattedBuildEventArgs() { }
+
+        public LazyFormattedBuildEventArgs(string? message, string? helpKeyword, string? senderName, System.DateTime eventTimestamp, params object[]? messageArgs) { }
+
+        public LazyFormattedBuildEventArgs(string? message, string? helpKeyword, string? senderName) { }
+
+        public override string? Message { get { throw null; } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class LoadInSeparateAppDomainAttribute : System.Attribute
+    {
+    }
+
+    public partial class LoggerException : System.Exception
+    {
+        public LoggerException() { }
+
+        protected LoggerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+
+        public LoggerException(string message, System.Exception innerException, string errorCode, string helpKeyword) { }
+
+        public LoggerException(string message, System.Exception innerException) { }
+
+        public LoggerException(string message) { }
+
+        public string ErrorCode { get { throw null; } }
+
+        public string HelpKeyword { get { throw null; } }
+
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public enum LoggerVerbosity
+    {
+        Quiet = 0,
+        Minimal = 1,
+        Normal = 2,
+        Detailed = 3,
+        Diagnostic = 4
+    }
+
+    public enum MessageImportance
+    {
+        High = 0,
+        Normal = 1,
+        Low = 2
+    }
+
+    public partial class MetaprojectGeneratedEventArgs : BuildMessageEventArgs
+    {
+        public string metaprojectXml;
+        public MetaprojectGeneratedEventArgs(string metaprojectXml, string metaprojectPath, string message) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed partial class OutputAttribute : System.Attribute
+    {
+    }
+
+    public sealed partial class ProjectEvaluationFinishedEventArgs : BuildStatusEventArgs
+    {
+        public ProjectEvaluationFinishedEventArgs() { }
+
+        public ProjectEvaluationFinishedEventArgs(string? message, params object[]? messageArgs) { }
+
+        public System.Collections.IEnumerable? GlobalProperties { get { throw null; } set { } }
+
+        public System.Collections.IEnumerable? Items { get { throw null; } set { } }
+
+        public Profiler.ProfilerResult? ProfilerResult { get { throw null; } set { } }
+
+        public string? ProjectFile { get { throw null; } set { } }
+
+        public System.Collections.IEnumerable? Properties { get { throw null; } set { } }
+    }
+
+    public partial class ProjectEvaluationStartedEventArgs : BuildStatusEventArgs
+    {
+        public ProjectEvaluationStartedEventArgs() { }
+
+        public ProjectEvaluationStartedEventArgs(string? message, params object[]? messageArgs) { }
+
+        public string? ProjectFile { get { throw null; } set { } }
+    }
+
+    public partial class ProjectFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected ProjectFinishedEventArgs() { }
+
+        public ProjectFinishedEventArgs(string? message, string? helpKeyword, string? projectFile, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public ProjectFinishedEventArgs(string? message, string? helpKeyword, string? projectFile, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string? ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public delegate void ProjectFinishedEventHandler(object sender, ProjectFinishedEventArgs e);
+    public partial class ProjectImportedEventArgs : BuildMessageEventArgs
+    {
+        public ProjectImportedEventArgs() { }
+
+        public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
+
+        public string ImportedProjectFile { get { throw null; } set { } }
+
+        public bool ImportIgnored { get { throw null; } set { } }
+
+        public string UnexpandedProject { get { throw null; } set { } }
+    }
+
+    public partial class ProjectStartedEventArgs : BuildStatusEventArgs
+    {
+        public const int InvalidProjectId = -1;
+        protected ProjectStartedEventArgs() { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion) { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext, System.DateTime eventTimestamp) { }
+
+        public ProjectStartedEventArgs(int projectId, string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, BuildEventContext parentBuildEventContext) { }
+
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items, System.DateTime eventTimestamp) { }
+
+        public ProjectStartedEventArgs(string message, string helpKeyword, string projectFile, string targetNames, System.Collections.IEnumerable properties, System.Collections.IEnumerable items) { }
+
+        public System.Collections.Generic.IDictionary<string, string>? GlobalProperties { get { throw null; } }
+
+        public System.Collections.IEnumerable? Items { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public BuildEventContext? ParentProjectBuildEventContext { get { throw null; } }
+
+        public string? ProjectFile { get { throw null; } }
+
+        public int ProjectId { get { throw null; } }
+
+        public System.Collections.IEnumerable? Properties { get { throw null; } }
+
+        public string? TargetNames { get { throw null; } }
+
+        public string? ToolsVersion { get { throw null; } }
+    }
+
+    public delegate void ProjectStartedEventHandler(object sender, ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string PropertyName { get { throw null; } set { } }
+
+        public string PropertySource { get { throw null; } set { } }
+
+        public string PropertyValue { get { throw null; } set { } }
+    }
+
+    public partial class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string Location { get { throw null; } set { } }
+
+        public override string Message { get { throw null; } }
+
+        public string NewValue { get { throw null; } set { } }
+
+        public string PreviousValue { get { throw null; } set { } }
+
+        public string PropertyName { get { throw null; } set { } }
+    }
+
+    public enum RegisteredTaskObjectLifetime
+    {
+        Build = 0,
+        AppDomain = 1
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RequiredAttribute : System.Attribute
+    {
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RequiredRuntimeAttribute : System.Attribute
+    {
+        public RequiredRuntimeAttribute(string runtimeVersion) { }
+
+        public string RuntimeVersion { get { throw null; } }
+    }
+
+    public partial class ResponseFileUsedEventArgs : BuildMessageEventArgs
+    {
+        public ResponseFileUsedEventArgs() { }
+
+        public ResponseFileUsedEventArgs(string responseFilePath) { }
+
+        public string? ResponseFilePath { get { throw null; } set { } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RunInMTAAttribute : System.Attribute
+    {
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class RunInSTAAttribute : System.Attribute
+    {
+    }
+
+    public abstract partial class SdkLogger
+    {
+        public abstract void LogMessage(string message, MessageImportance messageImportance = MessageImportance.Low);
+    }
+
+    public sealed partial class SdkReference : System.IEquatable<SdkReference>
+    {
+        public SdkReference(string name, string version, string minimumVersion) { }
+
+        public string MinimumVersion { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string Version { get { throw null; } }
+
+        public bool Equals(SdkReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static bool TryParse(string sdk, out SdkReference sdkReference) { throw null; }
+    }
+
+    public abstract partial class SdkResolver
+    {
+        public abstract string Name { get; }
+        public abstract int Priority { get; }
+
+        public abstract SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory);
+    }
+
+    public abstract partial class SdkResolverContext
+    {
+        public virtual bool Interactive { get { throw null; } protected set { } }
+
+        public virtual bool IsRunningInVisualStudio { get { throw null; } protected set { } }
+
+        public virtual SdkLogger Logger { get { throw null; } protected set { } }
+
+        public virtual System.Version MSBuildVersion { get { throw null; } protected set { } }
+
+        public virtual string ProjectFilePath { get { throw null; } protected set { } }
+
+        public virtual string SolutionFilePath { get { throw null; } protected set { } }
+
+        public virtual object State { get { throw null; } set { } }
+    }
+
+    public abstract partial class SdkResult
+    {
+        public virtual System.Collections.Generic.IList<string> AdditionalPaths { get { throw null; } set { } }
+
+        public virtual System.Collections.Generic.IDictionary<string, SdkResultItem> ItemsToAdd { get { throw null; } protected set { } }
+
+        public virtual string Path { get { throw null; } protected set { } }
+
+        public virtual System.Collections.Generic.IDictionary<string, string> PropertiesToAdd { get { throw null; } protected set { } }
+
+        public virtual SdkReference SdkReference { get { throw null; } protected set { } }
+
+        public virtual bool Success { get { throw null; } protected set { } }
+
+        public virtual string Version { get { throw null; } protected set { } }
+    }
+
+    public abstract partial class SdkResultFactory
+    {
+        public abstract SdkResult IndicateFailure(System.Collections.Generic.IEnumerable<string> errors, System.Collections.Generic.IEnumerable<string> warnings = null);
+        public virtual SdkResult IndicateSuccess(System.Collections.Generic.IEnumerable<string> paths, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd = null, System.Collections.Generic.IDictionary<string, SdkResultItem> itemsToAdd = null, System.Collections.Generic.IEnumerable<string> warnings = null) { throw null; }
+
+        public virtual SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd, System.Collections.Generic.IDictionary<string, SdkResultItem> itemsToAdd, System.Collections.Generic.IEnumerable<string> warnings = null) { throw null; }
+
+        public abstract SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IEnumerable<string> warnings = null);
+    }
+
+    public partial class SdkResultItem
+    {
+        public SdkResultItem() { }
+
+        public SdkResultItem(string itemSpec, System.Collections.Generic.Dictionary<string, string>? metadata) { }
+
+        public string ItemSpec { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string>? Metadata { get { throw null; } }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum TargetBuiltReason
+    {
+        None = 0,
+        BeforeTargets = 1,
+        DependsOn = 2,
+        AfterTargets = 3
+    }
+
+    public partial class TargetFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected TargetFinishedEventArgs() { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.Collections.IEnumerable targetOutputs) { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded, System.DateTime eventTimestamp, System.Collections.IEnumerable targetOutputs) { }
+
+        public TargetFinishedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+
+        public string TargetFile { get { throw null; } }
+
+        public string TargetName { get { throw null; } }
+
+        public System.Collections.IEnumerable TargetOutputs { get { throw null; } set { } }
+    }
+
+    public delegate void TargetFinishedEventHandler(object sender, TargetFinishedEventArgs e);
+    public partial class TargetSkippedEventArgs : BuildMessageEventArgs
+    {
+        public TargetSkippedEventArgs() { }
+
+        public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
+
+        public TargetBuiltReason BuildReason { get { throw null; } set { } }
+
+        public string Condition { get { throw null; } set { } }
+
+        public string EvaluatedCondition { get { throw null; } set { } }
+
+        public override string Message { get { throw null; } }
+
+        public BuildEventContext OriginalBuildEventContext { get { throw null; } set { } }
+
+        public bool OriginallySucceeded { get { throw null; } set { } }
+
+        public string ParentTarget { get { throw null; } set { } }
+
+        public TargetSkipReason SkipReason { get { throw null; } set { } }
+
+        public string TargetFile { get { throw null; } set { } }
+
+        public string TargetName { get { throw null; } set { } }
+    }
+
+    public enum TargetSkipReason
+    {
+        None = 0,
+        PreviouslyBuiltSuccessfully = 1,
+        PreviouslyBuiltUnsuccessfully = 2,
+        OutputsUpToDate = 3,
+        ConditionWasFalse = 4
+    }
+
+    public partial class TargetStartedEventArgs : BuildStatusEventArgs
+    {
+        protected TargetStartedEventArgs() { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, TargetBuiltReason buildReason, System.DateTime eventTimestamp) { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, System.DateTime eventTimestamp) { }
+
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile) { }
+
+        public TargetBuiltReason BuildReason { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string ParentTarget { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TargetFile { get { throw null; } }
+
+        public string TargetName { get { throw null; } }
+    }
+
+    public delegate void TargetStartedEventHandler(object sender, TargetStartedEventArgs e);
+    public partial class TaskCommandLineEventArgs : BuildMessageEventArgs
+    {
+        protected TaskCommandLineEventArgs() { }
+
+        public TaskCommandLineEventArgs(string commandLine, string taskName, MessageImportance importance, System.DateTime eventTimestamp) { }
+
+        public TaskCommandLineEventArgs(string commandLine, string taskName, MessageImportance importance) { }
+
+        public string CommandLine { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public partial class TaskFinishedEventArgs : BuildStatusEventArgs
+    {
+        protected TaskFinishedEventArgs() { }
+
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded, System.DateTime eventTimestamp) { }
+
+        public TaskFinishedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, bool succeeded) { }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+
+        public string TaskFile { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public delegate void TaskFinishedEventHandler(object sender, TaskFinishedEventArgs e);
+    public partial class TaskParameterEventArgs : BuildMessageEventArgs
+    {
+        public TaskParameterEventArgs(TaskParameterMessageKind kind, string itemType, System.Collections.IList items, bool logItemMetadata, System.DateTime eventTimestamp) { }
+
+        public System.Collections.IList Items { get { throw null; } }
+
+        public string ItemType { get { throw null; } }
+
+        public TaskParameterMessageKind Kind { get { throw null; } }
+
+        public bool LogItemMetadata { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+    }
+
+    public enum TaskParameterMessageKind
+    {
+        TaskInput = 0,
+        TaskOutput = 1,
+        AddItem = 2,
+        RemoveItem = 3,
+        SkippedTargetInputs = 4,
+        SkippedTargetOutputs = 5
+    }
+
+    public partial class TaskPropertyInfo
+    {
+        public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+
+        public bool Log { get { throw null; } set { } }
+
+        public bool LogItemMetadata { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public bool Output { get { throw null; } }
+
+        public System.Type PropertyType { get { throw null; } }
+
+        public bool Required { get { throw null; } }
+    }
+
+    public partial class TaskStartedEventArgs : BuildStatusEventArgs
+    {
+        protected TaskStartedEventArgs() { }
+
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName, System.DateTime eventTimestamp) { }
+
+        public TaskStartedEventArgs(string message, string helpKeyword, string projectFile, string taskFile, string taskName) { }
+
+        public int ColumnNumber { get { throw null; } }
+
+        public int LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string ProjectFile { get { throw null; } }
+
+        public string TaskFile { get { throw null; } }
+
+        public string TaskName { get { throw null; } }
+    }
+
+    public delegate void TaskStartedEventHandler(object sender, TaskStartedEventArgs e);
+    public sealed partial class TelemetryEventArgs : BuildEventArgs
+    {
+        public string EventName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
+    }
+
+    public delegate void TelemetryEventHandler(object sender, TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword = null, string senderName = null, MessageImportance importance = MessageImportance.Low) { }
+
+        public string PropertyName { get { throw null; } set { } }
+    }
+}
+
+namespace Microsoft.Build.Framework.Profiler
+{
+    public partial struct EvaluationLocation
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public EvaluationLocation(EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public EvaluationLocation(long id, long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public EvaluationLocation(long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind) { }
+
+        public string ElementDescription { get { throw null; } }
+
+        public string ElementName { get { throw null; } }
+
+        public static EvaluationLocation EmptyLocation { get { throw null; } }
+
+        public EvaluationPass EvaluationPass { get { throw null; } }
+
+        public string EvaluationPassDescription { get { throw null; } }
+
+        public string File { get { throw null; } }
+
+        public long Id { get { throw null; } }
+
+        public bool IsEvaluationPass { get { throw null; } }
+
+        public EvaluationLocationKind Kind { get { throw null; } }
+
+        public int? Line { get { throw null; } }
+
+        public long? ParentId { get { throw null; } }
+
+        public static EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
+
+        public static EvaluationLocation CreateLocationForCondition(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, string condition) { throw null; }
+
+        public static EvaluationLocation CreateLocationForGlob(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, string globDescription) { throw null; }
+
+        public static EvaluationLocation CreateLocationForProject(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file, int? line, IProjectElement element) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public EvaluationLocation WithEvaluationPass(EvaluationPass evaluationPass, string passDescription = null) { throw null; }
+
+        public EvaluationLocation WithFile(string file) { throw null; }
+
+        public EvaluationLocation WithFileLineAndCondition(string file, int? line, string condition) { throw null; }
+
+        public EvaluationLocation WithFileLineAndElement(string file, int? line, IProjectElement element) { throw null; }
+
+        public EvaluationLocation WithGlob(string globDescription) { throw null; }
+
+        public EvaluationLocation WithParentId(long? parentId) { throw null; }
+    }
+
+    public enum EvaluationLocationKind : byte
+    {
+        Element = 0,
+        Condition = 1,
+        Glob = 2
+    }
+
+    public enum EvaluationPass : byte
+    {
+        TotalEvaluation = 0,
+        TotalGlobbing = 1,
+        InitialProperties = 2,
+        Properties = 3,
+        ItemDefinitionGroups = 4,
+        Items = 5,
+        LazyItems = 6,
+        UsingTasks = 7,
+        Targets = 8
+    }
+
+    public partial struct ProfiledLocation
+    {
+        private int _dummyPrimitive;
+        public ProfiledLocation(System.TimeSpan inclusiveTime, System.TimeSpan exclusiveTime, int numberOfHits) { }
+
+        public System.TimeSpan ExclusiveTime { get { throw null; } }
+
+        public System.TimeSpan InclusiveTime { get { throw null; } }
+
+        public int NumberOfHits { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial struct ProfilerResult
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public ProfilerResult(System.Collections.Generic.IDictionary<EvaluationLocation, ProfiledLocation> profiledLocations) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<EvaluationLocation, ProfiledLocation> ProfiledLocations { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/Microsoft.Build.Tasks.Core.17.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/Microsoft.Build.Tasks.Core.17.5.0.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.5.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.5.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/microsoft.build.tasks.core.nuspec
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/microsoft.build.tasks.core.nuspec
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Build.Tasks.Core</id>
+    <version>17.5.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
+    <description>This package contains the Microsoft.Build.Tasks assembly which implements the commonly used tasks of MSBuild.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>MSBuild</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/msbuild" commit="6f08c67f3ed838dccfbcdab91e6bebc54a26fd94" />
+    <dependencies>
+      <group targetFramework="net7.0">
+        <dependency id="Microsoft.Build.Framework" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.StringTools" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="System.CodeDom" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Collections.Immutable" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.Metadata" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Resources.Extensions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="6.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Xml" version="6.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Permissions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Build.Framework" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.StringTools" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.CodeDom" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Collections.Immutable" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.Metadata" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Resources.Extensions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="6.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Xml" version="6.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Permissions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/ref/net7.0/Microsoft.Build.Tasks.Core.cs
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/ref/net7.0/Microsoft.Build.Tasks.Core.cs
@@ -1,0 +1,3176 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Tasks.Core.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Tasks.Core.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Tasks
+{
+    public partial class AssignCulture : TaskExtension
+    {
+        public AssignCulture() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFilesWithCulture { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFilesWithNoCulture { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CultureNeutralAssignedFiles { get { throw null; } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignLinkMetadata : TaskExtension
+    {
+        public AssignLinkMetadata() { }
+
+        public Framework.ITaskItem[] Items { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputItems { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignProjectConfiguration : ResolveProjectBase
+    {
+        public bool AddSyntheticProjectReferencesForSolutionDependencies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedProjects { get { throw null; } set { } }
+
+        public string CurrentProject { get { throw null; } set { } }
+
+        public string CurrentProjectConfiguration { get { throw null; } set { } }
+
+        public string CurrentProjectPlatform { get { throw null; } set { } }
+
+        public string DefaultToVcxPlatformMapping { get { throw null; } set { } }
+
+        public bool OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration { get { throw null; } set { } }
+
+        public string OutputType { get { throw null; } set { } }
+
+        public bool ResolveConfigurationPlatformUsingMappings { get { throw null; } set { } }
+
+        public bool ShouldUnsetParentConfigurationAndPlatform { get { throw null; } set { } }
+
+        public string SolutionConfigurationContents { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnassignedProjects { get { throw null; } set { } }
+
+        public string VcxToDefaultPlatformMapping { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignTargetPath : TaskExtension
+    {
+        public AssignTargetPath() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string RootFolder { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [Framework.RunInMTA]
+    public partial class CallTarget : TaskExtension
+    {
+        public CallTarget() { }
+
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+
+        public string[] Targets { get { throw null; } set { } }
+
+        public bool UseResultsCache { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Obsolete("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
+    public sealed partial class CodeTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public partial class CombinePath : TaskExtension
+    {
+        public CombinePath() { }
+
+        public string BasePath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CombinedPaths { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Paths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CombineTargetFrameworkInfoProperties : TaskExtension
+    {
+        public CombineTargetFrameworkInfoProperties() { }
+
+        public Framework.ITaskItem[] PropertiesAndValues { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string Result { get { throw null; } set { } }
+
+        public string RootElementName { get { throw null; } set { } }
+
+        public bool UseAttributeForTargetFrameworkInfoPropertyNames { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CombineXmlElements : TaskExtension
+    {
+        public CombineXmlElements() { }
+
+        [Framework.Output]
+        public string Result { get { throw null; } set { } }
+
+        public string RootElementName { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] XmlElements { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CommandLineBuilderExtension : Utilities.CommandLineBuilder
+    {
+        public CommandLineBuilderExtension() { }
+
+        public CommandLineBuilderExtension(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
+
+        protected string GetQuotedText(string unquotedText) { throw null; }
+    }
+
+    public partial class ConvertToAbsolutePath : TaskExtension
+    {
+        public ConvertToAbsolutePath() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AbsolutePaths { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Paths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Copy : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Copy() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopiedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        public bool ErrorIfLinkFails { get { throw null; } set { } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        public int Retries { get { throw null; } set { } }
+
+        public int RetryDelayMilliseconds { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public bool UseHardlinksIfPossible { get { throw null; } set { } }
+
+        public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+
+        [Framework.Output]
+        public bool WroteAtLeastOneFile { get { throw null; } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CreateCSharpManifestResourceName : CreateManifestResourceName
+    {
+        protected override string SourceFileExtension { get { throw null; } }
+
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+
+    public partial class CreateItem : TaskExtension
+    {
+        public CreateItem() { }
+
+        public string[] AdditionalMetadata { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Exclude { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Include { get { throw null; } set { } }
+
+        public bool PreserveExistingMetadata { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class CreateManifestResourceName : TaskExtension
+    {
+        protected System.Collections.Generic.Dictionary<string, Framework.ITaskItem> itemSpecToTaskitem;
+        protected CreateManifestResourceName() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ManifestResourceNames { get { throw null; } }
+
+        public bool PrependCultureAsDirectory { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ResourceFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
+
+        public string RootNamespace { get { throw null; } set { } }
+
+        protected abstract string SourceFileExtension { get; }
+
+        public bool UseDependentUponConvention { get { throw null; } set { } }
+
+        protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
+        public override bool Execute() { throw null; }
+
+        protected abstract bool IsSourceFile(string fileName);
+        public static string MakeValidEverettIdentifier(string name) { throw null; }
+    }
+
+    public partial class CreateProperty : TaskExtension
+    {
+        public CreateProperty() { }
+
+        [Framework.Output]
+        public string[] Value { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string[] ValueSetByTask { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CreateVisualBasicManifestResourceName : CreateManifestResourceName
+    {
+        protected override string SourceFileExtension { get { throw null; } }
+
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+
+    public partial class Delete : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Delete() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DeletedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool TreatErrorsAsWarnings { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class DownloadFile : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public DownloadFile() { }
+
+        public Framework.ITaskItem DestinationFileName { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem DownloadedFile { get { throw null; } set { } }
+
+        public int Retries { get { throw null; } set { } }
+
+        public int RetryDelayMilliseconds { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string SourceUrl { get { throw null; } set { } }
+
+        public int Timeout { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Error : TaskExtension
+    {
+        public Error() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string HelpLink { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ErrorFromResources : TaskExtension
+    {
+        public ErrorFromResources() { }
+
+        public string[] Arguments { get { throw null; } set { } }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Resource { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Exec : ToolTaskExtension
+    {
+        public Exec() { }
+
+        [Framework.Required]
+        public string Command { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ConsoleOutput { get { throw null; } }
+
+        public bool ConsoleToMSBuild { get { throw null; } set { } }
+
+        public string CustomErrorRegularExpression { get { throw null; } set { } }
+
+        public string CustomWarningRegularExpression { get { throw null; } set { } }
+
+        public bool IgnoreExitCode { get { throw null; } set { } }
+
+        public bool IgnoreStandardErrorWarningFormat { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Outputs { get { throw null; } set { } }
+
+        protected override System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+
+        protected override Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+
+        protected override System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+
+        protected override Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+
+        [Framework.Output]
+        public string StdErrEncoding { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StdOutEncoding { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        public string WorkingDirectory { get { throw null; } set { } }
+
+        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+
+        protected override string GetWorkingDirectory() { throw null; }
+
+        protected override bool HandleTaskExecutionErrors() { throw null; }
+
+        protected override void LogEventsFromTextOutput(string singleLine, Framework.MessageImportance messageImportance) { }
+
+        protected override void LogPathToTool(string toolName, string pathToTool) { }
+
+        protected override void LogToolCommand(string message) { }
+
+        protected override bool ValidateParameters() { throw null; }
+    }
+
+    public partial struct ExtractedClassName
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public bool IsInsideConditionalBlock { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public partial class FindAppConfigFile : TaskExtension
+    {
+        public FindAppConfigFile() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem AppConfigFile { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] PrimaryList { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SecondaryList { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindInList : TaskExtension
+    {
+        public FindInList() { }
+
+        public bool CaseSensitive { get { throw null; } set { } }
+
+        public bool FindLastMatch { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem ItemFound { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string ItemSpecToFind { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] List { get { throw null; } set { } }
+
+        public bool MatchFileNameOnly { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindInvalidProjectReferences : TaskExtension
+    {
+        public FindInvalidProjectReferences() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InvalidReferences { get { throw null; } }
+
+        public Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindUnderPath : TaskExtension
+    {
+        public FindUnderPath() { }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutOfPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem Path { get { throw null; } set { } }
+
+        public bool UpdateToAbsolutePaths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class FormatUrl : TaskExtension
+    {
+        public FormatUrl() { }
+
+        public string InputUrl { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string OutputUrl { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class FormatVersion : TaskExtension
+    {
+        public FormatVersion() { }
+
+        public string FormatType { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string OutputVersion { get { throw null; } set { } }
+
+        public int Revision { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public sealed partial class GenerateApplicationManifest : GenerateManifestBase
+    {
+        public string ClrVersion { get { throw null; } set { } }
+
+        public Framework.ITaskItem ConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Dependencies { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] FileAssociations { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool HostInBrowser { get { throw null; } set { } }
+
+        public Framework.ITaskItem IconFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] IsolatedComReferences { get { throw null; } set { } }
+
+        public string ManifestType { get { throw null; } set { } }
+
+        public string OSVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public bool RequiresMinimumFramework35SP1 { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkProfile { get { throw null; } set { } }
+
+        public string TargetFrameworkSubset { get { throw null; } set { } }
+
+        public Framework.ITaskItem TrustInfoFile { get { throw null; } set { } }
+
+        public bool UseApplicationTrust { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override System.Type GetObjectType() { throw null; }
+
+        protected override bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected override bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+
+    public partial class GenerateBindingRedirects : TaskExtension
+    {
+        public GenerateBindingRedirects() { }
+
+        public Framework.ITaskItem AppConfigFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputAppConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] SuggestedRedirects { get { throw null; } set { } }
+
+        public string TargetName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public sealed partial class GenerateDeploymentManifest : GenerateManifestBase
+    {
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+
+        public string DeploymentUrl { get { throw null; } set { } }
+
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public bool Install { get { throw null; } set { } }
+
+        public bool MapFileExtensions { get { throw null; } set { } }
+
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public bool TrustUrlParameters { get { throw null; } set { } }
+
+        public bool UpdateEnabled { get { throw null; } set { } }
+
+        public int UpdateInterval { get { throw null; } set { } }
+
+        public string UpdateMode { get { throw null; } set { } }
+
+        public string UpdateUnit { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override System.Type GetObjectType() { throw null; }
+
+        protected override bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected override bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public sealed partial class GenerateLauncher : TaskExtension
+    {
+        public GenerateLauncher() { }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public string LauncherPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string VisualStudioVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class GenerateManifestBase : Utilities.Task
+    {
+        public string AssemblyName { get { throw null; } set { } }
+
+        public string AssemblyVersion { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem InputManifest { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public int MaxTargetPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputManifest { get { throw null; } set { } }
+
+        public string Platform { get { throw null; } set { } }
+
+        public string TargetCulture { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddAssemblyFromItem(Framework.ITaskItem item) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddAssemblyNameFromItem(Framework.ITaskItem item, Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddEntryPointFromItem(Framework.ITaskItem item, Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.FileReference AddFileFromItem(Framework.ITaskItem item) { throw null; }
+
+        public override bool Execute() { throw null; }
+
+        protected internal Deployment.ManifestUtilities.FileReference FindFileFromItem(Framework.ITaskItem item) { throw null; }
+
+        protected abstract System.Type GetObjectType();
+        protected abstract bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest);
+        protected abstract bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest);
+        protected internal virtual bool ValidateInputs() { throw null; }
+
+        protected internal virtual bool ValidateOutput() { throw null; }
+    }
+
+    [Framework.RequiredRuntime("v2.0")]
+    public sealed partial class GenerateResource : TaskExtension
+    {
+        public GenerateResource() { }
+
+        public Framework.ITaskItem[] AdditionalInputs { get { throw null; } set { } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ExcludedInputPaths { get { throw null; } set { } }
+
+        public bool ExecuteAsTool { get { throw null; } set { } }
+
+        public bool ExtractResWFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] FilesWritten { get { throw null; } }
+
+        public bool MinimalRebuildFromTracking { get { throw null; } set { } }
+
+        public bool NeverLockTypeAssemblies { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputResources { get { throw null; } set { } }
+
+        public bool PublicClass { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] References { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        [Framework.Output]
+        public Framework.ITaskItem[] Sources { get { throw null; } set { } }
+
+        public Framework.ITaskItem StateFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StronglyTypedClassName { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StronglyTypedFileName { get { throw null; } set { } }
+
+        public string StronglyTypedLanguage { get { throw null; } set { } }
+
+        public string StronglyTypedManifestPrefix { get { throw null; } set { } }
+
+        public string StronglyTypedNamespace { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TLogReadFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] TLogWriteFiles { get { throw null; } }
+
+        public string ToolArchitecture { get { throw null; } set { } }
+
+        public string TrackerFrameworkPath { get { throw null; } set { } }
+
+        public string TrackerLogDirectory { get { throw null; } set { } }
+
+        public string TrackerSdkPath { get { throw null; } set { } }
+
+        public bool TrackFileAccess { get { throw null; } set { } }
+
+        public bool UsePreserializedResources { get { throw null; } set { } }
+
+        public bool UseSourcePath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetAssemblyIdentity : TaskExtension
+    {
+        public GetAssemblyIdentity() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetCompatiblePlatform : TaskExtension
+    {
+        public GetCompatiblePlatform() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] AnnotatedProjects { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[]? AssignedProjectsWithPlatform { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string CurrentProjectPlatform { get { throw null; } set { } }
+
+        public string PlatformLookupTable { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class GetFileHash : TaskExtension
+    {
+        public GetFileHash() { }
+
+        public string Algorithm { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string Hash { get { throw null; } set { } }
+
+        public string HashEncoding { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Items { get { throw null; } set { } }
+
+        public string MetadataName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetFrameworkPath : TaskExtension
+    {
+        public GetFrameworkPath() { }
+
+        [Framework.Output]
+        public string FrameworkVersion11Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion20Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion30Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion35Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion40Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion451Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion452Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion45Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion461Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion462Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion46Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion471Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion472Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion47Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion48Path { get { throw null; } }
+
+        [Framework.Output]
+        public string Path { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetInstalledSDKLocations : TaskExtension
+    {
+        public GetInstalledSDKLocations() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
+
+        public string[] SDKDirectoryRoots { get { throw null; } set { } }
+
+        public string[] SDKExtensionDirectoryRoots { get { throw null; } set { } }
+
+        public string SDKRegistryRoot { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public bool WarnWhenNoSDKsFound { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetReferenceAssemblyPaths : TaskExtension
+    {
+        public GetReferenceAssemblyPaths() { }
+
+        public bool BypassFrameworkInstallChecks { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string[] FullFrameworkReferenceAssemblyPaths { get { throw null; } }
+
+        [Framework.Output]
+        public string[] ReferenceAssemblyPaths { get { throw null; } }
+
+        public string RootPath { get { throw null; } set { } }
+
+        public bool SuppressNotFoundError { get { throw null; } set { } }
+
+        public string TargetFrameworkFallbackSearchPaths { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string TargetFrameworkMonikerDisplayName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetSDKReferenceFiles : TaskExtension
+    {
+        public GetSDKReferenceFiles() { }
+
+        public string CacheFileFolderPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+
+        public bool LogCacheFileExceptions { get { throw null; } set { } }
+
+        public bool LogRedistConflictBetweenSDKsAsWarning { get { throw null; } set { } }
+
+        public bool LogRedistConflictWithinSDKAsWarning { get { throw null; } set { } }
+
+        public bool LogRedistFilesList { get { throw null; } set { } }
+
+        public bool LogReferenceConflictBetweenSDKsAsWarning { get { throw null; } set { } }
+
+        public bool LogReferenceConflictWithinSDKAsWarning { get { throw null; } set { } }
+
+        public bool LogReferencesList { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RedistFiles { get { throw null; } }
+
+        public string[] ReferenceExtensions { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] References { get { throw null; } }
+
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public string TargetSDKIdentifier { get { throw null; } set { } }
+
+        public string TargetSDKVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Hash : TaskExtension
+    {
+        public Hash() { }
+
+        [Framework.Output]
+        public string HashResult { get { throw null; } set { } }
+
+        public bool IgnoreCase { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial interface IFixedTypeInfo
+    {
+        void AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out nint ppv);
+        void CreateInstance(object pUnkOuter, ref System.Guid riid, out object ppvObj);
+        void GetContainingTypeLib(out System.Runtime.InteropServices.ComTypes.ITypeLib ppTLB, out int pIndex);
+        void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, nint pBstrDllName, nint pBstrName, nint pwOrdinal);
+        void GetDocumentation(int index, out string strName, out string strDocString, out int dwHelpContext, out string strHelpFile);
+        void GetFuncDesc(int index, out nint ppFuncDesc);
+        void GetIDsOfNames(string[] rgszNames, int cNames, int[] pMemId);
+        void GetImplTypeFlags(int index, out System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS pImplTypeFlags);
+        void GetMops(int memid, out string pBstrMops);
+        void GetNames(int memid, string[] rgBstrNames, int cMaxNames, out int pcNames);
+        void GetRefTypeInfo(nint hRef, out IFixedTypeInfo ppTI);
+        void GetRefTypeOfImplType(int index, out nint href);
+        void GetTypeAttr(out nint ppTypeAttr);
+        void GetTypeComp(out System.Runtime.InteropServices.ComTypes.ITypeComp ppTComp);
+        void GetVarDesc(int index, out nint ppVarDesc);
+        void Invoke(object pvInstance, int memid, short wFlags, ref System.Runtime.InteropServices.ComTypes.DISPPARAMS pDispParams, nint pVarResult, nint pExcepInfo, out int puArgErr);
+        void ReleaseFuncDesc(nint pFuncDesc);
+        void ReleaseTypeAttr(nint pTypeAttr);
+        void ReleaseVarDesc(nint pVarDesc);
+    }
+
+    public partial class LC : ToolTaskExtension
+    {
+        public LC() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem LicenseTarget { get { throw null; } set { } }
+
+        public bool NoLogo { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputLicense { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ReferencedAssemblies { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Sources { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine) { }
+
+        public override bool Execute() { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+
+        protected override bool ValidateParameters() { throw null; }
+    }
+
+    public partial class MakeDir : TaskExtension
+    {
+        public MakeDir() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Directories { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DirectoriesCreated { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Message : TaskExtension
+    {
+        public Message() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string Importance { get { throw null; } set { } }
+
+        public bool IsCritical { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Move : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Move() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] MovedFiles { get { throw null; } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [Framework.RunInMTA]
+    public partial class MSBuild : TaskExtension
+    {
+        public MSBuild() { }
+
+        public bool BuildInParallel { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Projects { get { throw null; } set { } }
+
+        public string[] Properties { get { throw null; } set { } }
+
+        public bool RebaseOutputs { get { throw null; } set { } }
+
+        public string RemoveProperties { get { throw null; } set { } }
+
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+
+        public string SkipNonexistentProjects { get { throw null; } set { } }
+
+        public bool StopOnFirstFailure { get { throw null; } set { } }
+
+        public string[] TargetAndPropertyListSeparators { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+
+        public string[] Targets { get { throw null; } set { } }
+
+        public string ToolsVersion { get { throw null; } set { } }
+
+        public bool UnloadProjectsOnCompletion { get { throw null; } set { } }
+
+        public bool UseResultsCache { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ReadLinesFromFile : TaskExtension
+    {
+        public ReadLinesFromFile() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem File { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Lines { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class RemoveDir : TaskExtension
+    {
+        public RemoveDir() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Directories { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RemovedDirectories { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class RemoveDuplicates : TaskExtension
+    {
+        public RemoveDuplicates() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Filtered { get { throw null; } set { } }
+
+        [Framework.Output]
+        public bool HadAnyDuplicates { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Inputs { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveAssemblyReference : TaskExtension
+    {
+        public ResolveAssemblyReference() { }
+
+        public string[] AllowedAssemblyExtensions { get { throw null; } set { } }
+
+        public string[] AllowedRelatedFileExtensions { get { throw null; } set { } }
+
+        public string AppConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+
+        public string AssemblyInformationCacheOutputPath { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] AssemblyInformationCachePaths { get { throw null; } set { } }
+
+        public bool AutoUnify { get { throw null; } set { } }
+
+        public string[] CandidateAssemblyFiles { get { throw null; } set { } }
+
+        public bool CopyLocalDependenciesWhenParentReferenceInGac { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+
+        [Framework.Output]
+        public string DependsOnNETStandard { get { throw null; } }
+
+        [Framework.Output]
+        public string DependsOnSystemRuntime { get { throw null; } }
+
+        public bool DoNotCopyLocalIfInGac { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] FilesWritten { get { throw null; } set { } }
+
+        public bool FindDependencies { get { throw null; } set { } }
+
+        public bool FindDependenciesOfExternallyResolvedReferences { get { throw null; } set { } }
+
+        public bool FindRelatedFiles { get { throw null; } set { } }
+
+        public bool FindSatellites { get { throw null; } set { } }
+
+        public bool FindSerializationAssemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] FullFrameworkAssemblyTables { get { throw null; } set { } }
+
+        public string[] FullFrameworkFolders { get { throw null; } set { } }
+
+        public string[] FullTargetFrameworkSubsetNames { get { throw null; } set { } }
+
+        public bool IgnoreDefaultInstalledAssemblySubsetTables { get { throw null; } set { } }
+
+        public bool IgnoreDefaultInstalledAssemblyTables { get { throw null; } set { } }
+
+        public bool IgnoreTargetFrameworkAttributeVersionMismatch { get { throw null; } set { } }
+
+        public bool IgnoreVersionForFrameworkReferences { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] InstalledAssemblySubsetTables { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] InstalledAssemblyTables { get { throw null; } set { } }
+
+        public string[] LatestTargetFrameworkDirectories { get { throw null; } set { } }
+
+        public bool OutputUnresolvedAssemblyConflicts { get { throw null; } set { } }
+
+        public string ProfileName { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RelatedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedDependencyFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SatelliteFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ScatterFiles { get { throw null; } }
+
+        [Framework.Required]
+        public string[] SearchPaths { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SerializationAssemblyFiles { get { throw null; } }
+
+        public bool Silent { get { throw null; } set { } }
+
+        public string StateFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SuggestedRedirects { get { throw null; } }
+
+        public bool SupportsBindingRedirectGeneration { get { throw null; } set { } }
+
+        public string TargetedRuntimeVersion { get { throw null; } set { } }
+
+        public string[] TargetFrameworkDirectories { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public string TargetFrameworkMonikerDisplayName { get { throw null; } set { } }
+
+        public string[] TargetFrameworkSubsets { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnresolvedAssemblyConflicts { get { throw null; } }
+
+        public bool UnresolveFrameworkAssembliesFromHigherFrameworks { get { throw null; } set { } }
+
+        public string WarnOrErrorOnTargetArchitectureMismatch { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveCodeAnalysisRuleSet : TaskExtension
+    {
+        public ResolveCodeAnalysisRuleSet() { }
+
+        public string CodeAnalysisRuleSet { get { throw null; } set { } }
+
+        public string[] CodeAnalysisRuleSetDirectories { get { throw null; } set { } }
+
+        public string MSBuildProjectDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveComReference : TaskExtension
+    {
+        public ResolveComReference() { }
+
+        public bool DelaySign { get { throw null; } set { } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        public bool ExecuteAsTool { get { throw null; } set { } }
+
+        public bool IncludeVersionInInteropName { get { throw null; } set { } }
+
+        public string KeyContainer { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        public bool NoClassMembers { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ResolvedAssemblyReferences { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedModules { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        public bool Silent { get { throw null; } set { } }
+
+        public string StateFile { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TypeLibNames { get { throw null; } set { } }
+
+        public string WrapperOutputDirectory { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveKeySource : TaskExtension
+    {
+        public ResolveKeySource() { }
+
+        public int AutoClosePasswordPromptShow { get { throw null; } set { } }
+
+        public int AutoClosePasswordPromptTimeout { get { throw null; } set { } }
+
+        public string CertificateFile { get { throw null; } set { } }
+
+        public string CertificateThumbprint { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedKeyContainer { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedKeyFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedThumbprint { get { throw null; } set { } }
+
+        public bool ShowImportDialogDespitePreviousFailures { get { throw null; } set { } }
+
+        public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveManifestFiles : TaskExtension
+    {
+        public ResolveManifestFiles() { }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool IsSelfContainedPublish { get { throw null; } set { } }
+
+        public bool IsSingleFilePublish { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputAssemblies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputDeploymentManifestEntryPoint { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] RuntimePackAssets { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
+
+        public bool SigningManifests { get { throw null; } set { } }
+
+        public string TargetCulture { get { throw null; } set { } }
+
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveNonMSBuildProjectOutput : ResolveProjectBase
+    {
+        public string PreresolvedProjectOutputs { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedOutputPaths { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class ResolveProjectBase : TaskExtension
+    {
+        protected ResolveProjectBase() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+
+        protected void AddSyntheticProjectReferences(string currentProjectAbsolutePath) { }
+
+        protected System.Xml.XmlElement GetProjectElement(Framework.ITaskItem projectRef) { throw null; }
+
+        protected string GetProjectItem(Framework.ITaskItem projectRef) { throw null; }
+    }
+
+    public partial class ResolveSDKReference : TaskExtension
+    {
+        public ResolveSDKReference() { }
+
+        public Framework.ITaskItem[] DisallowedSDKDependencies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
+
+        public bool LogResolutionErrorsAsWarnings { get { throw null; } set { } }
+
+        public bool Prefer32Bit { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string ProjectName { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] References { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } }
+
+        public Framework.ITaskItem[] RuntimeReferenceOnlySDKDependencies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SDKReferences { get { throw null; } set { } }
+
+        public string TargetedSDKArchitecture { get { throw null; } set { } }
+
+        public string TargetedSDKConfiguration { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public bool WarnOnMissingPlatformVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class RoslynCodeTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public sealed partial class SetRidAgnosticValueForProjects : TaskExtension
+    {
+        public SetRidAgnosticValueForProjects() { }
+
+        public Framework.ITaskItem[] Projects { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UpdatedProjects { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class SGen : ToolTaskExtension
+    {
+        public SGen() { }
+
+        [Framework.Required]
+        public string BuildAssemblyName { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string BuildAssemblyPath { get { throw null; } set { } }
+
+        public bool DelaySign { get { throw null; } set { } }
+
+        public string KeyContainer { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        public string Platform { get { throw null; } set { } }
+
+        public string[] References { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SerializationAssembly { get { throw null; } set { } }
+
+        public string SerializationAssemblyName { get { throw null; } }
+
+        [Framework.Required]
+        public bool ShouldGenerateSerializer { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        public string[] Types { get { throw null; } set { } }
+
+        public bool UseKeep { get { throw null; } set { } }
+
+        [Framework.Required]
+        public bool UseProxyTypes { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public sealed partial class SignFile : Utilities.Task
+    {
+        [Framework.Required]
+        public string CertificateThumbprint { get { throw null; } set { } }
+
+        public bool DisallowMansignTimestampFallback { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem SigningTarget { get { throw null; } set { } }
+
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TimestampUrl { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class TaskExtension : Utilities.Task
+    {
+        internal TaskExtension() { }
+
+        public new Utilities.TaskLoggingHelper Log { get { throw null; } }
+    }
+
+    public partial class TaskLoggingHelperExtension : Utilities.TaskLoggingHelper
+    {
+        public TaskLoggingHelperExtension(Framework.ITask taskInstance, System.Resources.ResourceManager primaryResources, System.Resources.ResourceManager sharedResources, string helpKeywordPrefix) : base(default!) { }
+
+        public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
+
+        public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
+    }
+
+    public sealed partial class Telemetry : TaskExtension
+    {
+        public Telemetry() { }
+
+        public string EventData { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string EventName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class ToolTaskExtension : Utilities.ToolTask
+    {
+        internal ToolTaskExtension() { }
+
+        protected internal System.Collections.Hashtable Bag { get { throw null; } }
+
+        protected override bool HasLoggedErrors { get { throw null; } }
+
+        public Utilities.TaskLoggingHelper Log { get { throw null; } }
+
+        protected virtual bool UseNewLineSeparatorInResponseFile { get { throw null; } }
+
+        protected internal virtual void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected internal virtual void AddResponseFileCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected override string GenerateCommandLineCommands() { throw null; }
+
+        protected override string GenerateResponseFileCommands() { throw null; }
+
+        protected internal bool GetBoolParameterWithDefault(string parameterName, bool defaultValue) { throw null; }
+
+        protected internal int GetIntParameterWithDefault(string parameterName, int defaultValue) { throw null; }
+    }
+
+    public partial class Touch : TaskExtension
+    {
+        public Touch() { }
+
+        public bool AlwaysCreate { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool ForceTouch { get { throw null; } set { } }
+
+        public string Time { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Unzip : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Unzip() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Include { get { throw null; } set { } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class VerifyFileHash : TaskExtension
+    {
+        public VerifyFileHash() { }
+
+        public string Algorithm { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string File { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Hash { get { throw null; } set { } }
+
+        public string HashEncoding { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Warning : TaskExtension
+    {
+        public Warning() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string HelpLink { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class WriteCodeFragment : TaskExtension
+    {
+        public WriteCodeFragment() { }
+
+        public Framework.ITaskItem[] AssemblyAttributes { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Language { get { throw null; } set { } }
+
+        public Framework.ITaskItem OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputFile { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class WriteLinesToFile : TaskExtension
+    {
+        public WriteLinesToFile() { }
+
+        public string Encoding { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem File { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Lines { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        public bool WriteOnlyWhenDifferent { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Obsolete("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
+    public sealed partial class XamlTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public partial class XmlPeek : TaskExtension
+    {
+        public XmlPeek() { }
+
+        public string Namespaces { get { throw null; } set { } }
+
+        public bool ProhibitDtd { get { throw null; } set { } }
+
+        public string Query { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Result { get { throw null; } }
+
+        public string XmlContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class XmlPoke : TaskExtension
+    {
+        public XmlPoke() { }
+
+        public string Namespaces { get { throw null; } set { } }
+
+        public string Query { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem Value { get { throw null; } set { } }
+
+        public Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class XslTransformation : TaskExtension
+    {
+        public XslTransformation() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] OutputPaths { get { throw null; } set { } }
+
+        public string Parameters { get { throw null; } set { } }
+
+        public bool PreserveWhitespace { get { throw null; } set { } }
+
+        public bool UseTrustedSettings { get { throw null; } set { } }
+
+        public string XmlContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] XmlInputPaths { get { throw null; } set { } }
+
+        public Framework.ITaskItem XslCompiledDllPath { get { throw null; } set { } }
+
+        public string XslContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem XslInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ZipDirectory : TaskExtension
+    {
+        public ZipDirectory() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFile { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem SourceDirectory { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
+{
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public partial class BootstrapperBuilder : IBootstrapperBuilder
+    {
+        public BootstrapperBuilder() { }
+
+        public BootstrapperBuilder(string visualStudioVersion) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public ProductCollection Products { get { throw null; } }
+
+        public BuildResults Build(BuildSettings settings) { throw null; }
+
+        public string[] GetOutputFolders(string[] productCodes, string culture, string fallbackCulture, ComponentsLocation componentsLocation) { throw null; }
+
+        public static string XmlToConfigurationFile(System.Xml.XmlNode input) { throw null; }
+    }
+
+    public partial class BuildMessage : IBuildMessage
+    {
+        internal BuildMessage() { }
+
+        public int HelpId { get { throw null; } }
+
+        public string HelpKeyword { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public BuildMessageSeverity Severity { get { throw null; } }
+    }
+
+    public enum BuildMessageSeverity
+    {
+        Info = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class BuildResults : IBuildResults
+    {
+        internal BuildResults() { }
+
+        public string[] ComponentFiles { get { throw null; } }
+
+        public string KeyFile { get { throw null; } }
+
+        public BuildMessage[] Messages { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public partial class BuildSettings : IBuildSettings
+    {
+        public string ApplicationFile { get { throw null; } set { } }
+
+        public string ApplicationName { get { throw null; } set { } }
+
+        public bool ApplicationRequiresElevation { get { throw null; } set { } }
+
+        public string ApplicationUrl { get { throw null; } set { } }
+
+        public ComponentsLocation ComponentsLocation { get { throw null; } set { } }
+
+        public string ComponentsUrl { get { throw null; } set { } }
+
+        public bool CopyComponents { get { throw null; } set { } }
+
+        public int FallbackLCID { get { throw null; } set { } }
+
+        public int LCID { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public ProductBuilderCollection ProductBuilders { get { throw null; } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public bool Validate { get { throw null; } set { } }
+    }
+
+    public enum ComponentsLocation
+    {
+        HomeSite = 0,
+        Relative = 1,
+        Absolute = 2
+    }
+
+    public partial interface IBootstrapperBuilder
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        string Path { get; set; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        ProductCollection Products { get; }
+
+        [System.Runtime.InteropServices.DispId(5)]
+        BuildResults Build(BuildSettings settings);
+    }
+
+    public partial interface IBuildMessage
+    {
+        [System.Runtime.InteropServices.DispId(4)]
+        int HelpId { get; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string HelpKeyword { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string Message { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        BuildMessageSeverity Severity { get; }
+    }
+
+    public partial interface IBuildResults
+    {
+        [System.Runtime.InteropServices.DispId(3)]
+        string[] ComponentFiles { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string KeyFile { get; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        BuildMessage[] Messages { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        bool Succeeded { get; }
+    }
+
+    public partial interface IBuildSettings
+    {
+        [System.Runtime.InteropServices.DispId(2)]
+        string ApplicationFile { get; set; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        string ApplicationName { get; set; }
+
+        [System.Runtime.InteropServices.DispId(13)]
+        bool ApplicationRequiresElevation { get; set; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string ApplicationUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(11)]
+        ComponentsLocation ComponentsLocation { get; set; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        string ComponentsUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(5)]
+        bool CopyComponents { get; set; }
+
+        [System.Runtime.InteropServices.DispId(7)]
+        int FallbackLCID { get; set; }
+
+        [System.Runtime.InteropServices.DispId(6)]
+        int LCID { get; set; }
+
+        [System.Runtime.InteropServices.DispId(8)]
+        string OutputPath { get; set; }
+
+        [System.Runtime.InteropServices.DispId(9)]
+        ProductBuilderCollection ProductBuilders { get; }
+
+        [System.Runtime.InteropServices.DispId(12)]
+        string SupportUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(10)]
+        bool Validate { get; set; }
+    }
+
+    public partial interface IProduct
+    {
+        [System.Runtime.InteropServices.DispId(4)]
+        ProductCollection Includes { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string Name { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        ProductBuilder ProductBuilder { get; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string ProductCode { get; }
+    }
+
+    public partial interface IProductBuilder
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        Product Product { get; }
+    }
+
+    public partial interface IProductBuilderCollection
+    {
+        [System.Runtime.InteropServices.DispId(2)]
+        void Add(ProductBuilder builder);
+    }
+
+    public partial interface IProductCollection
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        int Count { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        Product Item(int index);
+        [System.Runtime.InteropServices.DispId(3)]
+        Product Product(string productCode);
+    }
+
+    public partial class Product : IProduct
+    {
+        public ProductCollection Includes { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public ProductBuilder ProductBuilder { get { throw null; } }
+
+        public string ProductCode { get { throw null; } }
+    }
+
+    public partial class ProductBuilder : IProductBuilder
+    {
+        internal ProductBuilder() { }
+
+        public Product Product { get { throw null; } }
+    }
+
+    public partial class ProductBuilderCollection : IProductBuilderCollection, System.Collections.IEnumerable
+    {
+        internal ProductBuilderCollection() { }
+
+        public void Add(ProductBuilder builder) { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public partial class ProductCollection : IProductCollection, System.Collections.IEnumerable
+    {
+        internal ProductCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Product Item(int index) { throw null; }
+
+        public Product Product(string productCode) { throw null; }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
+{
+    public sealed partial class ApplicationIdentity
+    {
+        public ApplicationIdentity(string url, AssemblyIdentity deployManifestIdentity, AssemblyIdentity applicationManifestIdentity) { }
+
+        public ApplicationIdentity(string url, string deployManifestPath, string applicationManifestPath) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class ApplicationManifest : AssemblyManifest
+    {
+        public ApplicationManifest() { }
+
+        public ApplicationManifest(string targetFrameworkVersion) { }
+
+        public string ConfigFile { get { throw null; } set { } }
+
+        public override AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public FileAssociationCollection FileAssociations { get { throw null; } }
+
+        public bool HostInBrowser { get { throw null; } set { } }
+
+        public string IconFile { get { throw null; } set { } }
+
+        public bool IsClickOnceManifest { get { throw null; } set { } }
+
+        public int MaxTargetPath { get { throw null; } set { } }
+
+        public string OSDescription { get { throw null; } set { } }
+
+        public string OSSupportUrl { get { throw null; } set { } }
+
+        public string OSVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public TrustInfo TrustInfo { get { throw null; } set { } }
+
+        public bool UseApplicationTrust { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlConfigFile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("EntryPointIdentity")]
+        public AssemblyIdentity XmlEntryPointIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlEntryPointParameters { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlEntryPointPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("FileAssociations")]
+        public FileAssociation[] XmlFileAssociations { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHostInBrowser { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIconFile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsClickOnceManifest { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSBuild { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSMajor { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSMinor { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSRevision { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProduct { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublisher { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSuiteName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUseApplicationTrust { get { throw null; } set { } }
+
+        public override void Validate() { }
+    }
+
+    public sealed partial class AssemblyIdentity
+    {
+        public AssemblyIdentity() { }
+
+        public AssemblyIdentity(AssemblyIdentity identity) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture, string type) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture) { }
+
+        public AssemblyIdentity(string name, string version) { }
+
+        public AssemblyIdentity(string name) { }
+
+        public string Culture { get { throw null; } set { } }
+
+        public bool IsFrameworkAssembly { get { throw null; } }
+
+        public bool IsNeutralPlatform { get { throw null; } }
+
+        public bool IsStrongName { get { throw null; } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string ProcessorArchitecture { get { throw null; } set { } }
+
+        public string PublicKeyToken { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlCulture { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProcessorArchitecture { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublicKeyToken { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlType { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+
+        public static AssemblyIdentity FromAssemblyName(string assemblyName) { throw null; }
+
+        public static AssemblyIdentity FromFile(string path) { throw null; }
+
+        public static AssemblyIdentity FromManagedAssembly(string path) { throw null; }
+
+        public static AssemblyIdentity FromManifest(string path) { throw null; }
+
+        public static AssemblyIdentity FromNativeAssembly(string path) { throw null; }
+
+        public string GetFullName(FullNameFlags flags) { throw null; }
+
+        public bool IsInFramework(string frameworkIdentifier, string frameworkVersion) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        [System.Flags]
+        public enum FullNameFlags
+        {
+            Default = 0,
+            ProcessorArchitecture = 1,
+            Type = 2,
+            All = 3
+        }
+    }
+
+    public partial class AssemblyManifest : Manifest
+    {
+        public ProxyStub[] ExternalProxyStubs { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ExternalProxyStubs")]
+        public ProxyStub[] XmlExternalProxyStubs { get { throw null; } set { } }
+    }
+
+    public sealed partial class AssemblyReference : BaseReference
+    {
+        public AssemblyReference() { }
+
+        public AssemblyReference(string path) { }
+
+        public AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+
+        public bool IsPrerequisite { get { throw null; } set { } }
+
+        public AssemblyReferenceType ReferenceType { get { throw null; } set { } }
+
+        protected internal override string SortName { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("AssemblyIdentity")]
+        public AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsNative { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsPrerequisite { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class AssemblyReferenceCollection : System.Collections.IEnumerable
+    {
+        internal AssemblyReferenceCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public AssemblyReference this[int index] { get { throw null; } }
+
+        public AssemblyReference Add(AssemblyReference assembly) { throw null; }
+
+        public AssemblyReference Add(string path) { throw null; }
+
+        public void Clear() { }
+
+        public AssemblyReference Find(AssemblyIdentity identity) { throw null; }
+
+        public AssemblyReference Find(string name) { throw null; }
+
+        public AssemblyReference FindTargetPath(string targetPath) { throw null; }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(AssemblyReference assemblyReference) { }
+    }
+
+    public enum AssemblyReferenceType
+    {
+        Unspecified = 0,
+        ClickOnceManifest = 1,
+        ManagedAssembly = 2,
+        NativeAssembly = 3
+    }
+
+    public abstract partial class BaseReference
+    {
+        protected internal BaseReference() { }
+
+        protected internal BaseReference(string path) { }
+
+        public string Group { get { throw null; } set { } }
+
+        public string Hash { get { throw null; } set { } }
+
+        public bool IsOptional { get { throw null; } set { } }
+
+        public string ResolvedPath { get { throw null; } set { } }
+
+        public long Size { get { throw null; } set { } }
+
+        protected internal abstract string SortName { get; }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        public string TargetPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlGroup { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHash { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHashAlgorithm { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsOptional { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSize { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ComClass
+    {
+        public string ClsId { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public string ProgId { get { throw null; } }
+
+        public string ThreadingModel { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlClsId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProgId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlThreadingModel { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+
+    public sealed partial class CompatibleFramework
+    {
+        public string Profile { get { throw null; } set { } }
+
+        public string SupportedRuntime { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProfile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportedRuntime { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+
+    public sealed partial class CompatibleFrameworkCollection : System.Collections.IEnumerable
+    {
+        internal CompatibleFrameworkCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public CompatibleFramework this[int index] { get { throw null; } }
+
+        public void Add(CompatibleFramework compatibleFramework) { }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class DeployManifest : Manifest
+    {
+        public DeployManifest() { }
+
+        public DeployManifest(string targetFrameworkMoniker) { }
+
+        public CompatibleFrameworkCollection CompatibleFrameworks { get { throw null; } }
+
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+
+        public string DeploymentUrl { get { throw null; } set { } }
+
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+
+        public override AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public bool Install { get { throw null; } set { } }
+
+        public bool MapFileExtensions { get { throw null; } set { } }
+
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public bool TrustUrlParameters { get { throw null; } set { } }
+
+        public bool UpdateEnabled { get { throw null; } set { } }
+
+        public int UpdateInterval { get { throw null; } set { } }
+
+        public UpdateMode UpdateMode { get { throw null; } set { } }
+
+        public UpdateUnit UpdateUnit { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("CompatibleFrameworks")]
+        public CompatibleFramework[] XmlCompatibleFrameworks { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlCreateDesktopShortcut { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDeploymentUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDisallowUrlActivation { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlInstall { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlMapFileExtensions { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlMinimumRequiredVersion { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProduct { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublisher { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSuiteName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTrustUrlParameters { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateEnabled { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateInterval { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateMode { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateUnit { get { throw null; } set { } }
+
+        public override void Validate() { }
+    }
+
+    public sealed partial class FileAssociation
+    {
+        public string DefaultIcon { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public string Extension { get { throw null; } set { } }
+
+        public string ProgId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDefaultIcon { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlExtension { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProgId { get { throw null; } set { } }
+    }
+
+    public sealed partial class FileAssociationCollection : System.Collections.IEnumerable
+    {
+        internal FileAssociationCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public FileAssociation this[int index] { get { throw null; } }
+
+        public void Add(FileAssociation fileAssociation) { }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class FileReference : BaseReference
+    {
+        public FileReference() { }
+
+        public FileReference(string path) { }
+
+        public ComClass[] ComClasses { get { throw null; } }
+
+        public bool IsDataFile { get { throw null; } set { } }
+
+        public ProxyStub[] ProxyStubs { get { throw null; } }
+
+        protected internal override string SortName { get { throw null; } }
+
+        public TypeLib[] TypeLibs { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ComClasses")]
+        public ComClass[] XmlComClasses { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ProxyStubs")]
+        public ProxyStub[] XmlProxyStubs { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("TypeLibs")]
+        public TypeLib[] XmlTypeLibs { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlWriteableType { get { throw null; } set { } }
+    }
+
+    public sealed partial class FileReferenceCollection : System.Collections.IEnumerable
+    {
+        internal FileReferenceCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public FileReference this[int index] { get { throw null; } }
+
+        public FileReference Add(FileReference file) { throw null; }
+
+        public FileReference Add(string path) { throw null; }
+
+        public void Clear() { }
+
+        public FileReference FindTargetPath(string targetPath) { throw null; }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(FileReference file) { }
+    }
+
+    public partial class LauncherBuilder
+    {
+        public LauncherBuilder(string launcherPath) { }
+
+        public string LauncherPath { get { throw null; } set { } }
+
+        public Bootstrapper.BuildResults Build(string filename, string outputPath) { throw null; }
+    }
+
+    public abstract partial class Manifest
+    {
+        protected internal Manifest() { }
+
+        public AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public AssemblyReferenceCollection AssemblyReferences { get { throw null; } }
+
+        public string Description { get { throw null; } set { } }
+
+        public virtual AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public FileReferenceCollection FileReferences { get { throw null; } }
+
+        public System.IO.Stream InputStream { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public OutputMessageCollection OutputMessages { get { throw null; } }
+
+        public bool ReadOnly { get { throw null; } set { } }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("AssemblyIdentity")]
+        public AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("AssemblyReferences")]
+        public AssemblyReference[] XmlAssemblyReferences { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("FileReferences")]
+        public FileReference[] XmlFileReferences { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSchema { get { throw null; } set { } }
+
+        public void ResolveFiles() { }
+
+        public void ResolveFiles(string[] searchPaths) { }
+
+        public override string ToString() { throw null; }
+
+        public void UpdateFileInfo() { }
+
+        public void UpdateFileInfo(string targetFrameworkVersion) { }
+
+        public virtual void Validate() { }
+
+        protected void ValidatePlatform() { }
+    }
+
+    public static partial class ManifestReader
+    {
+        public static Manifest ReadManifest(System.IO.Stream input, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string path, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string manifestType, System.IO.Stream input, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string manifestType, string path, bool preserveStream) { throw null; }
+    }
+
+    public static partial class ManifestWriter
+    {
+        public static void WriteManifest(Manifest manifest, System.IO.Stream output) { }
+
+        public static void WriteManifest(Manifest manifest, string path, string targetframeWorkVersion) { }
+
+        public static void WriteManifest(Manifest manifest, string path) { }
+
+        public static void WriteManifest(Manifest manifest) { }
+    }
+
+    public sealed partial class OutputMessage
+    {
+        internal OutputMessage() { }
+
+        public string Name { get { throw null; } }
+
+        public string Text { get { throw null; } }
+
+        public OutputMessageType Type { get { throw null; } }
+
+        public string[] GetArguments() { throw null; }
+    }
+
+    public sealed partial class OutputMessageCollection : System.Collections.IEnumerable
+    {
+        internal OutputMessageCollection() { }
+
+        public int ErrorCount { get { throw null; } }
+
+        public OutputMessage this[int index] { get { throw null; } }
+
+        public int WarningCount { get { throw null; } }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public enum OutputMessageType
+    {
+        Info = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class ProxyStub
+    {
+        public string BaseInterface { get { throw null; } }
+
+        public string IID { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string NumMethods { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlBaseInterface { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIID { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlNumMethods { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+
+    public static partial class SecurityUtilities
+    {
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Uri timestampUrl, string path) { }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(string certPath, System.Security.SecureString certPassword, System.Uri timestampUrl, string path) { }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier, bool disallowMansignTimestampFallback) { }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier) { }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion) { }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path) { }
+    }
+
+    public sealed partial class TrustInfo
+    {
+        public bool HasUnmanagedCodePermission { get { throw null; } }
+
+        public bool IsFullTrust { get { throw null; } }
+
+        public bool PreserveFullTrustPermissionSet { get { throw null; } set { } }
+
+        public string SameSiteAccess { get { throw null; } set { } }
+
+        public void Clear() { }
+
+        public void Read(System.IO.Stream input) { }
+
+        public void Read(string path) { }
+
+        public void ReadManifest(System.IO.Stream input) { }
+
+        public void ReadManifest(string path) { }
+
+        public override string ToString() { throw null; }
+
+        public void Write(System.IO.Stream output) { }
+
+        public void Write(string path) { }
+
+        public void WriteManifest(System.IO.Stream input, System.IO.Stream output) { }
+
+        public void WriteManifest(System.IO.Stream output) { }
+
+        public void WriteManifest(string path) { }
+    }
+
+    public partial class TypeLib
+    {
+        public string Flags { get { throw null; } }
+
+        public string HelpDirectory { get { throw null; } }
+
+        public string ResourceId { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        public string Version { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlFlags { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHelpDirectory { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlResourceId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+
+    public enum UpdateMode
+    {
+        Background = 0,
+        Foreground = 1
+    }
+
+    public enum UpdateUnit
+    {
+        Hours = 0,
+        Days = 1,
+        Weeks = 2
+    }
+
+    public partial class WindowClass
+    {
+        public WindowClass() { }
+
+        public WindowClass(string name, bool versioned) { }
+
+        public string Name { get { throw null; } }
+
+        public bool Versioned { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersioned { get { throw null; } set { } }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Hosting
+{
+    public partial interface IAnalyzerHostObject
+    {
+        bool SetAdditionalFiles(Framework.ITaskItem[] additionalFiles);
+        bool SetAnalyzers(Framework.ITaskItem[] analyzers);
+        bool SetRuleSet(string ruleSetFile);
+    }
+
+    public partial interface ICscHostObject : Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        bool EndInitialization(out string errorMessage, out int errorCode);
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetAllowUnsafeBlocks(bool allowUnsafeBlocks);
+        bool SetBaseAddress(string baseAddress);
+        bool SetCheckForOverflowUnderflow(bool checkForOverflowUnderflow);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySignExplicitlySet, bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetEmitDebugInformation(bool emitDebugInformation);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateFullPaths(bool generateFullPaths);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLangVersion(string langVersion);
+        bool SetLinkResources(Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string targetType, string mainEntryPoint);
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetOptimize(bool optimize);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPdbFile(string pdbFile);
+        bool SetPlatform(string platform);
+        bool SetReferences(Framework.ITaskItem[] references);
+        bool SetResources(Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Framework.ITaskItem[] responseFiles);
+        bool SetSources(Framework.ITaskItem[] sources);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningLevel(int warningLevel);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+
+    public partial interface ICscHostObject2 : ICscHostObject, Framework.ITaskHost
+    {
+        bool SetWin32Manifest(string win32Manifest);
+    }
+
+    public partial interface ICscHostObject3 : ICscHostObject2, ICscHostObject, Framework.ITaskHost
+    {
+        bool SetApplicationConfiguration(string applicationConfiguration);
+    }
+
+    public partial interface ICscHostObject4 : ICscHostObject3, ICscHostObject2, ICscHostObject, Framework.ITaskHost
+    {
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+
+    public partial interface IVbcHostObject : Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        void EndInitialization();
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetBaseAddress(string targetType, string baseAddress);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(bool emitDebugInformation, string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateDocumentation(bool generateDocumentation);
+        bool SetImports(Framework.ITaskItem[] importsList);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLinkResources(Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string mainEntryPoint);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetNoWarnings(bool noWarnings);
+        bool SetOptimize(bool optimize);
+        bool SetOptionCompare(string optionCompare);
+        bool SetOptionExplicit(bool optionExplicit);
+        bool SetOptionStrict(bool optionStrict);
+        bool SetOptionStrictType(string optionStrictType);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPlatform(string platform);
+        bool SetReferences(Framework.ITaskItem[] references);
+        bool SetRemoveIntegerChecks(bool removeIntegerChecks);
+        bool SetResources(Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Framework.ITaskItem[] responseFiles);
+        bool SetRootNamespace(string rootNamespace);
+        bool SetSdkPath(string sdkPath);
+        bool SetSources(Framework.ITaskItem[] sources);
+        bool SetTargetCompactFramework(bool targetCompactFramework);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+
+    public partial interface IVbcHostObject2 : IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetOptionInfer(bool optionInfer);
+        bool SetWin32Manifest(string win32Manifest);
+    }
+
+    public partial interface IVbcHostObject3 : IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetLanguageVersion(string languageVersion);
+    }
+
+    public partial interface IVbcHostObject4 : IVbcHostObject3, IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetVBRuntime(string VBRuntime);
+    }
+
+    public partial interface IVbcHostObject5 : IVbcHostObject4, IVbcHostObject3, IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        int CompileAsync(out nint buildSucceededEvent, out nint buildFailedEvent);
+        int EndCompile(bool buildSuccess);
+        IVbcHostObjectFreeThreaded GetFreeThreadedHostObject();
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+
+    public partial interface IVbcHostObjectFreeThreaded
+    {
+        bool Compile();
+    }
+}
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    public sealed partial class RSAPKCS1SHA256SignatureDescription : Security.Cryptography.SignatureDescription
+    {
+        public override Security.Cryptography.AsymmetricSignatureDeformatter CreateDeformatter(Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+
+        public override Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/ref/netstandard2.0/Microsoft.Build.Tasks.Core.cs
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.5.0/ref/netstandard2.0/Microsoft.Build.Tasks.Core.cs
@@ -1,0 +1,3165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Tasks.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Tasks.Core.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Tasks.Core.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Tasks
+{
+    public partial class AssignCulture : TaskExtension
+    {
+        public AssignCulture() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFilesWithCulture { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFilesWithNoCulture { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CultureNeutralAssignedFiles { get { throw null; } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignLinkMetadata : TaskExtension
+    {
+        public AssignLinkMetadata() { }
+
+        public Framework.ITaskItem[] Items { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputItems { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignProjectConfiguration : ResolveProjectBase
+    {
+        public bool AddSyntheticProjectReferencesForSolutionDependencies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedProjects { get { throw null; } set { } }
+
+        public string CurrentProject { get { throw null; } set { } }
+
+        public string CurrentProjectConfiguration { get { throw null; } set { } }
+
+        public string CurrentProjectPlatform { get { throw null; } set { } }
+
+        public string DefaultToVcxPlatformMapping { get { throw null; } set { } }
+
+        public bool OnlyReferenceAndBuildProjectsEnabledInSolutionConfiguration { get { throw null; } set { } }
+
+        public string OutputType { get { throw null; } set { } }
+
+        public bool ResolveConfigurationPlatformUsingMappings { get { throw null; } set { } }
+
+        public bool ShouldUnsetParentConfigurationAndPlatform { get { throw null; } set { } }
+
+        public string SolutionConfigurationContents { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnassignedProjects { get { throw null; } set { } }
+
+        public string VcxToDefaultPlatformMapping { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class AssignTargetPath : TaskExtension
+    {
+        public AssignTargetPath() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AssignedFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string RootFolder { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [Framework.RunInMTA]
+    public partial class CallTarget : TaskExtension
+    {
+        public CallTarget() { }
+
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+
+        public string[] Targets { get { throw null; } set { } }
+
+        public bool UseResultsCache { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Obsolete("The CodeTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
+    public sealed partial class CodeTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public partial class CombinePath : TaskExtension
+    {
+        public CombinePath() { }
+
+        public string BasePath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CombinedPaths { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Paths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CombineTargetFrameworkInfoProperties : TaskExtension
+    {
+        public CombineTargetFrameworkInfoProperties() { }
+
+        public Framework.ITaskItem[] PropertiesAndValues { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string Result { get { throw null; } set { } }
+
+        public string RootElementName { get { throw null; } set { } }
+
+        public bool UseAttributeForTargetFrameworkInfoPropertyNames { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CombineXmlElements : TaskExtension
+    {
+        public CombineXmlElements() { }
+
+        [Framework.Output]
+        public string Result { get { throw null; } set { } }
+
+        public string RootElementName { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] XmlElements { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CommandLineBuilderExtension : Utilities.CommandLineBuilder
+    {
+        public CommandLineBuilderExtension() { }
+
+        public CommandLineBuilderExtension(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
+
+        protected string GetQuotedText(string unquotedText) { throw null; }
+    }
+
+    public partial class ConvertToAbsolutePath : TaskExtension
+    {
+        public ConvertToAbsolutePath() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] AbsolutePaths { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Paths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Copy : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Copy() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopiedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        public bool ErrorIfLinkFails { get { throw null; } set { } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        public int Retries { get { throw null; } set { } }
+
+        public int RetryDelayMilliseconds { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public bool UseHardlinksIfPossible { get { throw null; } set { } }
+
+        public bool UseSymboliclinksIfPossible { get { throw null; } set { } }
+
+        [Framework.Output]
+        public bool WroteAtLeastOneFile { get { throw null; } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CreateCSharpManifestResourceName : CreateManifestResourceName
+    {
+        protected override string SourceFileExtension { get { throw null; } }
+
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+
+    public partial class CreateItem : TaskExtension
+    {
+        public CreateItem() { }
+
+        public string[] AdditionalMetadata { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Exclude { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Include { get { throw null; } set { } }
+
+        public bool PreserveExistingMetadata { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class CreateManifestResourceName : TaskExtension
+    {
+        protected System.Collections.Generic.Dictionary<string, Framework.ITaskItem> itemSpecToTaskitem;
+        protected CreateManifestResourceName() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ManifestResourceNames { get { throw null; } }
+
+        public bool PrependCultureAsDirectory { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ResourceFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
+
+        public string RootNamespace { get { throw null; } set { } }
+
+        protected abstract string SourceFileExtension { get; }
+
+        public bool UseDependentUponConvention { get { throw null; } set { } }
+
+        protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
+        public override bool Execute() { throw null; }
+
+        protected abstract bool IsSourceFile(string fileName);
+        public static string MakeValidEverettIdentifier(string name) { throw null; }
+    }
+
+    public partial class CreateProperty : TaskExtension
+    {
+        public CreateProperty() { }
+
+        [Framework.Output]
+        public string[] Value { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string[] ValueSetByTask { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class CreateVisualBasicManifestResourceName : CreateManifestResourceName
+    {
+        protected override string SourceFileExtension { get { throw null; } }
+
+        protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
+
+        protected override bool IsSourceFile(string fileName) { throw null; }
+    }
+
+    public partial class Delete : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Delete() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DeletedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool TreatErrorsAsWarnings { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class DownloadFile : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public DownloadFile() { }
+
+        public Framework.ITaskItem DestinationFileName { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem DownloadedFile { get { throw null; } set { } }
+
+        public int Retries { get { throw null; } set { } }
+
+        public int RetryDelayMilliseconds { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string SourceUrl { get { throw null; } set { } }
+
+        public int Timeout { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Error : TaskExtension
+    {
+        public Error() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string HelpLink { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ErrorFromResources : TaskExtension
+    {
+        public ErrorFromResources() { }
+
+        public string[] Arguments { get { throw null; } set { } }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Resource { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Exec : ToolTaskExtension
+    {
+        public Exec() { }
+
+        [Framework.Required]
+        public string Command { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ConsoleOutput { get { throw null; } }
+
+        public bool ConsoleToMSBuild { get { throw null; } set { } }
+
+        public string CustomErrorRegularExpression { get { throw null; } set { } }
+
+        public string CustomWarningRegularExpression { get { throw null; } set { } }
+
+        public bool IgnoreExitCode { get { throw null; } set { } }
+
+        public bool IgnoreStandardErrorWarningFormat { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Outputs { get { throw null; } set { } }
+
+        protected override System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+
+        protected override Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+
+        protected override System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+
+        protected override Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+
+        [Framework.Output]
+        public string StdErrEncoding { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StdOutEncoding { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        public string WorkingDirectory { get { throw null; } set { } }
+
+        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+
+        protected override string GetWorkingDirectory() { throw null; }
+
+        protected override bool HandleTaskExecutionErrors() { throw null; }
+
+        protected override void LogEventsFromTextOutput(string singleLine, Framework.MessageImportance messageImportance) { }
+
+        protected override void LogPathToTool(string toolName, string pathToTool) { }
+
+        protected override void LogToolCommand(string message) { }
+
+        protected override bool ValidateParameters() { throw null; }
+    }
+
+    public partial struct ExtractedClassName
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public bool IsInsideConditionalBlock { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public partial class FindAppConfigFile : TaskExtension
+    {
+        public FindAppConfigFile() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem AppConfigFile { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] PrimaryList { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SecondaryList { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindInList : TaskExtension
+    {
+        public FindInList() { }
+
+        public bool CaseSensitive { get { throw null; } set { } }
+
+        public bool FindLastMatch { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem ItemFound { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string ItemSpecToFind { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] List { get { throw null; } set { } }
+
+        public bool MatchFileNameOnly { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindInvalidProjectReferences : TaskExtension
+    {
+        public FindInvalidProjectReferences() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InvalidReferences { get { throw null; } }
+
+        public Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class FindUnderPath : TaskExtension
+    {
+        public FindUnderPath() { }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutOfPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem Path { get { throw null; } set { } }
+
+        public bool UpdateToAbsolutePaths { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class FormatUrl : TaskExtension
+    {
+        public FormatUrl() { }
+
+        public string InputUrl { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string OutputUrl { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class FormatVersion : TaskExtension
+    {
+        public FormatVersion() { }
+
+        public string FormatType { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string OutputVersion { get { throw null; } set { } }
+
+        public int Revision { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class GenerateApplicationManifest : GenerateManifestBase
+    {
+        public string ClrVersion { get { throw null; } set { } }
+
+        public Framework.ITaskItem ConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Dependencies { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] FileAssociations { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool HostInBrowser { get { throw null; } set { } }
+
+        public Framework.ITaskItem IconFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] IsolatedComReferences { get { throw null; } set { } }
+
+        public string ManifestType { get { throw null; } set { } }
+
+        public string OSVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public bool RequiresMinimumFramework35SP1 { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkProfile { get { throw null; } set { } }
+
+        public string TargetFrameworkSubset { get { throw null; } set { } }
+
+        public Framework.ITaskItem TrustInfoFile { get { throw null; } set { } }
+
+        public bool UseApplicationTrust { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override System.Type GetObjectType() { throw null; }
+
+        protected override bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected override bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+
+    public partial class GenerateBindingRedirects : TaskExtension
+    {
+        public GenerateBindingRedirects() { }
+
+        public Framework.ITaskItem AppConfigFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputAppConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] SuggestedRedirects { get { throw null; } set { } }
+
+        public string TargetName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class GenerateDeploymentManifest : GenerateManifestBase
+    {
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+
+        public string DeploymentUrl { get { throw null; } set { } }
+
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public bool Install { get { throw null; } set { } }
+
+        public bool MapFileExtensions { get { throw null; } set { } }
+
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public bool TrustUrlParameters { get { throw null; } set { } }
+
+        public bool UpdateEnabled { get { throw null; } set { } }
+
+        public int UpdateInterval { get { throw null; } set { } }
+
+        public string UpdateMode { get { throw null; } set { } }
+
+        public string UpdateUnit { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override System.Type GetObjectType() { throw null; }
+
+        protected override bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected override bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest) { throw null; }
+
+        protected internal override bool ValidateInputs() { throw null; }
+    }
+
+    public sealed partial class GenerateLauncher : TaskExtension
+    {
+        public GenerateLauncher() { }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public string LauncherPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string VisualStudioVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class GenerateManifestBase : Utilities.Task
+    {
+        public string AssemblyName { get { throw null; } set { } }
+
+        public string AssemblyVersion { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem InputManifest { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public int MaxTargetPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputManifest { get { throw null; } set { } }
+
+        public string Platform { get { throw null; } set { } }
+
+        public string TargetCulture { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddAssemblyFromItem(Framework.ITaskItem item) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddAssemblyNameFromItem(Framework.ITaskItem item, Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.AssemblyReference AddEntryPointFromItem(Framework.ITaskItem item, Deployment.ManifestUtilities.AssemblyReferenceType referenceType) { throw null; }
+
+        protected internal Deployment.ManifestUtilities.FileReference AddFileFromItem(Framework.ITaskItem item) { throw null; }
+
+        public override bool Execute() { throw null; }
+
+        protected internal Deployment.ManifestUtilities.FileReference FindFileFromItem(Framework.ITaskItem item) { throw null; }
+
+        protected abstract System.Type GetObjectType();
+        protected abstract bool OnManifestLoaded(Deployment.ManifestUtilities.Manifest manifest);
+        protected abstract bool OnManifestResolved(Deployment.ManifestUtilities.Manifest manifest);
+        protected internal virtual bool ValidateInputs() { throw null; }
+
+        protected internal virtual bool ValidateOutput() { throw null; }
+    }
+
+    [Framework.RequiredRuntime("v2.0")]
+    public sealed partial class GenerateResource : TaskExtension
+    {
+        public GenerateResource() { }
+
+        public Framework.ITaskItem[] AdditionalInputs { get { throw null; } set { } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ExcludedInputPaths { get { throw null; } set { } }
+
+        public bool ExecuteAsTool { get { throw null; } set { } }
+
+        public bool ExtractResWFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] FilesWritten { get { throw null; } }
+
+        public bool MinimalRebuildFromTracking { get { throw null; } set { } }
+
+        public bool NeverLockTypeAssemblies { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputResources { get { throw null; } set { } }
+
+        public bool PublicClass { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] References { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        [Framework.Output]
+        public Framework.ITaskItem[] Sources { get { throw null; } set { } }
+
+        public Framework.ITaskItem StateFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StronglyTypedClassName { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string StronglyTypedFileName { get { throw null; } set { } }
+
+        public string StronglyTypedLanguage { get { throw null; } set { } }
+
+        public string StronglyTypedManifestPrefix { get { throw null; } set { } }
+
+        public string StronglyTypedNamespace { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TLogReadFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] TLogWriteFiles { get { throw null; } }
+
+        public string ToolArchitecture { get { throw null; } set { } }
+
+        public string TrackerFrameworkPath { get { throw null; } set { } }
+
+        public string TrackerLogDirectory { get { throw null; } set { } }
+
+        public string TrackerSdkPath { get { throw null; } set { } }
+
+        public bool TrackFileAccess { get { throw null; } set { } }
+
+        public bool UsePreserializedResources { get { throw null; } set { } }
+
+        public bool UseSourcePath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetAssemblyIdentity : TaskExtension
+    {
+        public GetAssemblyIdentity() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetCompatiblePlatform : TaskExtension
+    {
+        public GetCompatiblePlatform() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] AnnotatedProjects { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[]? AssignedProjectsWithPlatform { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string CurrentProjectPlatform { get { throw null; } set { } }
+
+        public string PlatformLookupTable { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class GetFileHash : TaskExtension
+    {
+        public GetFileHash() { }
+
+        public string Algorithm { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string Hash { get { throw null; } set { } }
+
+        public string HashEncoding { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Items { get { throw null; } set { } }
+
+        public string MetadataName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetFrameworkPath : TaskExtension
+    {
+        public GetFrameworkPath() { }
+
+        [Framework.Output]
+        public string FrameworkVersion11Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion20Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion30Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion35Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion40Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion451Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion452Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion45Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion461Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion462Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion46Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion471Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion472Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion47Path { get { throw null; } }
+
+        [Framework.Output]
+        public string FrameworkVersion48Path { get { throw null; } }
+
+        [Framework.Output]
+        public string Path { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetInstalledSDKLocations : TaskExtension
+    {
+        public GetInstalledSDKLocations() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
+
+        public string[] SDKDirectoryRoots { get { throw null; } set { } }
+
+        public string[] SDKExtensionDirectoryRoots { get { throw null; } set { } }
+
+        public string SDKRegistryRoot { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public bool WarnWhenNoSDKsFound { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetReferenceAssemblyPaths : TaskExtension
+    {
+        public GetReferenceAssemblyPaths() { }
+
+        public bool BypassFrameworkInstallChecks { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string[] FullFrameworkReferenceAssemblyPaths { get { throw null; } }
+
+        [Framework.Output]
+        public string[] ReferenceAssemblyPaths { get { throw null; } }
+
+        public string RootPath { get { throw null; } set { } }
+
+        public bool SuppressNotFoundError { get { throw null; } set { } }
+
+        public string TargetFrameworkFallbackSearchPaths { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string TargetFrameworkMonikerDisplayName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class GetSDKReferenceFiles : TaskExtension
+    {
+        public GetSDKReferenceFiles() { }
+
+        public string CacheFileFolderPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+
+        public bool LogCacheFileExceptions { get { throw null; } set { } }
+
+        public bool LogRedistConflictBetweenSDKsAsWarning { get { throw null; } set { } }
+
+        public bool LogRedistConflictWithinSDKAsWarning { get { throw null; } set { } }
+
+        public bool LogRedistFilesList { get { throw null; } set { } }
+
+        public bool LogReferenceConflictBetweenSDKsAsWarning { get { throw null; } set { } }
+
+        public bool LogReferenceConflictWithinSDKAsWarning { get { throw null; } set { } }
+
+        public bool LogReferencesList { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RedistFiles { get { throw null; } }
+
+        public string[] ReferenceExtensions { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] References { get { throw null; } }
+
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public string TargetSDKIdentifier { get { throw null; } set { } }
+
+        public string TargetSDKVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Hash : TaskExtension
+    {
+        public Hash() { }
+
+        [Framework.Output]
+        public string HashResult { get { throw null; } set { } }
+
+        public bool IgnoreCase { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial interface IFixedTypeInfo
+    {
+        void AddressOfMember(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, out System.IntPtr ppv);
+        void CreateInstance(object pUnkOuter, ref System.Guid riid, out object ppvObj);
+        void GetContainingTypeLib(out System.Runtime.InteropServices.ComTypes.ITypeLib ppTLB, out int pIndex);
+        void GetDllEntry(int memid, System.Runtime.InteropServices.ComTypes.INVOKEKIND invKind, System.IntPtr pBstrDllName, System.IntPtr pBstrName, System.IntPtr pwOrdinal);
+        void GetDocumentation(int index, out string strName, out string strDocString, out int dwHelpContext, out string strHelpFile);
+        void GetFuncDesc(int index, out System.IntPtr ppFuncDesc);
+        void GetIDsOfNames(string[] rgszNames, int cNames, int[] pMemId);
+        void GetImplTypeFlags(int index, out System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS pImplTypeFlags);
+        void GetMops(int memid, out string pBstrMops);
+        void GetNames(int memid, string[] rgBstrNames, int cMaxNames, out int pcNames);
+        void GetRefTypeInfo(System.IntPtr hRef, out IFixedTypeInfo ppTI);
+        void GetRefTypeOfImplType(int index, out System.IntPtr href);
+        void GetTypeAttr(out System.IntPtr ppTypeAttr);
+        void GetTypeComp(out System.Runtime.InteropServices.ComTypes.ITypeComp ppTComp);
+        void GetVarDesc(int index, out System.IntPtr ppVarDesc);
+        void Invoke(object pvInstance, int memid, short wFlags, ref System.Runtime.InteropServices.ComTypes.DISPPARAMS pDispParams, System.IntPtr pVarResult, System.IntPtr pExcepInfo, out int puArgErr);
+        void ReleaseFuncDesc(System.IntPtr pFuncDesc);
+        void ReleaseTypeAttr(System.IntPtr pTypeAttr);
+        void ReleaseVarDesc(System.IntPtr pVarDesc);
+    }
+
+    public partial class LC : ToolTaskExtension
+    {
+        public LC() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem LicenseTarget { get { throw null; } set { } }
+
+        public bool NoLogo { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputLicense { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ReferencedAssemblies { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Sources { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected internal override void AddResponseFileCommands(CommandLineBuilderExtension commandLine) { }
+
+        public override bool Execute() { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+
+        protected override bool ValidateParameters() { throw null; }
+    }
+
+    public partial class MakeDir : TaskExtension
+    {
+        public MakeDir() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Directories { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DirectoriesCreated { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Message : TaskExtension
+    {
+        public Message() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string Importance { get { throw null; } set { } }
+
+        public bool IsCritical { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class Move : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Move() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] DestinationFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] MovedFiles { get { throw null; } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [Framework.RunInMTA]
+    public partial class MSBuild : TaskExtension
+    {
+        public MSBuild() { }
+
+        public bool BuildInParallel { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Projects { get { throw null; } set { } }
+
+        public string[] Properties { get { throw null; } set { } }
+
+        public bool RebaseOutputs { get { throw null; } set { } }
+
+        public string RemoveProperties { get { throw null; } set { } }
+
+        public bool RunEachTargetSeparately { get { throw null; } set { } }
+
+        public string SkipNonexistentProjects { get { throw null; } set { } }
+
+        public bool StopOnFirstFailure { get { throw null; } set { } }
+
+        public string[] TargetAndPropertyListSeparators { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TargetOutputs { get { throw null; } }
+
+        public string[] Targets { get { throw null; } set { } }
+
+        public string ToolsVersion { get { throw null; } set { } }
+
+        public bool UnloadProjectsOnCompletion { get { throw null; } set { } }
+
+        public bool UseResultsCache { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ReadLinesFromFile : TaskExtension
+    {
+        public ReadLinesFromFile() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem File { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Lines { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class RemoveDir : TaskExtension
+    {
+        public RemoveDir() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Directories { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RemovedDirectories { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class RemoveDuplicates : TaskExtension
+    {
+        public RemoveDuplicates() { }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Filtered { get { throw null; } set { } }
+
+        [Framework.Output]
+        public bool HadAnyDuplicates { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Inputs { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveAssemblyReference : TaskExtension
+    {
+        public ResolveAssemblyReference() { }
+
+        public string[] AllowedAssemblyExtensions { get { throw null; } set { } }
+
+        public string[] AllowedRelatedFileExtensions { get { throw null; } set { } }
+
+        public string AppConfigFile { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
+
+        public string AssemblyInformationCacheOutputPath { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] AssemblyInformationCachePaths { get { throw null; } set { } }
+
+        public bool AutoUnify { get { throw null; } set { } }
+
+        public string[] CandidateAssemblyFiles { get { throw null; } set { } }
+
+        public bool CopyLocalDependenciesWhenParentReferenceInGac { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
+
+        [Framework.Output]
+        public string DependsOnNETStandard { get { throw null; } }
+
+        [Framework.Output]
+        public string DependsOnSystemRuntime { get { throw null; } }
+
+        public bool DoNotCopyLocalIfInGac { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] FilesWritten { get { throw null; } set { } }
+
+        public bool FindDependencies { get { throw null; } set { } }
+
+        public bool FindDependenciesOfExternallyResolvedReferences { get { throw null; } set { } }
+
+        public bool FindRelatedFiles { get { throw null; } set { } }
+
+        public bool FindSatellites { get { throw null; } set { } }
+
+        public bool FindSerializationAssemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] FullFrameworkAssemblyTables { get { throw null; } set { } }
+
+        public string[] FullFrameworkFolders { get { throw null; } set { } }
+
+        public string[] FullTargetFrameworkSubsetNames { get { throw null; } set { } }
+
+        public bool IgnoreDefaultInstalledAssemblySubsetTables { get { throw null; } set { } }
+
+        public bool IgnoreDefaultInstalledAssemblyTables { get { throw null; } set { } }
+
+        public bool IgnoreTargetFrameworkAttributeVersionMismatch { get { throw null; } set { } }
+
+        public bool IgnoreVersionForFrameworkReferences { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] InstalledAssemblySubsetTables { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] InstalledAssemblyTables { get { throw null; } set { } }
+
+        public string[] LatestTargetFrameworkDirectories { get { throw null; } set { } }
+
+        public bool OutputUnresolvedAssemblyConflicts { get { throw null; } set { } }
+
+        public string ProfileName { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] RelatedFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedDependencyFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedFiles { get { throw null; } }
+
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SatelliteFiles { get { throw null; } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ScatterFiles { get { throw null; } }
+
+        [Framework.Required]
+        public string[] SearchPaths { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SerializationAssemblyFiles { get { throw null; } }
+
+        public bool Silent { get { throw null; } set { } }
+
+        public string StateFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SuggestedRedirects { get { throw null; } }
+
+        public bool SupportsBindingRedirectGeneration { get { throw null; } set { } }
+
+        public string TargetedRuntimeVersion { get { throw null; } set { } }
+
+        public string[] TargetFrameworkDirectories { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public string TargetFrameworkMonikerDisplayName { get { throw null; } set { } }
+
+        public string[] TargetFrameworkSubsets { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnresolvedAssemblyConflicts { get { throw null; } }
+
+        public bool UnresolveFrameworkAssembliesFromHigherFrameworks { get { throw null; } set { } }
+
+        public string WarnOrErrorOnTargetArchitectureMismatch { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveCodeAnalysisRuleSet : TaskExtension
+    {
+        public ResolveCodeAnalysisRuleSet() { }
+
+        public string CodeAnalysisRuleSet { get { throw null; } set { } }
+
+        public string[] CodeAnalysisRuleSetDirectories { get { throw null; } set { } }
+
+        public string MSBuildProjectDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveComReference : TaskExtension
+    {
+        public ResolveComReference() { }
+
+        public bool DelaySign { get { throw null; } set { } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        public bool ExecuteAsTool { get { throw null; } set { } }
+
+        public bool IncludeVersionInInteropName { get { throw null; } set { } }
+
+        public string KeyContainer { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        public bool NoClassMembers { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ResolvedAssemblyReferences { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedFiles { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedModules { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        public bool Silent { get { throw null; } set { } }
+
+        public string StateFile { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TargetProcessorArchitecture { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] TypeLibNames { get { throw null; } set { } }
+
+        public string WrapperOutputDirectory { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveKeySource : TaskExtension
+    {
+        public ResolveKeySource() { }
+
+        public int AutoClosePasswordPromptShow { get { throw null; } set { } }
+
+        public int AutoClosePasswordPromptTimeout { get { throw null; } set { } }
+
+        public string CertificateFile { get { throw null; } set { } }
+
+        public string CertificateThumbprint { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedKeyContainer { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedKeyFile { get { throw null; } set { } }
+
+        [Framework.Output]
+        public string ResolvedThumbprint { get { throw null; } set { } }
+
+        public bool ShowImportDialogDespitePreviousFailures { get { throw null; } set { } }
+
+        public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ResolveManifestFiles : TaskExtension
+    {
+        public ResolveManifestFiles() { }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool IsSelfContainedPublish { get { throw null; } set { } }
+
+        public bool IsSingleFilePublish { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputAssemblies { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputDeploymentManifestEntryPoint { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] RuntimePackAssets { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
+
+        public bool SigningManifests { get { throw null; } set { } }
+
+        public string TargetCulture { get { throw null; } set { } }
+
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class ResolveNonMSBuildProjectOutput : ResolveProjectBase
+    {
+        public string PreresolvedProjectOutputs { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedOutputPaths { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class ResolveProjectBase : TaskExtension
+    {
+        protected ResolveProjectBase() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] ProjectReferences { get { throw null; } set { } }
+
+        protected void AddSyntheticProjectReferences(string currentProjectAbsolutePath) { }
+
+        protected System.Xml.XmlElement GetProjectElement(Framework.ITaskItem projectRef) { throw null; }
+
+        protected string GetProjectItem(Framework.ITaskItem projectRef) { throw null; }
+    }
+
+    public partial class ResolveSDKReference : TaskExtension
+    {
+        public ResolveSDKReference() { }
+
+        public Framework.ITaskItem[] DisallowedSDKDependencies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
+
+        public bool LogResolutionErrorsAsWarnings { get { throw null; } set { } }
+
+        public bool Prefer32Bit { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string ProjectName { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] References { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] ResolvedSDKReferences { get { throw null; } }
+
+        public Framework.ITaskItem[] RuntimeReferenceOnlySDKDependencies { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SDKReferences { get { throw null; } set { } }
+
+        public string TargetedSDKArchitecture { get { throw null; } set { } }
+
+        public string TargetedSDKConfiguration { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformIdentifier { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string TargetPlatformVersion { get { throw null; } set { } }
+
+        public bool WarnOnMissingPlatformVersion { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class RoslynCodeTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public sealed partial class SetRidAgnosticValueForProjects : TaskExtension
+    {
+        public SetRidAgnosticValueForProjects() { }
+
+        public Framework.ITaskItem[] Projects { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] UpdatedProjects { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class SGen : ToolTaskExtension
+    {
+        public SGen() { }
+
+        [Framework.Required]
+        public string BuildAssemblyName { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string BuildAssemblyPath { get { throw null; } set { } }
+
+        public bool DelaySign { get { throw null; } set { } }
+
+        public string KeyContainer { get { throw null; } set { } }
+
+        public string KeyFile { get { throw null; } set { } }
+
+        public string Platform { get { throw null; } set { } }
+
+        public string[] References { get { throw null; } set { } }
+
+        public string SdkToolsPath { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] SerializationAssembly { get { throw null; } set { } }
+
+        public string SerializationAssemblyName { get { throw null; } }
+
+        [Framework.Required]
+        public bool ShouldGenerateSerializer { get { throw null; } set { } }
+
+        protected override string ToolName { get { throw null; } }
+
+        public string[] Types { get { throw null; } set { } }
+
+        public bool UseKeep { get { throw null; } set { } }
+
+        [Framework.Required]
+        public bool UseProxyTypes { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+
+        protected override string GenerateFullPathToTool() { throw null; }
+    }
+
+    public sealed partial class SignFile : Utilities.Task
+    {
+        [Framework.Required]
+        public string CertificateThumbprint { get { throw null; } set { } }
+
+        public bool DisallowMansignTimestampFallback { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem SigningTarget { get { throw null; } set { } }
+
+        public string TargetFrameworkIdentifier { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public string TimestampUrl { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class TaskExtension : Utilities.Task
+    {
+        internal TaskExtension() { }
+
+        public new Utilities.TaskLoggingHelper Log { get { throw null; } }
+    }
+
+    public partial class TaskLoggingHelperExtension : Utilities.TaskLoggingHelper
+    {
+        public TaskLoggingHelperExtension(Framework.ITask taskInstance, System.Resources.ResourceManager primaryResources, System.Resources.ResourceManager sharedResources, string helpKeywordPrefix) : base(default!) { }
+
+        public System.Resources.ResourceManager TaskSharedResources { get { throw null; } set { } }
+
+        public override string FormatResourceString(string resourceName, params object[] args) { throw null; }
+    }
+
+    public sealed partial class Telemetry : TaskExtension
+    {
+        public Telemetry() { }
+
+        public string EventData { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string EventName { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public abstract partial class ToolTaskExtension : Utilities.ToolTask
+    {
+        internal ToolTaskExtension() { }
+
+        protected internal System.Collections.Hashtable Bag { get { throw null; } }
+
+        protected override bool HasLoggedErrors { get { throw null; } }
+
+        public Utilities.TaskLoggingHelper Log { get { throw null; } }
+
+        protected virtual bool UseNewLineSeparatorInResponseFile { get { throw null; } }
+
+        protected internal virtual void AddCommandLineCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected internal virtual void AddResponseFileCommands(CommandLineBuilderExtension commandLine) { }
+
+        protected override string GenerateCommandLineCommands() { throw null; }
+
+        protected override string GenerateResponseFileCommands() { throw null; }
+
+        protected internal bool GetBoolParameterWithDefault(string parameterName, bool defaultValue) { throw null; }
+
+        protected internal int GetIntParameterWithDefault(string parameterName, int defaultValue) { throw null; }
+    }
+
+    public partial class Touch : TaskExtension
+    {
+        public Touch() { }
+
+        public bool AlwaysCreate { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] Files { get { throw null; } set { } }
+
+        public bool ForceTouch { get { throw null; } set { } }
+
+        public string Time { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Unzip : TaskExtension, Framework.ICancelableTask, Framework.ITask
+    {
+        public Unzip() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFolder { get { throw null; } set { } }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Include { get { throw null; } set { } }
+
+        public bool OverwriteReadOnlyFiles { get { throw null; } set { } }
+
+        public bool SkipUnchangedFiles { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] SourceFiles { get { throw null; } set { } }
+
+        public void Cancel() { }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class VerifyFileHash : TaskExtension
+    {
+        public VerifyFileHash() { }
+
+        public string Algorithm { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string File { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Hash { get { throw null; } set { } }
+
+        public string HashEncoding { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class Warning : TaskExtension
+    {
+        public Warning() { }
+
+        public string Code { get { throw null; } set { } }
+
+        public string File { get { throw null; } set { } }
+
+        public string HelpKeyword { get { throw null; } set { } }
+
+        public string HelpLink { get { throw null; } set { } }
+
+        public string Text { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class WriteCodeFragment : TaskExtension
+    {
+        public WriteCodeFragment() { }
+
+        public Framework.ITaskItem[] AssemblyAttributes { get { throw null; } set { } }
+
+        [Framework.Required]
+        public string Language { get { throw null; } set { } }
+
+        public Framework.ITaskItem OutputDirectory { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem OutputFile { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class WriteLinesToFile : TaskExtension
+    {
+        public WriteLinesToFile() { }
+
+        public string Encoding { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem File { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] Lines { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        public bool WriteOnlyWhenDifferent { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    [System.Obsolete("The XamlTaskFactory is not supported on .NET Core.  This class is included so that users receive run-time errors and should not be used for any other purpose.", true)]
+    public sealed partial class XamlTaskFactory : Framework.ITaskFactory
+    {
+        public string FactoryName { get { throw null; } }
+
+        public System.Type TaskType { get { throw null; } }
+
+        public void CleanupTask(Framework.ITask task) { }
+
+        public Framework.ITask CreateTask(Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+
+        public Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
+
+        public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Framework.TaskPropertyInfo> parameterGroup, string taskBody, Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
+    }
+
+    public partial class XmlPeek : TaskExtension
+    {
+        public XmlPeek() { }
+
+        public string Namespaces { get { throw null; } set { } }
+
+        public bool ProhibitDtd { get { throw null; } set { } }
+
+        public string Query { get { throw null; } set { } }
+
+        [Framework.Output]
+        public Framework.ITaskItem[] Result { get { throw null; } }
+
+        public string XmlContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class XmlPoke : TaskExtension
+    {
+        public XmlPoke() { }
+
+        public string Namespaces { get { throw null; } set { } }
+
+        public string Query { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem Value { get { throw null; } set { } }
+
+        public Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public partial class XslTransformation : TaskExtension
+    {
+        public XslTransformation() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem[] OutputPaths { get { throw null; } set { } }
+
+        public string Parameters { get { throw null; } set { } }
+
+        public bool PreserveWhitespace { get { throw null; } set { } }
+
+        public bool UseTrustedSettings { get { throw null; } set { } }
+
+        public string XmlContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem[] XmlInputPaths { get { throw null; } set { } }
+
+        public Framework.ITaskItem XslCompiledDllPath { get { throw null; } set { } }
+
+        public string XslContent { get { throw null; } set { } }
+
+        public Framework.ITaskItem XslInputPath { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+
+    public sealed partial class ZipDirectory : TaskExtension
+    {
+        public ZipDirectory() { }
+
+        [Framework.Required]
+        public Framework.ITaskItem DestinationFile { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        [Framework.Required]
+        public Framework.ITaskItem SourceDirectory { get { throw null; } set { } }
+
+        public override bool Execute() { throw null; }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
+{
+    public partial class BootstrapperBuilder : IBootstrapperBuilder
+    {
+        public BootstrapperBuilder() { }
+
+        public BootstrapperBuilder(string visualStudioVersion) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public ProductCollection Products { get { throw null; } }
+
+        public BuildResults Build(BuildSettings settings) { throw null; }
+
+        public string[] GetOutputFolders(string[] productCodes, string culture, string fallbackCulture, ComponentsLocation componentsLocation) { throw null; }
+
+        public static string XmlToConfigurationFile(System.Xml.XmlNode input) { throw null; }
+    }
+
+    public partial class BuildMessage : IBuildMessage
+    {
+        internal BuildMessage() { }
+
+        public int HelpId { get { throw null; } }
+
+        public string HelpKeyword { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public BuildMessageSeverity Severity { get { throw null; } }
+    }
+
+    public enum BuildMessageSeverity
+    {
+        Info = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class BuildResults : IBuildResults
+    {
+        internal BuildResults() { }
+
+        public string[] ComponentFiles { get { throw null; } }
+
+        public string KeyFile { get { throw null; } }
+
+        public BuildMessage[] Messages { get { throw null; } }
+
+        public bool Succeeded { get { throw null; } }
+    }
+
+    public partial class BuildSettings : IBuildSettings
+    {
+        public string ApplicationFile { get { throw null; } set { } }
+
+        public string ApplicationName { get { throw null; } set { } }
+
+        public bool ApplicationRequiresElevation { get { throw null; } set { } }
+
+        public string ApplicationUrl { get { throw null; } set { } }
+
+        public ComponentsLocation ComponentsLocation { get { throw null; } set { } }
+
+        public string ComponentsUrl { get { throw null; } set { } }
+
+        public bool CopyComponents { get { throw null; } set { } }
+
+        public int FallbackLCID { get { throw null; } set { } }
+
+        public int LCID { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public ProductBuilderCollection ProductBuilders { get { throw null; } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public bool Validate { get { throw null; } set { } }
+    }
+
+    public enum ComponentsLocation
+    {
+        HomeSite = 0,
+        Relative = 1,
+        Absolute = 2
+    }
+
+    public partial interface IBootstrapperBuilder
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        string Path { get; set; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        ProductCollection Products { get; }
+
+        [System.Runtime.InteropServices.DispId(5)]
+        BuildResults Build(BuildSettings settings);
+    }
+
+    public partial interface IBuildMessage
+    {
+        [System.Runtime.InteropServices.DispId(4)]
+        int HelpId { get; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string HelpKeyword { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string Message { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        BuildMessageSeverity Severity { get; }
+    }
+
+    public partial interface IBuildResults
+    {
+        [System.Runtime.InteropServices.DispId(3)]
+        string[] ComponentFiles { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string KeyFile { get; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        BuildMessage[] Messages { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        bool Succeeded { get; }
+    }
+
+    public partial interface IBuildSettings
+    {
+        [System.Runtime.InteropServices.DispId(2)]
+        string ApplicationFile { get; set; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        string ApplicationName { get; set; }
+
+        [System.Runtime.InteropServices.DispId(13)]
+        bool ApplicationRequiresElevation { get; set; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string ApplicationUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(11)]
+        ComponentsLocation ComponentsLocation { get; set; }
+
+        [System.Runtime.InteropServices.DispId(4)]
+        string ComponentsUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(5)]
+        bool CopyComponents { get; set; }
+
+        [System.Runtime.InteropServices.DispId(7)]
+        int FallbackLCID { get; set; }
+
+        [System.Runtime.InteropServices.DispId(6)]
+        int LCID { get; set; }
+
+        [System.Runtime.InteropServices.DispId(8)]
+        string OutputPath { get; set; }
+
+        [System.Runtime.InteropServices.DispId(9)]
+        ProductBuilderCollection ProductBuilders { get; }
+
+        [System.Runtime.InteropServices.DispId(12)]
+        string SupportUrl { get; set; }
+
+        [System.Runtime.InteropServices.DispId(10)]
+        bool Validate { get; set; }
+    }
+
+    public partial interface IProduct
+    {
+        [System.Runtime.InteropServices.DispId(4)]
+        ProductCollection Includes { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        string Name { get; }
+
+        [System.Runtime.InteropServices.DispId(1)]
+        ProductBuilder ProductBuilder { get; }
+
+        [System.Runtime.InteropServices.DispId(3)]
+        string ProductCode { get; }
+    }
+
+    public partial interface IProductBuilder
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        Product Product { get; }
+    }
+
+    public partial interface IProductBuilderCollection
+    {
+        [System.Runtime.InteropServices.DispId(2)]
+        void Add(ProductBuilder builder);
+    }
+
+    public partial interface IProductCollection
+    {
+        [System.Runtime.InteropServices.DispId(1)]
+        int Count { get; }
+
+        [System.Runtime.InteropServices.DispId(2)]
+        Product Item(int index);
+        [System.Runtime.InteropServices.DispId(3)]
+        Product Product(string productCode);
+    }
+
+    public partial class Product : IProduct
+    {
+        public ProductCollection Includes { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public ProductBuilder ProductBuilder { get { throw null; } }
+
+        public string ProductCode { get { throw null; } }
+    }
+
+    public partial class ProductBuilder : IProductBuilder
+    {
+        internal ProductBuilder() { }
+
+        public Product Product { get { throw null; } }
+    }
+
+    public partial class ProductBuilderCollection : IProductBuilderCollection, System.Collections.IEnumerable
+    {
+        internal ProductBuilderCollection() { }
+
+        public void Add(ProductBuilder builder) { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public partial class ProductCollection : IProductCollection, System.Collections.IEnumerable
+    {
+        internal ProductCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Product Item(int index) { throw null; }
+
+        public Product Product(string productCode) { throw null; }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
+{
+    public sealed partial class ApplicationIdentity
+    {
+        public ApplicationIdentity(string url, AssemblyIdentity deployManifestIdentity, AssemblyIdentity applicationManifestIdentity) { }
+
+        public ApplicationIdentity(string url, string deployManifestPath, string applicationManifestPath) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class ApplicationManifest : AssemblyManifest
+    {
+        public ApplicationManifest() { }
+
+        public ApplicationManifest(string targetFrameworkVersion) { }
+
+        public string ConfigFile { get { throw null; } set { } }
+
+        public override AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public FileAssociationCollection FileAssociations { get { throw null; } }
+
+        public bool HostInBrowser { get { throw null; } set { } }
+
+        public string IconFile { get { throw null; } set { } }
+
+        public bool IsClickOnceManifest { get { throw null; } set { } }
+
+        public int MaxTargetPath { get { throw null; } set { } }
+
+        public string OSDescription { get { throw null; } set { } }
+
+        public string OSSupportUrl { get { throw null; } set { } }
+
+        public string OSVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkVersion { get { throw null; } set { } }
+
+        public TrustInfo TrustInfo { get { throw null; } set { } }
+
+        public bool UseApplicationTrust { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlConfigFile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("EntryPointIdentity")]
+        public AssemblyIdentity XmlEntryPointIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlEntryPointParameters { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlEntryPointPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("FileAssociations")]
+        public FileAssociation[] XmlFileAssociations { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHostInBrowser { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIconFile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsClickOnceManifest { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSBuild { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSMajor { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSMinor { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSRevision { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlOSSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProduct { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublisher { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSuiteName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUseApplicationTrust { get { throw null; } set { } }
+
+        public override void Validate() { }
+    }
+
+    public sealed partial class AssemblyIdentity
+    {
+        public AssemblyIdentity() { }
+
+        public AssemblyIdentity(AssemblyIdentity identity) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture, string type) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture, string processorArchitecture) { }
+
+        public AssemblyIdentity(string name, string version, string publicKeyToken, string culture) { }
+
+        public AssemblyIdentity(string name, string version) { }
+
+        public AssemblyIdentity(string name) { }
+
+        public string Culture { get { throw null; } set { } }
+
+        public bool IsFrameworkAssembly { get { throw null; } }
+
+        public bool IsNeutralPlatform { get { throw null; } }
+
+        public bool IsStrongName { get { throw null; } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string ProcessorArchitecture { get { throw null; } set { } }
+
+        public string PublicKeyToken { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlCulture { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProcessorArchitecture { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublicKeyToken { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlType { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+
+        public static AssemblyIdentity FromAssemblyName(string assemblyName) { throw null; }
+
+        public static AssemblyIdentity FromFile(string path) { throw null; }
+
+        public static AssemblyIdentity FromManagedAssembly(string path) { throw null; }
+
+        public static AssemblyIdentity FromManifest(string path) { throw null; }
+
+        public static AssemblyIdentity FromNativeAssembly(string path) { throw null; }
+
+        public string GetFullName(FullNameFlags flags) { throw null; }
+
+        public bool IsInFramework(string frameworkIdentifier, string frameworkVersion) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        [System.Flags]
+        public enum FullNameFlags
+        {
+            Default = 0,
+            ProcessorArchitecture = 1,
+            Type = 2,
+            All = 3
+        }
+    }
+
+    public partial class AssemblyManifest : Manifest
+    {
+        public ProxyStub[] ExternalProxyStubs { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ExternalProxyStubs")]
+        public ProxyStub[] XmlExternalProxyStubs { get { throw null; } set { } }
+    }
+
+    public sealed partial class AssemblyReference : BaseReference
+    {
+        public AssemblyReference() { }
+
+        public AssemblyReference(string path) { }
+
+        public AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+
+        public bool IsPrerequisite { get { throw null; } set { } }
+
+        public AssemblyReferenceType ReferenceType { get { throw null; } set { } }
+
+        protected internal override string SortName { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("AssemblyIdentity")]
+        public AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsNative { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsPrerequisite { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class AssemblyReferenceCollection : System.Collections.IEnumerable
+    {
+        internal AssemblyReferenceCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public AssemblyReference this[int index] { get { throw null; } }
+
+        public AssemblyReference Add(AssemblyReference assembly) { throw null; }
+
+        public AssemblyReference Add(string path) { throw null; }
+
+        public void Clear() { }
+
+        public AssemblyReference Find(AssemblyIdentity identity) { throw null; }
+
+        public AssemblyReference Find(string name) { throw null; }
+
+        public AssemblyReference FindTargetPath(string targetPath) { throw null; }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(AssemblyReference assemblyReference) { }
+    }
+
+    public enum AssemblyReferenceType
+    {
+        Unspecified = 0,
+        ClickOnceManifest = 1,
+        ManagedAssembly = 2,
+        NativeAssembly = 3
+    }
+
+    public abstract partial class BaseReference
+    {
+        protected internal BaseReference() { }
+
+        protected internal BaseReference(string path) { }
+
+        public string Group { get { throw null; } set { } }
+
+        public string Hash { get { throw null; } set { } }
+
+        public bool IsOptional { get { throw null; } set { } }
+
+        public string ResolvedPath { get { throw null; } set { } }
+
+        public long Size { get { throw null; } set { } }
+
+        protected internal abstract string SortName { get; }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        public string TargetPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlGroup { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHash { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHashAlgorithm { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIsOptional { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSize { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ComClass
+    {
+        public string ClsId { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public string ProgId { get { throw null; } }
+
+        public string ThreadingModel { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlClsId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProgId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlThreadingModel { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+
+    public sealed partial class CompatibleFramework
+    {
+        public string Profile { get { throw null; } set { } }
+
+        public string SupportedRuntime { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProfile { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportedRuntime { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+
+    public sealed partial class CompatibleFrameworkCollection : System.Collections.IEnumerable
+    {
+        internal CompatibleFrameworkCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public CompatibleFramework this[int index] { get { throw null; } }
+
+        public void Add(CompatibleFramework compatibleFramework) { }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class DeployManifest : Manifest
+    {
+        public DeployManifest() { }
+
+        public DeployManifest(string targetFrameworkMoniker) { }
+
+        public CompatibleFrameworkCollection CompatibleFrameworks { get { throw null; } }
+
+        public bool CreateDesktopShortcut { get { throw null; } set { } }
+
+        public string DeploymentUrl { get { throw null; } set { } }
+
+        public bool DisallowUrlActivation { get { throw null; } set { } }
+
+        public override AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public string ErrorReportUrl { get { throw null; } set { } }
+
+        public bool Install { get { throw null; } set { } }
+
+        public bool MapFileExtensions { get { throw null; } set { } }
+
+        public string MinimumRequiredVersion { get { throw null; } set { } }
+
+        public string Product { get { throw null; } set { } }
+
+        public string Publisher { get { throw null; } set { } }
+
+        public string SuiteName { get { throw null; } set { } }
+
+        public string SupportUrl { get { throw null; } set { } }
+
+        public string TargetFrameworkMoniker { get { throw null; } set { } }
+
+        public bool TrustUrlParameters { get { throw null; } set { } }
+
+        public bool UpdateEnabled { get { throw null; } set { } }
+
+        public int UpdateInterval { get { throw null; } set { } }
+
+        public UpdateMode UpdateMode { get { throw null; } set { } }
+
+        public UpdateUnit UpdateUnit { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("CompatibleFrameworks")]
+        public CompatibleFramework[] XmlCompatibleFrameworks { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlCreateDesktopShortcut { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDeploymentUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDisallowUrlActivation { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlErrorReportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlInstall { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlMapFileExtensions { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlMinimumRequiredVersion { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProduct { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlPublisher { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSuiteName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSupportUrl { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTrustUrlParameters { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateEnabled { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateInterval { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateMode { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlUpdateUnit { get { throw null; } set { } }
+
+        public override void Validate() { }
+    }
+
+    public sealed partial class FileAssociation
+    {
+        public string DefaultIcon { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public string Extension { get { throw null; } set { } }
+
+        public string ProgId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDefaultIcon { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlExtension { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlProgId { get { throw null; } set { } }
+    }
+
+    public sealed partial class FileAssociationCollection : System.Collections.IEnumerable
+    {
+        internal FileAssociationCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public FileAssociation this[int index] { get { throw null; } }
+
+        public void Add(FileAssociation fileAssociation) { }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class FileReference : BaseReference
+    {
+        public FileReference() { }
+
+        public FileReference(string path) { }
+
+        public ComClass[] ComClasses { get { throw null; } }
+
+        public bool IsDataFile { get { throw null; } set { } }
+
+        public ProxyStub[] ProxyStubs { get { throw null; } }
+
+        protected internal override string SortName { get { throw null; } }
+
+        public TypeLib[] TypeLibs { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ComClasses")]
+        public ComClass[] XmlComClasses { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("ProxyStubs")]
+        public ProxyStub[] XmlProxyStubs { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("TypeLibs")]
+        public TypeLib[] XmlTypeLibs { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlWriteableType { get { throw null; } set { } }
+    }
+
+    public sealed partial class FileReferenceCollection : System.Collections.IEnumerable
+    {
+        internal FileReferenceCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public FileReference this[int index] { get { throw null; } }
+
+        public FileReference Add(FileReference file) { throw null; }
+
+        public FileReference Add(string path) { throw null; }
+
+        public void Clear() { }
+
+        public FileReference FindTargetPath(string targetPath) { throw null; }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(FileReference file) { }
+    }
+
+    public partial class LauncherBuilder
+    {
+        public LauncherBuilder(string launcherPath) { }
+
+        public string LauncherPath { get { throw null; } set { } }
+
+        public Bootstrapper.BuildResults Build(string filename, string outputPath) { throw null; }
+    }
+
+    public abstract partial class Manifest
+    {
+        protected internal Manifest() { }
+
+        public AssemblyIdentity AssemblyIdentity { get { throw null; } set { } }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public AssemblyReferenceCollection AssemblyReferences { get { throw null; } }
+
+        public string Description { get { throw null; } set { } }
+
+        public virtual AssemblyReference EntryPoint { get { throw null; } set { } }
+
+        public FileReferenceCollection FileReferences { get { throw null; } }
+
+        public System.IO.Stream InputStream { get { throw null; } set { } }
+
+        public bool LauncherBasedDeployment { get { throw null; } set { } }
+
+        public OutputMessageCollection OutputMessages { get { throw null; } }
+
+        public bool ReadOnly { get { throw null; } set { } }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlElement("AssemblyIdentity")]
+        public AssemblyIdentity XmlAssemblyIdentity { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("AssemblyReferences")]
+        public AssemblyReference[] XmlAssemblyReferences { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlDescription { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        [System.Xml.Serialization.XmlArray("FileReferences")]
+        public FileReference[] XmlFileReferences { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlSchema { get { throw null; } set { } }
+
+        public void ResolveFiles() { }
+
+        public void ResolveFiles(string[] searchPaths) { }
+
+        public override string ToString() { throw null; }
+
+        public void UpdateFileInfo() { }
+
+        public void UpdateFileInfo(string targetFrameworkVersion) { }
+
+        public virtual void Validate() { }
+
+        protected void ValidatePlatform() { }
+    }
+
+    public static partial class ManifestReader
+    {
+        public static Manifest ReadManifest(System.IO.Stream input, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string path, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string manifestType, System.IO.Stream input, bool preserveStream) { throw null; }
+
+        public static Manifest ReadManifest(string manifestType, string path, bool preserveStream) { throw null; }
+    }
+
+    public static partial class ManifestWriter
+    {
+        public static void WriteManifest(Manifest manifest, System.IO.Stream output) { }
+
+        public static void WriteManifest(Manifest manifest, string path, string targetframeWorkVersion) { }
+
+        public static void WriteManifest(Manifest manifest, string path) { }
+
+        public static void WriteManifest(Manifest manifest) { }
+    }
+
+    public sealed partial class OutputMessage
+    {
+        internal OutputMessage() { }
+
+        public string Name { get { throw null; } }
+
+        public string Text { get { throw null; } }
+
+        public OutputMessageType Type { get { throw null; } }
+
+        public string[] GetArguments() { throw null; }
+    }
+
+    public sealed partial class OutputMessageCollection : System.Collections.IEnumerable
+    {
+        internal OutputMessageCollection() { }
+
+        public int ErrorCount { get { throw null; } }
+
+        public OutputMessage this[int index] { get { throw null; } }
+
+        public int WarningCount { get { throw null; } }
+
+        public void Clear() { }
+
+        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public enum OutputMessageType
+    {
+        Info = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class ProxyStub
+    {
+        public string BaseInterface { get { throw null; } }
+
+        public string IID { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string NumMethods { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlBaseInterface { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlIID { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlNumMethods { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+    }
+
+    public static partial class SecurityUtilities
+    {
+        public static void SignFile(System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Uri timestampUrl, string path) { }
+
+        public static void SignFile(string certPath, System.Security.SecureString certPassword, System.Uri timestampUrl, string path) { }
+
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier, bool disallowMansignTimestampFallback) { }
+
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion, string targetFrameworkIdentifier) { }
+
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path, string targetFrameworkVersion) { }
+
+        public static void SignFile(string certThumbprint, System.Uri timestampUrl, string path) { }
+    }
+
+    public sealed partial class TrustInfo
+    {
+        public bool HasUnmanagedCodePermission { get { throw null; } }
+
+        public bool IsFullTrust { get { throw null; } }
+
+        public bool PreserveFullTrustPermissionSet { get { throw null; } set { } }
+
+        public string SameSiteAccess { get { throw null; } set { } }
+
+        public void Clear() { }
+
+        public void Read(System.IO.Stream input) { }
+
+        public void Read(string path) { }
+
+        public void ReadManifest(System.IO.Stream input) { }
+
+        public void ReadManifest(string path) { }
+
+        public override string ToString() { throw null; }
+
+        public void Write(System.IO.Stream output) { }
+
+        public void Write(string path) { }
+
+        public void WriteManifest(System.IO.Stream input, System.IO.Stream output) { }
+
+        public void WriteManifest(System.IO.Stream output) { }
+
+        public void WriteManifest(string path) { }
+    }
+
+    public partial class TypeLib
+    {
+        public string Flags { get { throw null; } }
+
+        public string HelpDirectory { get { throw null; } }
+
+        public string ResourceId { get { throw null; } }
+
+        public string TlbId { get { throw null; } }
+
+        public string Version { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlFlags { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlHelpDirectory { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlResourceId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlTlbId { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersion { get { throw null; } set { } }
+    }
+
+    public enum UpdateMode
+    {
+        Background = 0,
+        Foreground = 1
+    }
+
+    public enum UpdateUnit
+    {
+        Hours = 0,
+        Days = 1,
+        Weeks = 2
+    }
+
+    public partial class WindowClass
+    {
+        public WindowClass() { }
+
+        public WindowClass(string name, bool versioned) { }
+
+        public string Name { get { throw null; } }
+
+        public bool Versioned { get { throw null; } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlName { get { throw null; } set { } }
+
+        [System.ComponentModel.Browsable(false)]
+        public string XmlVersioned { get { throw null; } set { } }
+    }
+}
+
+namespace Microsoft.Build.Tasks.Hosting
+{
+    public partial interface IAnalyzerHostObject
+    {
+        bool SetAdditionalFiles(Framework.ITaskItem[] additionalFiles);
+        bool SetAnalyzers(Framework.ITaskItem[] analyzers);
+        bool SetRuleSet(string ruleSetFile);
+    }
+
+    public partial interface ICscHostObject : Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        bool EndInitialization(out string errorMessage, out int errorCode);
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetAllowUnsafeBlocks(bool allowUnsafeBlocks);
+        bool SetBaseAddress(string baseAddress);
+        bool SetCheckForOverflowUnderflow(bool checkForOverflowUnderflow);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySignExplicitlySet, bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetEmitDebugInformation(bool emitDebugInformation);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateFullPaths(bool generateFullPaths);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLangVersion(string langVersion);
+        bool SetLinkResources(Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string targetType, string mainEntryPoint);
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetOptimize(bool optimize);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPdbFile(string pdbFile);
+        bool SetPlatform(string platform);
+        bool SetReferences(Framework.ITaskItem[] references);
+        bool SetResources(Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Framework.ITaskItem[] responseFiles);
+        bool SetSources(Framework.ITaskItem[] sources);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningLevel(int warningLevel);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+
+    public partial interface ICscHostObject2 : ICscHostObject, Framework.ITaskHost
+    {
+        bool SetWin32Manifest(string win32Manifest);
+    }
+
+    public partial interface ICscHostObject3 : ICscHostObject2, ICscHostObject, Framework.ITaskHost
+    {
+        bool SetApplicationConfiguration(string applicationConfiguration);
+    }
+
+    public partial interface ICscHostObject4 : ICscHostObject3, ICscHostObject2, ICscHostObject, Framework.ITaskHost
+    {
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+
+    public partial interface IVbcHostObject : Framework.ITaskHost
+    {
+        void BeginInitialization();
+        bool Compile();
+        void EndInitialization();
+        bool IsDesignTime();
+        bool IsUpToDate();
+        bool SetAdditionalLibPaths(string[] additionalLibPaths);
+        bool SetAddModules(string[] addModules);
+        bool SetBaseAddress(string targetType, string baseAddress);
+        bool SetCodePage(int codePage);
+        bool SetDebugType(bool emitDebugInformation, string debugType);
+        bool SetDefineConstants(string defineConstants);
+        bool SetDelaySign(bool delaySign);
+        bool SetDisabledWarnings(string disabledWarnings);
+        bool SetDocumentationFile(string documentationFile);
+        bool SetErrorReport(string errorReport);
+        bool SetFileAlignment(int fileAlignment);
+        bool SetGenerateDocumentation(bool generateDocumentation);
+        bool SetImports(Framework.ITaskItem[] importsList);
+        bool SetKeyContainer(string keyContainer);
+        bool SetKeyFile(string keyFile);
+        bool SetLinkResources(Framework.ITaskItem[] linkResources);
+        bool SetMainEntryPoint(string mainEntryPoint);
+        bool SetNoConfig(bool noConfig);
+        bool SetNoStandardLib(bool noStandardLib);
+        bool SetNoWarnings(bool noWarnings);
+        bool SetOptimize(bool optimize);
+        bool SetOptionCompare(string optionCompare);
+        bool SetOptionExplicit(bool optionExplicit);
+        bool SetOptionStrict(bool optionStrict);
+        bool SetOptionStrictType(string optionStrictType);
+        bool SetOutputAssembly(string outputAssembly);
+        bool SetPlatform(string platform);
+        bool SetReferences(Framework.ITaskItem[] references);
+        bool SetRemoveIntegerChecks(bool removeIntegerChecks);
+        bool SetResources(Framework.ITaskItem[] resources);
+        bool SetResponseFiles(Framework.ITaskItem[] responseFiles);
+        bool SetRootNamespace(string rootNamespace);
+        bool SetSdkPath(string sdkPath);
+        bool SetSources(Framework.ITaskItem[] sources);
+        bool SetTargetCompactFramework(bool targetCompactFramework);
+        bool SetTargetType(string targetType);
+        bool SetTreatWarningsAsErrors(bool treatWarningsAsErrors);
+        bool SetWarningsAsErrors(string warningsAsErrors);
+        bool SetWarningsNotAsErrors(string warningsNotAsErrors);
+        bool SetWin32Icon(string win32Icon);
+        bool SetWin32Resource(string win32Resource);
+    }
+
+    public partial interface IVbcHostObject2 : IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetModuleAssemblyName(string moduleAssemblyName);
+        bool SetOptionInfer(bool optionInfer);
+        bool SetWin32Manifest(string win32Manifest);
+    }
+
+    public partial interface IVbcHostObject3 : IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetLanguageVersion(string languageVersion);
+    }
+
+    public partial interface IVbcHostObject4 : IVbcHostObject3, IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        bool SetVBRuntime(string VBRuntime);
+    }
+
+    public partial interface IVbcHostObject5 : IVbcHostObject4, IVbcHostObject3, IVbcHostObject2, IVbcHostObject, Framework.ITaskHost
+    {
+        int CompileAsync(out System.IntPtr buildSucceededEvent, out System.IntPtr buildFailedEvent);
+        int EndCompile(bool buildSuccess);
+        IVbcHostObjectFreeThreaded GetFreeThreadedHostObject();
+        bool SetHighEntropyVA(bool highEntropyVA);
+        bool SetPlatformWith32BitPreference(string platformWith32BitPreference);
+        bool SetSubsystemVersion(string subsystemVersion);
+    }
+
+    public partial interface IVbcHostObjectFreeThreaded
+    {
+        bool Compile();
+    }
+}
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    public sealed partial class RSAPKCS1SHA256SignatureDescription : Security.Cryptography.SignatureDescription
+    {
+        public override Security.Cryptography.AsymmetricSignatureDeformatter CreateDeformatter(Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+
+        public override Security.Cryptography.AsymmetricSignatureFormatter CreateFormatter(Security.Cryptography.AsymmetricAlgorithm key) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/Microsoft.Build.Utilities.Core.17.5.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/Microsoft.Build.Utilities.Core.17.5.0.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="17.5.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/microsoft.build.utilities.core.nuspec
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/microsoft.build.utilities.core.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Build.Utilities.Core</id>
+    <version>17.5.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
+    <description>This package contains the Microsoft.Build.Utilities assembly which is used to implement custom MSBuild tasks.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>MSBuild</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/msbuild" commit="6f08c67f3ed838dccfbcdab91e6bebc54a26fd94" />
+    <dependencies>
+      <group targetFramework="net7.0">
+        <dependency id="Microsoft.Build.Framework" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.StringTools" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="System.Collections.Immutable" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Build.Framework" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.NET.StringTools" version="17.5.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Collections.Immutable" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Permissions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/ref/net7.0/Microsoft.Build.Utilities.Core.cs
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/ref/net7.0/Microsoft.Build.Utilities.Core.cs
@@ -1,0 +1,813 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Utilities.Core.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Utilities.Core.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Utilities
+{
+    [Framework.LoadInSeparateAppDomain]
+    [System.Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+    public abstract partial class AppDomainIsolatedTask : System.MarshalByRefObject, Framework.ITask
+    {
+        protected AppDomainIsolatedTask() { }
+
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources) { }
+
+        public Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public Framework.ITaskHost HostObject { get { throw null; } set { } }
+
+        public TaskLoggingHelper Log { get { throw null; } }
+
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public abstract bool Execute();
+        [System.Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+        public override object InitializeLifetimeService() { throw null; }
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public partial class AssemblyFoldersExInfo
+    {
+        public AssemblyFoldersExInfo(Win32.RegistryHive hive, Win32.RegistryView view, string registryKey, string directoryPath, System.Version targetFrameworkVersion) { }
+
+        public string DirectoryPath { get { throw null; } }
+
+        public Win32.RegistryHive Hive { get { throw null; } }
+
+        public string Key { get { throw null; } }
+
+        public System.Version TargetFrameworkVersion { get { throw null; } }
+
+        public Win32.RegistryView View { get { throw null; } }
+    }
+
+    public partial class AssemblyFoldersFromConfigInfo
+    {
+        public AssemblyFoldersFromConfigInfo(string directoryPath, System.Version targetFrameworkVersion) { }
+
+        public string DirectoryPath { get { throw null; } }
+
+        public System.Version TargetFrameworkVersion { get { throw null; } }
+    }
+
+    public partial class CommandLineBuilder
+    {
+        public CommandLineBuilder() { }
+
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
+
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine) { }
+
+        protected System.Text.StringBuilder CommandLine { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public void AppendFileNameIfNotNull(Framework.ITaskItem fileItem) { }
+
+        public void AppendFileNameIfNotNull(string fileName) { }
+
+        public void AppendFileNamesIfNotNull(Framework.ITaskItem[] fileItems, string delimiter) { }
+
+        public void AppendFileNamesIfNotNull(string[] fileNames, string delimiter) { }
+
+        protected void AppendFileNameWithQuoting(string fileName) { }
+
+        protected void AppendQuotedTextToBuffer(System.Text.StringBuilder buffer, string unquotedTextToAppend) { }
+
+        protected void AppendSpaceIfNotEmpty() { }
+
+        public void AppendSwitch(string switchName) { }
+
+        public void AppendSwitchIfNotNull(string switchName, Framework.ITaskItem parameter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, Framework.ITaskItem[] parameters, string delimiter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, string parameter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, string[] parameters, string delimiter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Framework.ITaskItem parameter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Framework.ITaskItem[] parameters, string delimiter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string parameter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string[] parameters, string delimiter) { }
+
+        public void AppendTextUnquoted(string textToAppend) { }
+
+        protected void AppendTextWithQuoting(string textToAppend) { }
+
+        protected virtual bool IsQuotingRequired(string parameter) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        protected virtual void VerifyThrowNoEmbeddedDoubleQuotes(string switchName, string parameter) { }
+    }
+
+    public enum DotNetFrameworkArchitecture
+    {
+        Current = 0,
+        Bitness32 = 1,
+        Bitness64 = 2
+    }
+
+    public enum HostObjectInitializationStatus
+    {
+        UseHostObjectToExecute = 0,
+        UseAlternateToolToExecute = 1,
+        NoActionReturnSuccess = 2,
+        NoActionReturnFailure = 3
+    }
+
+    public abstract partial class Logger : Framework.ILogger
+    {
+        public virtual string Parameters { get { throw null; } set { } }
+
+        public virtual Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+
+        public virtual string FormatErrorEvent(Framework.BuildErrorEventArgs args) { throw null; }
+
+        public virtual string FormatWarningEvent(Framework.BuildWarningEventArgs args) { throw null; }
+
+        public abstract void Initialize(Framework.IEventSource eventSource);
+        public bool IsVerbosityAtLeast(Framework.LoggerVerbosity checkVerbosity) { throw null; }
+
+        public virtual void Shutdown() { }
+    }
+
+    public enum MultipleVersionSupport
+    {
+        Allow = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class MuxLogger : Framework.INodeLogger, Framework.ILogger
+    {
+        public bool IncludeEvaluationMetaprojects { get { throw null; } set { } }
+
+        public bool IncludeEvaluationProfiles { get { throw null; } set { } }
+
+        public bool IncludeEvaluationPropertiesAndItems { get { throw null; } set { } }
+
+        public bool IncludeTaskInputs { get { throw null; } set { } }
+
+        public string Parameters { get { throw null; } set { } }
+
+        public Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+
+        public void Initialize(Framework.IEventSource eventSource, int maxNodeCount) { }
+
+        public void Initialize(Framework.IEventSource eventSource) { }
+
+        public void RegisterLogger(int submissionId, Framework.ILogger logger) { }
+
+        public void Shutdown() { }
+
+        public bool UnregisterLoggers(int submissionId) { throw null; }
+    }
+
+    public static partial class ProcessorArchitecture
+    {
+        public const string AMD64 = "AMD64";
+        public const string ARM = "ARM";
+        public const string ARM64 = "ARM64";
+        public const string IA64 = "IA64";
+        public const string MSIL = "MSIL";
+        public const string X86 = "x86";
+        public static string CurrentProcessArchitecture { get { throw null; } }
+    }
+
+    public partial class SDKManifest
+    {
+        public SDKManifest(string pathToSdk) { }
+
+        public System.Collections.Generic.IDictionary<string, string> AppxLocations { get { throw null; } }
+
+        public string CopyRedistToSubDirectory { get { throw null; } }
+
+        public string DependsOnSDK { get { throw null; } }
+
+        public string DisplayName { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> FrameworkIdentities { get { throw null; } }
+
+        public string FrameworkIdentity { get { throw null; } }
+
+        public string MaxOSVersionTested { get { throw null; } }
+
+        public string MaxPlatformVersion { get { throw null; } }
+
+        public string MinOSVersion { get { throw null; } }
+
+        public string MinVSVersion { get { throw null; } }
+
+        public string MoreInfo { get { throw null; } }
+
+        public string PlatformIdentity { get { throw null; } }
+
+        public string ProductFamilyName { get { throw null; } }
+
+        public bool ReadError { get { throw null; } }
+
+        public string ReadErrorMessage { get { throw null; } }
+
+        public SDKType SDKType { get { throw null; } }
+
+        public string SupportedArchitectures { get { throw null; } }
+
+        public string SupportPrefer32Bit { get { throw null; } }
+
+        public MultipleVersionSupport SupportsMultipleVersions { get { throw null; } }
+
+        public string TargetPlatform { get { throw null; } }
+
+        public string TargetPlatformMinVersion { get { throw null; } }
+
+        public string TargetPlatformVersion { get { throw null; } }
+
+        public static partial class Attributes
+        {
+            public const string APPX = "APPX";
+            public const string AppxLocation = "AppxLocation";
+            public const string CopyLocalExpandedReferenceAssemblies = "CopyLocalExpandedReferenceAssemblies";
+            public const string CopyRedist = "CopyRedist";
+            public const string CopyRedistToSubDirectory = "CopyRedistToSubDirectory";
+            public const string DependsOnSDK = "DependsOn";
+            public const string DisplayName = "DisplayName";
+            public const string ExpandReferenceAssemblies = "ExpandReferenceAssemblies";
+            public const string FrameworkIdentity = "FrameworkIdentity";
+            public const string MaxOSVersionTested = "MaxOSVersionTested";
+            public const string MaxPlatformVersion = "MaxPlatformVersion";
+            public const string MinOSVersion = "MinOSVersion";
+            public const string MinVSVersion = "MinVSVersion";
+            public const string MoreInfo = "MoreInfo";
+            public const string PlatformIdentity = "PlatformIdentity";
+            public const string ProductFamilyName = "ProductFamilyName";
+            public const string SDKType = "SDKType";
+            public const string SupportedArchitectures = "SupportedArchitectures";
+            public const string SupportPrefer32Bit = "SupportPrefer32Bit";
+            public const string SupportsMultipleVersions = "SupportsMultipleVersions";
+            public const string TargetedSDK = "TargetedSDKArchitecture";
+            public const string TargetedSDKConfiguration = "TargetedSDKConfiguration";
+            public const string TargetPlatform = "TargetPlatform";
+            public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
+            public const string TargetPlatformVersion = "TargetPlatformVersion";
+        }
+    }
+
+    public enum SDKType
+    {
+        Unspecified = 0,
+        External = 1,
+        Platform = 2,
+        Framework = 3
+    }
+
+    public enum TargetDotNetFrameworkVersion
+    {
+        Version11 = 0,
+        Version20 = 1,
+        Version30 = 2,
+        Version35 = 3,
+        Version40 = 4,
+        Version45 = 5,
+        Version451 = 6,
+        Version46 = 7,
+        Version461 = 8,
+        Version452 = 9,
+        Version462 = 10,
+        Version47 = 11,
+        Version471 = 12,
+        Version472 = 13,
+        Version48 = 14,
+        VersionLatest = 14,
+        Version481 = 15,
+        Latest = 9999
+    }
+
+    public partial class TargetPlatformSDK : System.IEquatable<TargetPlatformSDK>
+    {
+        public TargetPlatformSDK(string targetPlatformIdentifier, System.Version targetPlatformVersion, string path) { }
+
+        public string DisplayName { get { throw null; } }
+
+        public System.Version MinOSVersion { get { throw null; } }
+
+        public System.Version MinVSVersion { get { throw null; } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string TargetPlatformIdentifier { get { throw null; } }
+
+        public System.Version TargetPlatformVersion { get { throw null; } }
+
+        public bool ContainsPlatform(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public bool Equals(TargetPlatformSDK other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public abstract partial class Task : Framework.ITask
+    {
+        protected Task() { }
+
+        protected Task(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected Task(System.Resources.ResourceManager taskResources) { }
+
+        public Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+
+        public Framework.IBuildEngine2 BuildEngine2 { get { throw null; } }
+
+        public Framework.IBuildEngine3 BuildEngine3 { get { throw null; } }
+
+        public Framework.IBuildEngine4 BuildEngine4 { get { throw null; } }
+
+        public Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
+
+        public Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
+
+        public Framework.IBuildEngine7 BuildEngine7 { get { throw null; } }
+
+        public Framework.IBuildEngine8 BuildEngine8 { get { throw null; } }
+
+        public Framework.IBuildEngine9 BuildEngine9 { get { throw null; } }
+
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public Framework.ITaskHost HostObject { get { throw null; } set { } }
+
+        public TaskLoggingHelper Log { get { throw null; } }
+
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public abstract bool Execute();
+    }
+
+    public sealed partial class TaskItem : Framework.ITaskItem2, Framework.ITaskItem
+    {
+        public TaskItem() { }
+
+        public TaskItem(Framework.ITaskItem sourceItem) { }
+
+        public TaskItem(string itemSpec, System.Collections.IDictionary itemMetadata) { }
+
+        public TaskItem(string itemSpec) { }
+
+        public string ItemSpec { get { throw null; } set { } }
+
+        public int MetadataCount { get { throw null; } }
+
+        public System.Collections.ICollection MetadataNames { get { throw null; } }
+
+        string Framework.ITaskItem2.EvaluatedIncludeEscaped { get { throw null; } set { } }
+
+        public System.Collections.IDictionary CloneCustomMetadata() { throw null; }
+
+        public void CopyMetadataTo(Framework.ITaskItem destinationItem) { }
+
+        public string GetMetadata(string metadataName) { throw null; }
+
+        System.Collections.IDictionary Framework.ITaskItem2.CloneCustomMetadataEscaped() { throw null; }
+
+        string Framework.ITaskItem2.GetMetadataValueEscaped(string metadataName) { throw null; }
+
+        void Framework.ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) { }
+
+        public static explicit operator string(TaskItem taskItemToCast) { throw null; }
+
+        public void RemoveMetadata(string metadataName) { }
+
+        public void SetMetadata(string metadataName, string metadataValue) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class TaskLoggingHelper
+    {
+        public TaskLoggingHelper(Framework.IBuildEngine buildEngine, string taskName) { }
+
+        public TaskLoggingHelper(Framework.ITask taskInstance) { }
+
+        protected Framework.IBuildEngine BuildEngine { get { throw null; } }
+
+        public bool HasLoggedErrors { get { throw null; } }
+
+        public string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public bool IsTaskInputLoggingEnabled { get { throw null; } }
+
+        protected string TaskName { get { throw null; } }
+
+        public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { throw null; }
+
+        public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
+
+        public virtual string FormatString(string unformatted, params object[] args) { throw null; }
+
+        public virtual string GetResourceMessage(string resourceName) { throw null; }
+
+        public void LogCommandLine(Framework.MessageImportance importance, string commandLine) { }
+
+        public void LogCommandLine(string commandLine) { }
+
+        public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogError(string message, params object[] messageArgs) { }
+
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }
+
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
+
+        public void LogErrorFromException(System.Exception exception) { }
+
+        public void LogErrorFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorFromResources(string subcategoryResourceName, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogExternalProjectFinished(string message, string helpKeyword, string projectFile, bool succeeded) { }
+
+        public void LogExternalProjectStarted(string message, string helpKeyword, string projectFile, string targetNames) { }
+
+        public void LogMessage(Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+
+        public void LogMessage(string message, params object[] messageArgs) { }
+
+        public void LogMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+
+        public void LogMessageFromResources(Framework.MessageImportance importance, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogMessageFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public bool LogMessageFromText(string lineOfText, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogMessagesFromFile(string fileName, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogMessagesFromFile(string fileName) { throw null; }
+
+        public bool LogMessagesFromStream(System.IO.TextReader stream, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogsMessagesOfImportance(Framework.MessageImportance importance) { throw null; }
+
+        public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
+
+        public void LogWarning(string message, params object[] messageArgs) { }
+
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogWarningFromException(System.Exception exception, bool showStackTrace) { }
+
+        public void LogWarningFromException(System.Exception exception) { }
+
+        public void LogWarningFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningFromResources(string subcategoryResourceName, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+    }
+
+    public static partial class ToolLocationHelper
+    {
+        public static string CurrentToolsVersion { get { throw null; } }
+
+        public static string PathToSystem { get { throw null; } }
+
+        public static void ClearSDKStaticCache() { }
+
+        public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+
+        public static string FindRootFolderWhereAllFilesExist(string possibleRoots, string relativeFilePaths) { throw null; }
+
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+        public static System.Collections.Generic.IList<AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<AssemblyFoldersFromConfigInfo> GetAssemblyFoldersFromConfigInfo(string configFile, string targetFrameworkVersion, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+
+        public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static string GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetFoldersInVSInstalls(System.Version minVersion = null, System.Version maxVersion = null, string subFolder = null) { throw null; }
+
+        public static string GetFoldersInVSInstallsAsString(string minVersionString = null, string maxVersionString = null, string subFolder = null) { throw null; }
+
+        public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion, string[] sdkRoots) { throw null; }
+
+        public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion) { throw null; }
+
+        public static string GetPathToBuildTools(string toolsVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToBuildTools(string toolsVersion) { throw null; }
+
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion) { throw null; }
+
+        public static string GetPathToDotNetFramework(TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFramework(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkFile(string fileName, TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkFile(string fileName, TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk() { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+
+        public static string GetPathToSystemFile(string fileName) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocation instead")]
+        public static string GetPathToWindowsSdk(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string[] extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string[] extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string[] multiPlatformDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static string[] GetPlatformOrFrameworkExtensionSdkReferences(string extensionSdkMoniker, string targetSdkIdentifier, string targetSdkVersion, string diskRoots, string extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string[] GetPlatformOrFrameworkExtensionSdkReferences(string extensionSdkMoniker, string targetSdkIdentifier, string targetSdkVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion) { throw null; }
+
+        public static string GetProgramFilesReferenceAssemblyRoot() { throw null; }
+
+        public static string GetSDKContentFolderPath(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string folderName, string diskRoot = null) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSupportedTargetFrameworks() { throw null; }
+
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> GetTargetPlatformSdks() { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> GetTargetPlatformSdks(string[] diskRoots, string registryRoot) { throw null; }
+
+        public static System.Runtime.Versioning.FrameworkName HighestVersionOfTargetFrameworkIdentifier(string targetFrameworkRootDirectory, string frameworkIdentifier) { throw null; }
+    }
+
+    public abstract partial class ToolTask : Task, Framework.ICancelableTask, Framework.ITask
+    {
+        protected ToolTask() { }
+
+        protected ToolTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected ToolTask(System.Resources.ResourceManager taskResources) { }
+
+        public bool EchoOff { get { throw null; } set { } }
+
+        [System.Obsolete("Use EnvironmentVariables property")]
+        protected virtual System.Collections.Generic.Dictionary<string, string> EnvironmentOverride { get { throw null; } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        [Framework.Output]
+        public int ExitCode { get { throw null; } }
+
+        protected virtual bool HasLoggedErrors { get { throw null; } }
+
+        public bool LogStandardErrorAsError { get { throw null; } set { } }
+
+        protected virtual System.Text.Encoding ResponseFileEncoding { get { throw null; } }
+
+        protected virtual System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+
+        public string StandardErrorImportance { get { throw null; } set { } }
+
+        protected Framework.MessageImportance StandardErrorImportanceToUse { get { throw null; } }
+
+        protected virtual Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+
+        protected virtual System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+
+        public string StandardOutputImportance { get { throw null; } set { } }
+
+        protected Framework.MessageImportance StandardOutputImportanceToUse { get { throw null; } }
+
+        protected virtual Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+
+        protected int TaskProcessTerminationTimeout { get { throw null; } set { } }
+
+        public virtual int Timeout { get { throw null; } set { } }
+
+        protected System.Threading.ManualResetEvent ToolCanceled { get { throw null; } }
+
+        public virtual string ToolExe { get { throw null; } set { } }
+
+        protected abstract string ToolName { get; }
+
+        public string ToolPath { get { throw null; } set { } }
+
+        public bool UseCommandProcessor { get { throw null; } set { } }
+
+        public string UseUtf8Encoding { get { throw null; } set { } }
+
+        public bool YieldDuringToolExecution { get { throw null; } set { } }
+
+        protected virtual string AdjustCommandsForOperatingSystem(string input) { throw null; }
+
+        protected virtual bool CallHostObjectToExecute() { throw null; }
+
+        public virtual void Cancel() { }
+
+        protected void DeleteTempFile(string fileName) { }
+
+        public override bool Execute() { throw null; }
+
+        protected virtual int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+
+        protected virtual string GenerateCommandLineCommands() { throw null; }
+
+        protected abstract string GenerateFullPathToTool();
+        protected virtual string GenerateResponseFileCommands() { throw null; }
+
+        protected virtual System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
+
+        protected virtual string GetResponseFileSwitch(string responseFilePath) { throw null; }
+
+        protected virtual string GetWorkingDirectory() { throw null; }
+
+        protected virtual bool HandleTaskExecutionErrors() { throw null; }
+
+        protected virtual HostObjectInitializationStatus InitializeHostObject() { throw null; }
+
+        protected virtual void LogEventsFromTextOutput(string singleLine, Framework.MessageImportance messageImportance) { }
+
+        protected virtual void LogPathToTool(string toolName, string pathToTool) { }
+
+        protected virtual void LogToolCommand(string message) { }
+
+        protected virtual void ProcessStarted() { }
+
+        protected virtual string ResponseFileEscape(string responseString) { throw null; }
+
+        protected virtual bool SkipTaskExecution() { throw null; }
+
+        protected internal virtual bool ValidateParameters() { throw null; }
+    }
+
+    public static partial class TrackedDependencies
+    {
+        public static Framework.ITaskItem[] ExpandWildcards(Framework.ITaskItem[] expand) { throw null; }
+    }
+
+    public enum VisualStudioVersion
+    {
+        Version100 = 0,
+        Version110 = 1,
+        Version120 = 2,
+        Version140 = 3,
+        Version150 = 4,
+        Version160 = 5,
+        Version170 = 6,
+        VersionLatest = 6
+    }
+}

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/ref/netstandard2.0/Microsoft.Build.Utilities.Core.cs
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.5.0/ref/netstandard2.0/Microsoft.Build.Utilities.Core.cs
@@ -1,0 +1,811 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Build.Utilities.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.SafeDirectories)]
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Build.Utilities.Core.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Build.Utilities.Core.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("15.1.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.Build.Utilities
+{
+    [Framework.LoadInSeparateAppDomain]
+    [System.Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+    public abstract partial class AppDomainIsolatedTask : System.MarshalByRefObject, Framework.ITask
+    {
+        protected AppDomainIsolatedTask() { }
+
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected AppDomainIsolatedTask(System.Resources.ResourceManager taskResources) { }
+
+        public Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public Framework.ITaskHost HostObject { get { throw null; } set { } }
+
+        public TaskLoggingHelper Log { get { throw null; } }
+
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public abstract bool Execute();
+        [System.Obsolete("AppDomains are no longer supported in .NET Core or .NET 5.0 or higher.")]
+        public override object InitializeLifetimeService() { throw null; }
+    }
+
+    public partial class AssemblyFoldersExInfo
+    {
+        public AssemblyFoldersExInfo(Win32.RegistryHive hive, Win32.RegistryView view, string registryKey, string directoryPath, System.Version targetFrameworkVersion) { }
+
+        public string DirectoryPath { get { throw null; } }
+
+        public Win32.RegistryHive Hive { get { throw null; } }
+
+        public string Key { get { throw null; } }
+
+        public System.Version TargetFrameworkVersion { get { throw null; } }
+
+        public Win32.RegistryView View { get { throw null; } }
+    }
+
+    public partial class AssemblyFoldersFromConfigInfo
+    {
+        public AssemblyFoldersFromConfigInfo(string directoryPath, System.Version targetFrameworkVersion) { }
+
+        public string DirectoryPath { get { throw null; } }
+
+        public System.Version TargetFrameworkVersion { get { throw null; } }
+    }
+
+    public partial class CommandLineBuilder
+    {
+        public CommandLineBuilder() { }
+
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine, bool useNewLineSeparator) { }
+
+        public CommandLineBuilder(bool quoteHyphensOnCommandLine) { }
+
+        protected System.Text.StringBuilder CommandLine { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public void AppendFileNameIfNotNull(Framework.ITaskItem fileItem) { }
+
+        public void AppendFileNameIfNotNull(string fileName) { }
+
+        public void AppendFileNamesIfNotNull(Framework.ITaskItem[] fileItems, string delimiter) { }
+
+        public void AppendFileNamesIfNotNull(string[] fileNames, string delimiter) { }
+
+        protected void AppendFileNameWithQuoting(string fileName) { }
+
+        protected void AppendQuotedTextToBuffer(System.Text.StringBuilder buffer, string unquotedTextToAppend) { }
+
+        protected void AppendSpaceIfNotEmpty() { }
+
+        public void AppendSwitch(string switchName) { }
+
+        public void AppendSwitchIfNotNull(string switchName, Framework.ITaskItem parameter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, Framework.ITaskItem[] parameters, string delimiter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, string parameter) { }
+
+        public void AppendSwitchIfNotNull(string switchName, string[] parameters, string delimiter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Framework.ITaskItem parameter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, Framework.ITaskItem[] parameters, string delimiter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string parameter) { }
+
+        public void AppendSwitchUnquotedIfNotNull(string switchName, string[] parameters, string delimiter) { }
+
+        public void AppendTextUnquoted(string textToAppend) { }
+
+        protected void AppendTextWithQuoting(string textToAppend) { }
+
+        protected virtual bool IsQuotingRequired(string parameter) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        protected virtual void VerifyThrowNoEmbeddedDoubleQuotes(string switchName, string parameter) { }
+    }
+
+    public enum DotNetFrameworkArchitecture
+    {
+        Current = 0,
+        Bitness32 = 1,
+        Bitness64 = 2
+    }
+
+    public enum HostObjectInitializationStatus
+    {
+        UseHostObjectToExecute = 0,
+        UseAlternateToolToExecute = 1,
+        NoActionReturnSuccess = 2,
+        NoActionReturnFailure = 3
+    }
+
+    public abstract partial class Logger : Framework.ILogger
+    {
+        public virtual string Parameters { get { throw null; } set { } }
+
+        public virtual Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+
+        public virtual string FormatErrorEvent(Framework.BuildErrorEventArgs args) { throw null; }
+
+        public virtual string FormatWarningEvent(Framework.BuildWarningEventArgs args) { throw null; }
+
+        public abstract void Initialize(Framework.IEventSource eventSource);
+        public bool IsVerbosityAtLeast(Framework.LoggerVerbosity checkVerbosity) { throw null; }
+
+        public virtual void Shutdown() { }
+    }
+
+    public enum MultipleVersionSupport
+    {
+        Allow = 0,
+        Warning = 1,
+        Error = 2
+    }
+
+    public partial class MuxLogger : Framework.INodeLogger, Framework.ILogger
+    {
+        public bool IncludeEvaluationMetaprojects { get { throw null; } set { } }
+
+        public bool IncludeEvaluationProfiles { get { throw null; } set { } }
+
+        public bool IncludeEvaluationPropertiesAndItems { get { throw null; } set { } }
+
+        public bool IncludeTaskInputs { get { throw null; } set { } }
+
+        public string Parameters { get { throw null; } set { } }
+
+        public Framework.LoggerVerbosity Verbosity { get { throw null; } set { } }
+
+        public void Initialize(Framework.IEventSource eventSource, int maxNodeCount) { }
+
+        public void Initialize(Framework.IEventSource eventSource) { }
+
+        public void RegisterLogger(int submissionId, Framework.ILogger logger) { }
+
+        public void Shutdown() { }
+
+        public bool UnregisterLoggers(int submissionId) { throw null; }
+    }
+
+    public static partial class ProcessorArchitecture
+    {
+        public const string AMD64 = "AMD64";
+        public const string ARM = "ARM";
+        public const string ARM64 = "ARM64";
+        public const string IA64 = "IA64";
+        public const string MSIL = "MSIL";
+        public const string X86 = "x86";
+        public static string CurrentProcessArchitecture { get { throw null; } }
+    }
+
+    public partial class SDKManifest
+    {
+        public SDKManifest(string pathToSdk) { }
+
+        public System.Collections.Generic.IDictionary<string, string> AppxLocations { get { throw null; } }
+
+        public string CopyRedistToSubDirectory { get { throw null; } }
+
+        public string DependsOnSDK { get { throw null; } }
+
+        public string DisplayName { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> FrameworkIdentities { get { throw null; } }
+
+        public string FrameworkIdentity { get { throw null; } }
+
+        public string MaxOSVersionTested { get { throw null; } }
+
+        public string MaxPlatformVersion { get { throw null; } }
+
+        public string MinOSVersion { get { throw null; } }
+
+        public string MinVSVersion { get { throw null; } }
+
+        public string MoreInfo { get { throw null; } }
+
+        public string PlatformIdentity { get { throw null; } }
+
+        public string ProductFamilyName { get { throw null; } }
+
+        public bool ReadError { get { throw null; } }
+
+        public string ReadErrorMessage { get { throw null; } }
+
+        public SDKType SDKType { get { throw null; } }
+
+        public string SupportedArchitectures { get { throw null; } }
+
+        public string SupportPrefer32Bit { get { throw null; } }
+
+        public MultipleVersionSupport SupportsMultipleVersions { get { throw null; } }
+
+        public string TargetPlatform { get { throw null; } }
+
+        public string TargetPlatformMinVersion { get { throw null; } }
+
+        public string TargetPlatformVersion { get { throw null; } }
+
+        public static partial class Attributes
+        {
+            public const string APPX = "APPX";
+            public const string AppxLocation = "AppxLocation";
+            public const string CopyLocalExpandedReferenceAssemblies = "CopyLocalExpandedReferenceAssemblies";
+            public const string CopyRedist = "CopyRedist";
+            public const string CopyRedistToSubDirectory = "CopyRedistToSubDirectory";
+            public const string DependsOnSDK = "DependsOn";
+            public const string DisplayName = "DisplayName";
+            public const string ExpandReferenceAssemblies = "ExpandReferenceAssemblies";
+            public const string FrameworkIdentity = "FrameworkIdentity";
+            public const string MaxOSVersionTested = "MaxOSVersionTested";
+            public const string MaxPlatformVersion = "MaxPlatformVersion";
+            public const string MinOSVersion = "MinOSVersion";
+            public const string MinVSVersion = "MinVSVersion";
+            public const string MoreInfo = "MoreInfo";
+            public const string PlatformIdentity = "PlatformIdentity";
+            public const string ProductFamilyName = "ProductFamilyName";
+            public const string SDKType = "SDKType";
+            public const string SupportedArchitectures = "SupportedArchitectures";
+            public const string SupportPrefer32Bit = "SupportPrefer32Bit";
+            public const string SupportsMultipleVersions = "SupportsMultipleVersions";
+            public const string TargetedSDK = "TargetedSDKArchitecture";
+            public const string TargetedSDKConfiguration = "TargetedSDKConfiguration";
+            public const string TargetPlatform = "TargetPlatform";
+            public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
+            public const string TargetPlatformVersion = "TargetPlatformVersion";
+        }
+    }
+
+    public enum SDKType
+    {
+        Unspecified = 0,
+        External = 1,
+        Platform = 2,
+        Framework = 3
+    }
+
+    public enum TargetDotNetFrameworkVersion
+    {
+        Version11 = 0,
+        Version20 = 1,
+        Version30 = 2,
+        Version35 = 3,
+        Version40 = 4,
+        Version45 = 5,
+        Version451 = 6,
+        Version46 = 7,
+        Version461 = 8,
+        Version452 = 9,
+        Version462 = 10,
+        Version47 = 11,
+        Version471 = 12,
+        Version472 = 13,
+        Version48 = 14,
+        VersionLatest = 14,
+        Version481 = 15,
+        Latest = 9999
+    }
+
+    public partial class TargetPlatformSDK : System.IEquatable<TargetPlatformSDK>
+    {
+        public TargetPlatformSDK(string targetPlatformIdentifier, System.Version targetPlatformVersion, string path) { }
+
+        public string DisplayName { get { throw null; } }
+
+        public System.Version MinOSVersion { get { throw null; } }
+
+        public System.Version MinVSVersion { get { throw null; } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string TargetPlatformIdentifier { get { throw null; } }
+
+        public System.Version TargetPlatformVersion { get { throw null; } }
+
+        public bool ContainsPlatform(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public bool Equals(TargetPlatformSDK other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public abstract partial class Task : Framework.ITask
+    {
+        protected Task() { }
+
+        protected Task(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected Task(System.Resources.ResourceManager taskResources) { }
+
+        public Framework.IBuildEngine BuildEngine { get { throw null; } set { } }
+
+        public Framework.IBuildEngine2 BuildEngine2 { get { throw null; } }
+
+        public Framework.IBuildEngine3 BuildEngine3 { get { throw null; } }
+
+        public Framework.IBuildEngine4 BuildEngine4 { get { throw null; } }
+
+        public Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
+
+        public Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
+
+        public Framework.IBuildEngine7 BuildEngine7 { get { throw null; } }
+
+        public Framework.IBuildEngine8 BuildEngine8 { get { throw null; } }
+
+        public Framework.IBuildEngine9 BuildEngine9 { get { throw null; } }
+
+        protected string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public Framework.ITaskHost HostObject { get { throw null; } set { } }
+
+        public TaskLoggingHelper Log { get { throw null; } }
+
+        protected System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public abstract bool Execute();
+    }
+
+    public sealed partial class TaskItem : Framework.ITaskItem2, Framework.ITaskItem
+    {
+        public TaskItem() { }
+
+        public TaskItem(Framework.ITaskItem sourceItem) { }
+
+        public TaskItem(string itemSpec, System.Collections.IDictionary itemMetadata) { }
+
+        public TaskItem(string itemSpec) { }
+
+        public string ItemSpec { get { throw null; } set { } }
+
+        public int MetadataCount { get { throw null; } }
+
+        public System.Collections.ICollection MetadataNames { get { throw null; } }
+
+        string Framework.ITaskItem2.EvaluatedIncludeEscaped { get { throw null; } set { } }
+
+        public System.Collections.IDictionary CloneCustomMetadata() { throw null; }
+
+        public void CopyMetadataTo(Framework.ITaskItem destinationItem) { }
+
+        public string GetMetadata(string metadataName) { throw null; }
+
+        System.Collections.IDictionary Framework.ITaskItem2.CloneCustomMetadataEscaped() { throw null; }
+
+        string Framework.ITaskItem2.GetMetadataValueEscaped(string metadataName) { throw null; }
+
+        void Framework.ITaskItem2.SetMetadataValueLiteral(string metadataName, string metadataValue) { }
+
+        public static explicit operator string(TaskItem taskItemToCast) { throw null; }
+
+        public void RemoveMetadata(string metadataName) { }
+
+        public void SetMetadata(string metadataName, string metadataValue) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class TaskLoggingHelper
+    {
+        public TaskLoggingHelper(Framework.IBuildEngine buildEngine, string taskName) { }
+
+        public TaskLoggingHelper(Framework.ITask taskInstance) { }
+
+        protected Framework.IBuildEngine BuildEngine { get { throw null; } }
+
+        public bool HasLoggedErrors { get { throw null; } }
+
+        public string HelpKeywordPrefix { get { throw null; } set { } }
+
+        public bool IsTaskInputLoggingEnabled { get { throw null; } }
+
+        protected string TaskName { get { throw null; } }
+
+        public System.Resources.ResourceManager TaskResources { get { throw null; } set { } }
+
+        public string ExtractMessageCode(string message, out string messageWithoutCodePrefix) { throw null; }
+
+        public virtual string FormatResourceString(string resourceName, params object[] args) { throw null; }
+
+        public virtual string FormatString(string unformatted, params object[] args) { throw null; }
+
+        public virtual string GetResourceMessage(string resourceName) { throw null; }
+
+        public void LogCommandLine(Framework.MessageImportance importance, string commandLine) { }
+
+        public void LogCommandLine(string commandLine) { }
+
+        public void LogCriticalMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogError(string message, params object[] messageArgs) { }
+
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogError(string subcategory, string errorCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace, bool showDetail, string file) { }
+
+        public void LogErrorFromException(System.Exception exception, bool showStackTrace) { }
+
+        public void LogErrorFromException(System.Exception exception) { }
+
+        public void LogErrorFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorFromResources(string subcategoryResourceName, string errorCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogErrorWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogExternalProjectFinished(string message, string helpKeyword, string projectFile, bool succeeded) { }
+
+        public void LogExternalProjectStarted(string message, string helpKeyword, string projectFile, string targetNames) { }
+
+        public void LogMessage(Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+
+        public void LogMessage(string message, params object[] messageArgs) { }
+
+        public void LogMessage(string subcategory, string code, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, Framework.MessageImportance importance, string message, params object[] messageArgs) { }
+
+        public void LogMessageFromResources(Framework.MessageImportance importance, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogMessageFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public bool LogMessageFromText(string lineOfText, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogMessagesFromFile(string fileName, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogMessagesFromFile(string fileName) { throw null; }
+
+        public bool LogMessagesFromStream(System.IO.TextReader stream, Framework.MessageImportance messageImportance) { throw null; }
+
+        public bool LogsMessagesOfImportance(Framework.MessageImportance importance) { throw null; }
+
+        public void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties) { }
+
+        public void LogWarning(string message, params object[] messageArgs) { }
+
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogWarning(string subcategory, string warningCode, string helpKeyword, string helpLink, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string message, params object[] messageArgs) { }
+
+        public void LogWarningFromException(System.Exception exception, bool showStackTrace) { }
+
+        public void LogWarningFromException(System.Exception exception) { }
+
+        public void LogWarningFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningFromResources(string subcategoryResourceName, string warningCode, string helpKeyword, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningWithCodeFromResources(string messageResourceName, params object[] messageArgs) { }
+
+        public void LogWarningWithCodeFromResources(string subcategoryResourceName, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string messageResourceName, params object[] messageArgs) { }
+    }
+
+    public static partial class ToolLocationHelper
+    {
+        public static string CurrentToolsVersion { get { throw null; } }
+
+        public static string PathToSystem { get { throw null; } }
+
+        public static void ClearSDKStaticCache() { }
+
+        public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+
+        public static string FindRootFolderWhereAllFilesExist(string possibleRoots, string relativeFilePaths) { throw null; }
+
+        public static System.Collections.Generic.IList<AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<AssemblyFoldersFromConfigInfo> GetAssemblyFoldersFromConfigInfo(string configFile, string targetFrameworkVersion, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
+
+        public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static string GetDotNetFrameworkRootRegistryKey(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetDotNetFrameworkSdkInstallKeyValue(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetDotNetFrameworkSdkRootRegistryKey(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetDotNetFrameworkVersionFolderPrefix(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetFoldersInVSInstalls(System.Version minVersion = null, System.Version maxVersion = null, string subFolder = null) { throw null; }
+
+        public static string GetFoldersInVSInstallsAsString(string minVersionString = null, string maxVersionString = null, string subFolder = null) { throw null; }
+
+        public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion, string[] sdkRoots) { throw null; }
+
+        public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion) { throw null; }
+
+        public static string GetPathToBuildTools(string toolsVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToBuildTools(string toolsVersion) { throw null; }
+
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToBuildToolsFile(string fileName, string toolsVersion) { throw null; }
+
+        public static string GetPathToDotNetFramework(TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFramework(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkFile(string fileName, TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkFile(string fileName, TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkReferenceAssemblies(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk() { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName, TargetDotNetFrameworkVersion version) { throw null; }
+
+        public static string GetPathToDotNetFrameworkSdkFile(string fileName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string targetFrameworkRootPath) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath, string targetFrameworkFallbackSearchPaths) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget, string targetFrameworkRootPath) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile, string platformTarget) { throw null; }
+
+        public static string GetPathToStandardLibraries(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile) { throw null; }
+
+        public static string GetPathToSystemFile(string fileName) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocation instead")]
+        public static string GetPathToWindowsSdk(TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion, DotNetFrameworkArchitecture architecture) { throw null; }
+
+        [System.Obsolete("Consider using GetPlatformSDKLocationFile instead")]
+        public static string GetPathToWindowsSdkFile(string fileName, TargetDotNetFrameworkVersion version, VisualStudioVersion visualStudioVersion) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string[] extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformExtensionSDKLocation(string sdkMoniker, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, string> GetPlatformExtensionSDKLocations(string[] diskRoots, string[] extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IDictionary<string, System.Tuple<string, string>> GetPlatformExtensionSDKLocationsAndVersions(string[] diskRoots, string[] multiPlatformDiskRoots, string registryRoot, string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static string[] GetPlatformOrFrameworkExtensionSdkReferences(string extensionSdkMoniker, string targetSdkIdentifier, string targetSdkVersion, string diskRoots, string extensionDiskRoots, string registryRoot, string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string[] GetPlatformOrFrameworkExtensionSdkReferences(string extensionSdkMoniker, string targetSdkIdentifier, string targetSdkVersion, string diskRoots, string extensionDiskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKDisplayName(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, string targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKLocation(string targetPlatformIdentifier, System.Version targetPlatformVersion) { throw null; }
+
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string GetPlatformSDKPropsFileLocation(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion, string[] diskRoots, string registryRoot) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPlatformsForSDK(string sdkIdentifier, System.Version sdkVersion) { throw null; }
+
+        public static string GetProgramFilesReferenceAssemblyRoot() { throw null; }
+
+        public static string GetSDKContentFolderPath(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string folderName, string diskRoot = null) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKDesignTimeFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKRedistFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot, string targetConfiguration, string targetArchitecture) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSDKReferenceFolders(string sdkRoot) { throw null; }
+
+        public static System.Collections.Generic.IList<string> GetSupportedTargetFrameworks() { throw null; }
+
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion, string diskRoots, string registryRoot) { throw null; }
+
+        public static string[] GetTargetPlatformReferences(string sdkIdentifier, string sdkVersion, string targetPlatformIdentifier, string targetPlatformMinVersion, string targetPlatformVersion) { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> GetTargetPlatformSdks() { throw null; }
+
+        public static System.Collections.Generic.IList<TargetPlatformSDK> GetTargetPlatformSdks(string[] diskRoots, string registryRoot) { throw null; }
+
+        public static System.Runtime.Versioning.FrameworkName HighestVersionOfTargetFrameworkIdentifier(string targetFrameworkRootDirectory, string frameworkIdentifier) { throw null; }
+    }
+
+    public abstract partial class ToolTask : Task, Framework.ICancelableTask, Framework.ITask
+    {
+        protected ToolTask() { }
+
+        protected ToolTask(System.Resources.ResourceManager taskResources, string helpKeywordPrefix) { }
+
+        protected ToolTask(System.Resources.ResourceManager taskResources) { }
+
+        public bool EchoOff { get { throw null; } set { } }
+
+        [System.Obsolete("Use EnvironmentVariables property")]
+        protected virtual System.Collections.Generic.Dictionary<string, string> EnvironmentOverride { get { throw null; } }
+
+        public string[] EnvironmentVariables { get { throw null; } set { } }
+
+        [Framework.Output]
+        public int ExitCode { get { throw null; } }
+
+        protected virtual bool HasLoggedErrors { get { throw null; } }
+
+        public bool LogStandardErrorAsError { get { throw null; } set { } }
+
+        protected virtual System.Text.Encoding ResponseFileEncoding { get { throw null; } }
+
+        protected virtual System.Text.Encoding StandardErrorEncoding { get { throw null; } }
+
+        public string StandardErrorImportance { get { throw null; } set { } }
+
+        protected Framework.MessageImportance StandardErrorImportanceToUse { get { throw null; } }
+
+        protected virtual Framework.MessageImportance StandardErrorLoggingImportance { get { throw null; } }
+
+        protected virtual System.Text.Encoding StandardOutputEncoding { get { throw null; } }
+
+        public string StandardOutputImportance { get { throw null; } set { } }
+
+        protected Framework.MessageImportance StandardOutputImportanceToUse { get { throw null; } }
+
+        protected virtual Framework.MessageImportance StandardOutputLoggingImportance { get { throw null; } }
+
+        protected int TaskProcessTerminationTimeout { get { throw null; } set { } }
+
+        public virtual int Timeout { get { throw null; } set { } }
+
+        protected System.Threading.ManualResetEvent ToolCanceled { get { throw null; } }
+
+        public virtual string ToolExe { get { throw null; } set { } }
+
+        protected abstract string ToolName { get; }
+
+        public string ToolPath { get { throw null; } set { } }
+
+        public bool UseCommandProcessor { get { throw null; } set { } }
+
+        public string UseUtf8Encoding { get { throw null; } set { } }
+
+        public bool YieldDuringToolExecution { get { throw null; } set { } }
+
+        protected virtual string AdjustCommandsForOperatingSystem(string input) { throw null; }
+
+        protected virtual bool CallHostObjectToExecute() { throw null; }
+
+        public virtual void Cancel() { }
+
+        protected void DeleteTempFile(string fileName) { }
+
+        public override bool Execute() { throw null; }
+
+        protected virtual int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands) { throw null; }
+
+        protected virtual string GenerateCommandLineCommands() { throw null; }
+
+        protected abstract string GenerateFullPathToTool();
+        protected virtual string GenerateResponseFileCommands() { throw null; }
+
+        protected virtual System.Diagnostics.ProcessStartInfo GetProcessStartInfo(string pathToTool, string commandLineCommands, string responseFileSwitch) { throw null; }
+
+        protected virtual string GetResponseFileSwitch(string responseFilePath) { throw null; }
+
+        protected virtual string GetWorkingDirectory() { throw null; }
+
+        protected virtual bool HandleTaskExecutionErrors() { throw null; }
+
+        protected virtual HostObjectInitializationStatus InitializeHostObject() { throw null; }
+
+        protected virtual void LogEventsFromTextOutput(string singleLine, Framework.MessageImportance messageImportance) { }
+
+        protected virtual void LogPathToTool(string toolName, string pathToTool) { }
+
+        protected virtual void LogToolCommand(string message) { }
+
+        protected virtual void ProcessStarted() { }
+
+        protected virtual string ResponseFileEscape(string responseString) { throw null; }
+
+        protected virtual bool SkipTaskExecution() { throw null; }
+
+        protected internal virtual bool ValidateParameters() { throw null; }
+    }
+
+    public static partial class TrackedDependencies
+    {
+        public static Framework.ITaskItem[] ExpandWildcards(Framework.ITaskItem[] expand) { throw null; }
+    }
+
+    public enum VisualStudioVersion
+    {
+        Version100 = 0,
+        Version110 = 1,
+        Version120 = 2,
+        Version140 = 3,
+        Version150 = 4,
+        Version160 = 5,
+        Version170 = 6,
+        VersionLatest = 6
+    }
+}

--- a/src/referencePackages/src/microsoft.net.stringtools/17.5.0/Microsoft.NET.StringTools.17.5.0.csproj
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.5.0/Microsoft.NET.StringTools.17.5.0.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.net.stringtools/17.5.0/microsoft.net.stringtools.nuspec
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.5.0/microsoft.net.stringtools.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.NET.StringTools</id>
+    <version>17.5.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
+    <description>This package contains the Microsoft.NET.StringTools assembly which implements common string-related functionality such as weak interning.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>MSBuild</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/msbuild" commit="6f08c67f3ed838dccfbcdab91e6bebc54a26fd94" />
+    <dependencies>
+      <group targetFramework="net7.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/microsoft.net.stringtools/17.5.0/ref/net7.0/Microsoft.NET.StringTools.cs
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.5.0/ref/net7.0/Microsoft.NET.StringTools.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.net35.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.Benchmark, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.NET.StringTools.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.NET.StringTools.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.NET.StringTools
+{
+    public partial class SpanBasedStringBuilder : System.IDisposable
+    {
+        public SpanBasedStringBuilder(int capacity = 4) { }
+
+        public SpanBasedStringBuilder(string str) { }
+
+        public int Capacity { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public void Append(System.ReadOnlyMemory<char> span) { }
+
+        public void Append(string value, int startIndex, int count) { }
+
+        public void Append(string value) { }
+
+        public void Clear() { }
+
+        public void Dispose() { }
+
+        public Enumerator GetEnumerator() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public void Trim() { }
+
+        public void TrimEnd() { }
+
+        public void TrimStart() { }
+
+        public partial struct Enumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public char Current { get { throw null; } }
+
+            public bool MoveNext() { throw null; }
+        }
+    }
+
+    public static partial class Strings
+    {
+        public static string CreateDiagnosticReport() { throw null; }
+
+        public static void EnableDiagnostics() { }
+
+        public static SpanBasedStringBuilder GetSpanBasedStringBuilder() { throw null; }
+
+        public static string WeakIntern(System.ReadOnlySpan<char> str) { throw null; }
+
+        public static string WeakIntern(string str) { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.net.stringtools/17.5.0/ref/netstandard2.0/Microsoft.NET.StringTools.cs
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.5.0/ref/netstandard2.0/Microsoft.NET.StringTools.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.net35.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.NET.StringTools.Benchmark, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.NET.StringTools.dll")]
+[assembly: System.Reflection.AssemblyFileVersion("17.5.0.10706")]
+[assembly: System.Reflection.AssemblyInformationalVersion("17.5.0+6f08c67f3ed838dccfbcdab91e6bebc54a26fd94")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.NET.StringTools.dll")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/msbuild")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Microsoft.NET.StringTools
+{
+    public partial class SpanBasedStringBuilder : System.IDisposable
+    {
+        public SpanBasedStringBuilder(int capacity = 4) { }
+
+        public SpanBasedStringBuilder(string str) { }
+
+        public int Capacity { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public void Append(System.ReadOnlyMemory<char> span) { }
+
+        public void Append(string value, int startIndex, int count) { }
+
+        public void Append(string value) { }
+
+        public void Clear() { }
+
+        public void Dispose() { }
+
+        public Enumerator GetEnumerator() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public void Trim() { }
+
+        public void TrimEnd() { }
+
+        public void TrimStart() { }
+
+        public partial struct Enumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public char Current { get { throw null; } }
+
+            public bool MoveNext() { throw null; }
+        }
+    }
+
+    public static partial class Strings
+    {
+        public static string CreateDiagnosticReport() { throw null; }
+
+        public static void EnableDiagnostics() { }
+
+        public static SpanBasedStringBuilder GetSpanBasedStringBuilder() { throw null; }
+
+        public static string WeakIntern(System.ReadOnlySpan<char> str) { throw null; }
+
+        public static string WeakIntern(string str) { throw null; }
+    }
+}


### PR DESCRIPTION
The following SBRP packages are needed for completion of `fsharp` prebuilt detection work:
```
Microsoft.NET.StringTools.17.5.0
Microsoft.Build.Framework.17.5.0
Microsoft.Build.Utilities.Core.17.5.0
Microsoft.Build.Tasks.Core.17.5.0
```

This work contributes to https://github.com/dotnet/fsharp/issues/15166

