### PR TITLE
Remove NETFramework targeting pack version

### DIFF
--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -23,7 +23,6 @@
 
   <PropertyGroup>
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion>
     <!-- The SDK already sets the NETStandardImplicitPackageVersion and we don't expect it to change anymore. Hence, we don't encode it here. -->
   </PropertyGroup>
 


### PR DESCRIPTION
.NET Framework support was removed from SBRP a while ago but the property that indicates which .NET Framework targeting pack version to restore was left over.