### PR TITLE
Revert "remove nuget 6.2.2 (#673)"

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -65,6 +65,16 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Encodings.Web.4.6.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.4.6.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.DependencyModel.3.0.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Frameworks.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Common.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Versioning.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Configuration.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Packaging.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.LibraryModel.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Protocol.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.DependencyResolver.Core.6.2.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.ProjectModel.6.2.2.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/nuget.common/6.2.2/NuGet.Common.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.common/6.2.2/NuGet.Common.6.2.2.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Common</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Frameworks" Version="6.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.common/6.2.2/lib/netstandard2.0/NuGet.Common.cs
+++ b/src/referencePackages/src/nuget.common/6.2.2/lib/netstandard2.0/NuGet.Common.cs
@@ -1,0 +1,1077 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Common.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Common utilities and interfaces for all NuGet libraries.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Common")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Common
+{
+    public static partial class ActivityCorrelationId
+    {
+        public static string Current { get { throw null; } }
+
+        public static void Clear() { }
+
+        public static void StartNew() { }
+    }
+
+    public partial class AggregateEnumerableAsync<T> : IEnumerableAsync<T>
+    {
+        public AggregateEnumerableAsync(System.Collections.Generic.IList<IEnumerableAsync<T>> asyncEnumerables, System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { }
+
+        public IEnumeratorAsync<T> GetEnumeratorAsync() { throw null; }
+    }
+
+    public partial class AggregateEnumeratorAsync<T> : IEnumeratorAsync<T>
+    {
+        public AggregateEnumeratorAsync(System.Collections.Generic.IList<IEnumerableAsync<T>> asyncEnumerables, System.Collections.Generic.IComparer<T> orderingComparer, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { }
+
+        public T Current { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> MoveNextAsync() { throw null; }
+    }
+
+    public static partial class AsyncLazy
+    {
+        public static AsyncLazy<T> New<T>(T innerData) { throw null; }
+
+        public static AsyncLazy<T> New<T>(System.Func<T> valueFactory) { throw null; }
+
+        public static AsyncLazy<T> New<T>(System.Func<System.Threading.Tasks.Task<T>> asyncValueFactory) { throw null; }
+
+        public static AsyncLazy<T> New<T>(System.Lazy<System.Threading.Tasks.Task<T>> inner) { throw null; }
+    }
+
+    [System.CLSCompliant(true)]
+    public partial class AsyncLazy<T>
+    {
+        public AsyncLazy(System.Func<System.Threading.Tasks.Task<T>> valueFactory) { }
+
+        public AsyncLazy(System.Lazy<System.Threading.Tasks.Task<T>> inner) { }
+
+        public System.Runtime.CompilerServices.TaskAwaiter<T> GetAwaiter() { throw null; }
+
+        public static implicit operator System.Lazy<System.Threading.Tasks.Task<T>>(AsyncLazy<T> outer) { throw null; }
+    }
+
+    public partial class AuthTypeFilteredCredentials : System.Net.ICredentials
+    {
+        public AuthTypeFilteredCredentials(System.Net.NetworkCredential innerCredential, System.Collections.Generic.IEnumerable<string> authTypes) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> AuthTypes { get { throw null; } }
+
+        public System.Net.NetworkCredential InnerCredential { get { throw null; } }
+
+        public System.Net.NetworkCredential GetCredential(System.Uri uri, string authType) { throw null; }
+    }
+
+    public static partial class ClientVersionUtility
+    {
+        public static string GetNuGetAssemblyVersion() { throw null; }
+    }
+
+    public partial class CommandLineArgumentCombinationException : System.Exception, ILogMessageException
+    {
+        public CommandLineArgumentCombinationException(string message) { }
+
+        public virtual ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public static partial class ComparisonUtility
+    {
+        public static readonly System.StringComparer FrameworkReferenceNameComparer;
+    }
+
+    public static partial class ConcurrencyUtilities
+    {
+        public static void ExecuteWithFileLocked(string filePath, System.Action action) { }
+
+        public static System.Threading.Tasks.Task<T> ExecuteWithFileLockedAsync<T>(string filePath, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> action, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class CryptoHashProvider
+    {
+        public CryptoHashProvider() { }
+
+        public CryptoHashProvider(string hashAlgorithm) { }
+
+        public byte[] CalculateHash(byte[] data) { throw null; }
+
+        public byte[] CalculateHash(System.IO.Stream stream) { throw null; }
+
+        public bool VerifyHash(byte[] data, byte[] hash) { throw null; }
+    }
+
+    public static partial class CryptoHashUtility
+    {
+        public static byte[] ComputeHash(this HashAlgorithmName hashAlgorithmName, byte[] data) { throw null; }
+
+        public static byte[] ComputeHash(this System.Security.Cryptography.HashAlgorithm hashAlgorithm, System.IO.Stream data, bool leaveStreamOpen) { throw null; }
+
+        public static byte[] ComputeHash(this System.Security.Cryptography.HashAlgorithm hashAlgorithm, System.IO.Stream data) { throw null; }
+
+        public static string ComputeHashAsBase64(this System.Security.Cryptography.HashAlgorithm hashAlgorithm, System.IO.Stream data, bool leaveStreamOpen) { throw null; }
+
+        public static string ComputeHashAsBase64(this System.Security.Cryptography.HashAlgorithm hashAlgorithm, System.IO.Stream data) { throw null; }
+
+        public static System.Security.Cryptography.Oid ConvertToOid(this HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static string ConvertToOidString(this HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static string ConvertToOidString(this SignatureAlgorithmName signatureAlgorithmName) { throw null; }
+
+        public static System.Security.Cryptography.HashAlgorithmName ConvertToSystemSecurityHashAlgorithmName(this HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static string GenerateUniqueToken(string caseInsensitiveKey) { throw null; }
+
+        public static System.Security.Cryptography.HashAlgorithm GetHashAlgorithm(HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static System.Security.Cryptography.HashAlgorithm GetHashAlgorithm(string hashAlgorithmName) { throw null; }
+
+        public static HashAlgorithmName GetHashAlgorithmName(string hashAlgorithm) { throw null; }
+
+        public static System.Security.Cryptography.HashAlgorithm GetHashProvider(this HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static HashAlgorithmName OidToHashAlgorithmName(string oid) { throw null; }
+    }
+
+    public static partial class CultureUtility
+    {
+        public static void DisableLocalization() { }
+    }
+
+    public static partial class DatetimeUtility
+    {
+        public static string ToReadableTimeFormat(System.TimeSpan time) { throw null; }
+    }
+
+    public partial class EnvironmentVariableWrapper : IEnvironmentVariableReader
+    {
+        public EnvironmentVariableWrapper() { }
+
+        public static IEnvironmentVariableReader Instance { get { throw null; } }
+
+        public string GetEnvironmentVariable(string variable) { throw null; }
+    }
+
+    public partial class ExceptionLogger
+    {
+        public ExceptionLogger(IEnvironmentVariableReader reader) { }
+
+        public static ExceptionLogger Instance { get { throw null; } }
+
+        public bool ShowStack { get { throw null; } }
+    }
+
+    public static partial class ExceptionUtilities
+    {
+        public static string DisplayMessage(System.AggregateException exception) { throw null; }
+
+        public static string DisplayMessage(System.Exception exception, bool indent) { throw null; }
+
+        public static string DisplayMessage(System.Exception exception) { throw null; }
+
+        public static string DisplayMessage(System.Reflection.TargetInvocationException exception) { throw null; }
+
+        public static void LogException(System.Exception ex, ILogger logger, bool logStackAsError) { }
+
+        public static void LogException(System.Exception ex, ILogger logger) { }
+
+        public static System.Exception Unwrap(System.Exception exception) { throw null; }
+    }
+
+    public static partial class FileUtility
+    {
+        public static readonly System.IO.FileShare FileSharePermissions;
+        public static readonly int MaxTries;
+        public static void Delete(string path) { }
+
+        public static System.Threading.Tasks.Task DeleteWithLock(string filePath) { throw null; }
+
+        public static string GetTempFilePath(string directory) { throw null; }
+
+        public static void Move(string sourceFileName, string destFileName) { }
+
+        public static void Replace(System.Action<string> writeSourceFile, string destFilePath) { }
+
+        public static void Replace(string sourceFileName, string destFileName) { }
+
+        public static System.Threading.Tasks.Task ReplaceAsync(System.Func<string, System.Threading.Tasks.Task> writeSourceFile, string destFilePath) { throw null; }
+
+        public static System.Threading.Tasks.Task ReplaceWithLock(System.Action<string> writeSourceFile, string destFilePath) { throw null; }
+
+        public static T SafeRead<T>(string filePath, System.Func<System.IO.FileStream, string, T> read) { throw null; }
+
+        public static System.Threading.Tasks.Task<T> SafeReadAsync<T>(string filePath, System.Func<System.IO.FileStream, string, System.Threading.Tasks.Task<T>> read) { throw null; }
+    }
+
+    public enum HashAlgorithmName
+    {
+        Unknown = 0,
+        SHA256 = 1,
+        SHA384 = 2,
+        SHA512 = 3
+    }
+
+    public partial interface ICollectorLogger : ILogger
+    {
+        System.Collections.Generic.IEnumerable<IRestoreLogMessage> Errors { get; }
+    }
+
+    public partial interface IEnumerableAsync<T>
+    {
+        IEnumeratorAsync<T> GetEnumeratorAsync();
+    }
+
+    public partial interface IEnumeratorAsync<T>
+    {
+        T Current { get; }
+
+        System.Threading.Tasks.Task<bool> MoveNextAsync();
+    }
+
+    public partial interface IEnvironmentVariableReader
+    {
+        string GetEnvironmentVariable(string variable);
+    }
+
+    public partial interface ILogFileContext
+    {
+        int EndColumnNumber { get; set; }
+
+        int EndLineNumber { get; set; }
+
+        string FilePath { get; set; }
+
+        int StartColumnNumber { get; set; }
+
+        int StartLineNumber { get; set; }
+    }
+
+    public partial interface ILogger
+    {
+        void Log(ILogMessage message);
+        void Log(LogLevel level, string data);
+        System.Threading.Tasks.Task LogAsync(ILogMessage message);
+        System.Threading.Tasks.Task LogAsync(LogLevel level, string data);
+        void LogDebug(string data);
+        void LogError(string data);
+        void LogInformation(string data);
+        void LogInformationSummary(string data);
+        void LogMinimal(string data);
+        void LogVerbose(string data);
+        void LogWarning(string data);
+    }
+
+    public partial interface ILogMessage
+    {
+        NuGetLogCode Code { get; set; }
+
+        LogLevel Level { get; set; }
+
+        string Message { get; set; }
+
+        string ProjectPath { get; set; }
+
+        System.DateTimeOffset Time { get; set; }
+
+        WarningLevel WarningLevel { get; set; }
+    }
+
+    public partial interface ILogMessageException
+    {
+        ILogMessage AsLogMessage();
+    }
+
+    public partial interface INuGetLogMessage : ILogMessage, ILogFileContext
+    {
+    }
+
+    public partial interface INuGetPathContext
+    {
+        System.Collections.Generic.IReadOnlyList<string> FallbackPackageFolders { get; }
+
+        string HttpCacheFolder { get; }
+
+        string UserPackageFolder { get; }
+    }
+
+    public partial interface INuGetTelemetryService
+    {
+        void EmitTelemetryEvent(TelemetryEvent telemetryData);
+        System.IDisposable StartActivity(string activityName);
+    }
+
+    public partial interface IPackLogMessage : INuGetLogMessage, ILogMessage, ILogFileContext
+    {
+        Frameworks.NuGetFramework Framework { get; set; }
+
+        string LibraryId { get; set; }
+    }
+
+    public partial interface IRestoreLogMessage : INuGetLogMessage, ILogMessage, ILogFileContext
+    {
+        string LibraryId { get; set; }
+
+        bool ShouldDisplay { get; set; }
+
+        System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get; set; }
+    }
+
+    public partial interface ITelemetrySession
+    {
+        void PostEvent(TelemetryEvent telemetryEvent);
+    }
+
+    public abstract partial class LegacyLoggerAdapter : ILogger
+    {
+        protected LegacyLoggerAdapter() { }
+
+        public virtual void Log(ILogMessage message) { }
+
+        public void Log(LogLevel level, string data) { }
+
+        public virtual System.Threading.Tasks.Task LogAsync(ILogMessage message) { throw null; }
+
+        public System.Threading.Tasks.Task LogAsync(LogLevel level, string data) { throw null; }
+
+        public abstract void LogDebug(string data);
+        public abstract void LogError(string data);
+        public abstract void LogInformation(string data);
+        public abstract void LogInformationSummary(string data);
+        public abstract void LogMinimal(string data);
+        public abstract void LogVerbose(string data);
+        public abstract void LogWarning(string data);
+    }
+
+    public static partial class LocalResourceUtils
+    {
+        public static void DeleteDirectoryTree(string folderPath, System.Collections.Generic.List<string> failedDeletes) { }
+    }
+
+    public abstract partial class LoggerBase : ILogger
+    {
+        public LoggerBase() { }
+
+        public LoggerBase(LogLevel verbosityLevel) { }
+
+        public LogLevel VerbosityLevel { get { throw null; } set { } }
+
+        protected virtual bool CollectMessage(LogLevel messageLevel) { throw null; }
+
+        protected virtual bool DisplayMessage(LogLevel messageLevel) { throw null; }
+
+        public abstract void Log(ILogMessage message);
+        public virtual void Log(LogLevel level, string data) { }
+
+        public abstract System.Threading.Tasks.Task LogAsync(ILogMessage message);
+        public virtual System.Threading.Tasks.Task LogAsync(LogLevel level, string data) { throw null; }
+
+        public virtual void LogDebug(string data) { }
+
+        public virtual void LogError(string data) { }
+
+        public virtual void LogInformation(string data) { }
+
+        public virtual void LogInformationSummary(string data) { }
+
+        public virtual void LogMinimal(string data) { }
+
+        public virtual void LogVerbose(string data) { }
+
+        public virtual void LogWarning(string data) { }
+    }
+
+    public static partial class LoggingExtensions
+    {
+        public static string FormatWithCode(this ILogMessage message) { throw null; }
+
+        public static string GetName(this NuGetLogCode code) { throw null; }
+
+        public static bool TryGetName(this NuGetLogCode code, out string codeString) { throw null; }
+    }
+
+    public enum LogLevel
+    {
+        Debug = 0,
+        Verbose = 1,
+        Information = 2,
+        Minimal = 3,
+        Warning = 4,
+        Error = 5
+    }
+
+    public partial class LogMessage : ILogMessage
+    {
+        public LogMessage(LogLevel level, string message, NuGetLogCode code) { }
+
+        public LogMessage(LogLevel level, string message) { }
+
+        public NuGetLogCode Code { get { throw null; } set { } }
+
+        public LogLevel Level { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public System.DateTimeOffset Time { get { throw null; } set { } }
+
+        public WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static LogMessage Create(LogLevel level, string message) { throw null; }
+
+        public static LogMessage CreateError(NuGetLogCode code, string message) { throw null; }
+
+        public static LogMessage CreateWarning(NuGetLogCode code, string message) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class LogMessageProperties
+    {
+        public const string CODE = "code";
+        public const string END_COLUMN_NUMBER = "endColumnNumber";
+        public const string END_LINE_NUMBER = "endLineNumber";
+        public const string FILE_PATH = "filePath";
+        public const string LEVEL = "level";
+        public const string LIBRARY_ID = "libraryId";
+        public const string MESSAGE = "message";
+        public const string START_COLUMN_NUMBER = "startColumnNumber";
+        public const string START_LINE_NUMBER = "startLineNumber";
+        public const string TARGET_GRAPHS = "targetGraphs";
+        public const string WARNING_LEVEL = "warningLevel";
+    }
+
+    public static partial class MSBuildStringUtility
+    {
+        public static string Convert(string value) { throw null; }
+
+        public static bool? GetBooleanOrNull(string value) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<NuGetLogCode> GetDistinctNuGetLogCodesOrDefault(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<NuGetLogCode>> nugetLogCodeLists) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<NuGetLogCode> GetNuGetLogCodes(string s) { throw null; }
+
+        public static bool IsTrue(string value) { throw null; }
+
+        public static bool IsTrueOrEmpty(string value) { throw null; }
+
+        public static string[] Split(string s, params char[] chars) { throw null; }
+
+        public static string[] Split(string s) { throw null; }
+
+        public static string[] TrimAndExcludeNullOrEmpty(string[] strings) { throw null; }
+
+        public static string TrimAndGetNullForEmpty(string s) { throw null; }
+    }
+
+    public static partial class NetworkProtocolUtility
+    {
+        public static void SetConnectionLimit() { }
+    }
+
+    public static partial class NuGetEnvironment
+    {
+        public static string GetDotNetLocation() { throw null; }
+
+        public static string GetFolderPath(NuGetFolderPath folder) { throw null; }
+    }
+
+    public enum NuGetFolderPath
+    {
+        MachineWideSettingsBaseDirectory = 0,
+        MachineWideConfigDirectory = 1,
+        UserSettingsDirectory = 2,
+        HttpCacheDirectory = 3,
+        NuGetHome = 4,
+        DefaultMsBuildPath = 5,
+        Temp = 6,
+        NuGetPluginsCacheDirectory = 7
+    }
+
+    public enum NuGetLogCode
+    {
+        Undefined = 0,
+        NU1000 = 1000,
+        NU1001 = 1001,
+        NU1002 = 1002,
+        NU1003 = 1003,
+        NU1004 = 1004,
+        NU1005 = 1005,
+        NU1006 = 1006,
+        NU1007 = 1007,
+        NU1008 = 1008,
+        NU1009 = 1009,
+        NU1010 = 1010,
+        NU1011 = 1011,
+        NU1012 = 1012,
+        NU1013 = 1013,
+        NU1100 = 1100,
+        NU1101 = 1101,
+        NU1102 = 1102,
+        NU1103 = 1103,
+        NU1104 = 1104,
+        NU1105 = 1105,
+        NU1106 = 1106,
+        NU1107 = 1107,
+        NU1108 = 1108,
+        NU1109 = 1109,
+        NU1201 = 1201,
+        NU1202 = 1202,
+        NU1203 = 1203,
+        NU1204 = 1204,
+        NU1211 = 1211,
+        NU1212 = 1212,
+        NU1213 = 1213,
+        NU1301 = 1301,
+        NU1401 = 1401,
+        NU1402 = 1402,
+        NU1403 = 1403,
+        NU1410 = 1410,
+        NU1500 = 1500,
+        NU1501 = 1501,
+        NU1502 = 1502,
+        NU1503 = 1503,
+        NU1507 = 1507,
+        NU1601 = 1601,
+        NU1602 = 1602,
+        NU1603 = 1603,
+        NU1604 = 1604,
+        NU1605 = 1605,
+        NU1608 = 1608,
+        NU1701 = 1701,
+        NU1702 = 1702,
+        NU1703 = 1703,
+        NU1801 = 1801,
+        NU1802 = 1802,
+        NU3000 = 3000,
+        NU3001 = 3001,
+        NU3002 = 3002,
+        NU3003 = 3003,
+        NU3004 = 3004,
+        NU3005 = 3005,
+        NU3006 = 3006,
+        NU3007 = 3007,
+        NU3008 = 3008,
+        NU3009 = 3009,
+        NU3010 = 3010,
+        NU3011 = 3011,
+        NU3012 = 3012,
+        NU3013 = 3013,
+        NU3014 = 3014,
+        NU3015 = 3015,
+        NU3016 = 3016,
+        NU3017 = 3017,
+        NU3018 = 3018,
+        NU3019 = 3019,
+        NU3020 = 3020,
+        NU3021 = 3021,
+        NU3022 = 3022,
+        NU3023 = 3023,
+        NU3024 = 3024,
+        NU3025 = 3025,
+        NU3026 = 3026,
+        NU3027 = 3027,
+        NU3028 = 3028,
+        NU3029 = 3029,
+        NU3030 = 3030,
+        NU3031 = 3031,
+        NU3032 = 3032,
+        NU3033 = 3033,
+        NU3034 = 3034,
+        NU3035 = 3035,
+        NU3036 = 3036,
+        NU3037 = 3037,
+        NU3038 = 3038,
+        NU3039 = 3039,
+        NU3040 = 3040,
+        NU3041 = 3041,
+        NU5000 = 5000,
+        NU5001 = 5001,
+        NU5002 = 5002,
+        NU5003 = 5003,
+        NU5004 = 5004,
+        NU5005 = 5005,
+        NU5007 = 5007,
+        NU5008 = 5008,
+        NU5009 = 5009,
+        NU5010 = 5010,
+        NU5011 = 5011,
+        NU5012 = 5012,
+        NU5013 = 5013,
+        NU5014 = 5014,
+        NU5015 = 5015,
+        NU5016 = 5016,
+        NU5017 = 5017,
+        NU5018 = 5018,
+        NU5019 = 5019,
+        NU5020 = 5020,
+        NU5021 = 5021,
+        NU5022 = 5022,
+        NU5023 = 5023,
+        NU5024 = 5024,
+        NU5025 = 5025,
+        NU5026 = 5026,
+        NU5027 = 5027,
+        NU5028 = 5028,
+        NU5029 = 5029,
+        NU5030 = 5030,
+        NU5031 = 5031,
+        NU5032 = 5032,
+        NU5033 = 5033,
+        NU5034 = 5034,
+        NU5035 = 5035,
+        NU5036 = 5036,
+        NU5037 = 5037,
+        NU5038 = 5038,
+        NU5039 = 5039,
+        NU5040 = 5040,
+        NU5041 = 5041,
+        NU5042 = 5042,
+        NU5045 = 5045,
+        NU5046 = 5046,
+        NU5047 = 5047,
+        NU5048 = 5048,
+        NU5050 = 5050,
+        NU5100 = 5100,
+        NU5101 = 5101,
+        NU5102 = 5102,
+        NU5103 = 5103,
+        NU5104 = 5104,
+        NU5105 = 5105,
+        NU5106 = 5106,
+        NU5107 = 5107,
+        NU5108 = 5108,
+        NU5109 = 5109,
+        NU5110 = 5110,
+        NU5111 = 5111,
+        NU5112 = 5112,
+        NU5114 = 5114,
+        NU5115 = 5115,
+        NU5116 = 5116,
+        NU5117 = 5117,
+        NU5118 = 5118,
+        NU5119 = 5119,
+        NU5120 = 5120,
+        NU5121 = 5121,
+        NU5122 = 5122,
+        NU5123 = 5123,
+        NU5124 = 5124,
+        NU5125 = 5125,
+        NU5126 = 5126,
+        NU5127 = 5127,
+        NU5128 = 5128,
+        NU5129 = 5129,
+        NU5130 = 5130,
+        NU5131 = 5131,
+        NU5132 = 5132,
+        NU5133 = 5133,
+        NU5500 = 5500,
+        NU5501 = 5501
+    }
+
+    public enum NuGetOperationStatus
+    {
+        NoOp = 0,
+        Succeeded = 1,
+        Failed = 2,
+        Cancelled = 3
+    }
+
+    public partial class NullLogger : LoggerBase
+    {
+        public NullLogger() { }
+
+        public static ILogger Instance { get { throw null; } }
+
+        public override void Log(ILogMessage message) { }
+
+        public override void Log(LogLevel level, string data) { }
+
+        public override System.Threading.Tasks.Task LogAsync(ILogMessage message) { throw null; }
+
+        public override System.Threading.Tasks.Task LogAsync(LogLevel level, string data) { throw null; }
+    }
+
+    public partial class PackagingLogMessage : IPackLogMessage, INuGetLogMessage, ILogMessage, ILogFileContext
+    {
+        public NuGetLogCode Code { get { throw null; } set { } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } set { } }
+
+        public LogLevel Level { get { throw null; } set { } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.DateTimeOffset Time { get { throw null; } set { } }
+
+        public WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static PackagingLogMessage CreateError(string message, NuGetLogCode code) { throw null; }
+
+        public static PackagingLogMessage CreateMessage(string message, LogLevel logLevel) { throw null; }
+
+        public static PackagingLogMessage CreateWarning(string message, NuGetLogCode code, string libraryId, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static PackagingLogMessage CreateWarning(string message, NuGetLogCode code) { throw null; }
+    }
+
+    public static partial class PathResolver
+    {
+        public static void FilterPackageFiles<T>(System.Collections.Generic.ICollection<T> source, System.Func<T, string> getPath, System.Collections.Generic.IEnumerable<string> wildcards) { }
+
+        public static System.Collections.Generic.IEnumerable<T> GetFilteredPackageFiles<T>(System.Collections.Generic.ICollection<T> source, System.Func<T, string> getPath, System.Collections.Generic.IEnumerable<string> wildcards) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<T> GetMatches<T>(System.Collections.Generic.IEnumerable<T> source, System.Func<T, string> getPath, System.Collections.Generic.IEnumerable<string> wildcards) { throw null; }
+
+        public static bool IsDirectoryPath(string path) { throw null; }
+
+        public static bool IsWildcardSearch(string filter) { throw null; }
+
+        public static string NormalizeWildcardForExcludedFiles(string basePath, string wildcard) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<SearchPathResult> PerformWildcardSearch(string basePath, string searchPath, bool includeEmptyDirectories, out string normalizedBasePath) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> PerformWildcardSearch(string basePath, string searchPath) { throw null; }
+
+        public partial struct SearchPathResult
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public SearchPathResult(string path, bool isFile) { }
+
+            public bool IsFile { get { throw null; } }
+
+            public string Path { get { throw null; } }
+        }
+    }
+
+    public static partial class PathUtility
+    {
+        public static bool IsFileSystemCaseInsensitive { get { throw null; } }
+
+        public static void EnsureParentDirectory(string filePath) { }
+
+        public static string EnsureTrailingForwardSlash(string path) { throw null; }
+
+        public static string EnsureTrailingSlash(string path) { throw null; }
+
+        public static string EscapePSPath(string path) { throw null; }
+
+        public static string GetAbsolutePath(string basePath, string relativePath) { throw null; }
+
+        public static string GetDirectoryName(string path) { throw null; }
+
+        public static System.IO.Compression.ZipArchiveEntry GetEntry(System.IO.Compression.ZipArchive archive, string path) { throw null; }
+
+        public static string GetPath(System.Uri uri) { throw null; }
+
+        public static string GetPathWithBackSlashes(string path) { throw null; }
+
+        public static string GetPathWithDirectorySeparator(string path) { throw null; }
+
+        public static string GetPathWithForwardSlashes(string path) { throw null; }
+
+        public static string GetRelativePath(string path1, string path2, char separator) { throw null; }
+
+        public static string GetRelativePath(string path1, string path2) { throw null; }
+
+        public static System.StringComparer GetStringComparerBasedOnOS() { throw null; }
+
+        public static System.StringComparison GetStringComparisonBasedOnOS() { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetUniquePathsBasedOnOS(System.Collections.Generic.IEnumerable<string> paths) { throw null; }
+
+        public static bool HasTrailingDirectorySeparator(string path) { throw null; }
+
+        public static bool IsChildOfDirectory(string dir, string candidate) { throw null; }
+
+        public static bool IsDirectorySeparatorChar(char ch) { throw null; }
+
+        public static bool IsSubdirectory(string basePath, string path) { throw null; }
+
+        public static string ReplaceAltDirSeparatorWithDirSeparator(string path) { throw null; }
+
+        public static string ReplaceDirSeparatorWithAltDirSeparator(string path) { throw null; }
+
+        public static string SmartTruncate(string path, int maxWidth) { throw null; }
+
+        public static string StripLeadingDirectorySeparators(string filename) { throw null; }
+    }
+
+    public static partial class PathValidator
+    {
+        public static bool IsValidLocalPath(string path) { throw null; }
+
+        public static bool IsValidRelativePath(string path) { throw null; }
+
+        public static bool IsValidSource(string source) { throw null; }
+
+        public static bool IsValidUncPath(string path) { throw null; }
+
+        public static bool IsValidUrl(string url) { throw null; }
+    }
+
+    public static partial class Preprocessor
+    {
+        public static string Process(System.IO.Stream stream, System.Func<string, string> tokenReplacement) { throw null; }
+
+        public static System.Threading.Tasks.Task<string> ProcessAsync(System.Func<System.Threading.Tasks.Task<System.IO.Stream>> streamTaskFactory, System.Func<string, string> tokenReplacement, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public static partial class ProjectJsonPathUtilities
+    {
+        public static readonly string ProjectConfigFileEnding;
+        public static readonly string ProjectConfigFileName;
+        public static readonly string ProjectLockFileName;
+        public static string GetLockFilePath(string configFilePath) { throw null; }
+
+        public static string GetProjectConfigPath(string directoryPath, string projectName) { throw null; }
+
+        public static string GetProjectConfigWithProjectName(string projectName) { throw null; }
+
+        public static string GetProjectLockFileNameWithProjectName(string projectName) { throw null; }
+
+        public static string GetProjectNameFromConfigFileName(string configPath) { throw null; }
+
+        public static bool IsProjectConfig(string configPath) { throw null; }
+    }
+
+    public partial class RestoreLogMessage : IRestoreLogMessage, INuGetLogMessage, ILogMessage, ILogFileContext
+    {
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString, string targetGraph, bool logToInnerLogger) { }
+
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString, string targetGraph) { }
+
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString) { }
+
+        public RestoreLogMessage(LogLevel logLevel, string errorString) { }
+
+        public NuGetLogCode Code { get { throw null; } set { } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public LogLevel Level { get { throw null; } set { } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public bool ShouldDisplay { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get { throw null; } set { } }
+
+        public System.DateTimeOffset Time { get { throw null; } set { } }
+
+        public WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static RestoreLogMessage CreateError(NuGetLogCode code, string message, string libraryId, params string[] targetGraphs) { throw null; }
+
+        public static RestoreLogMessage CreateError(NuGetLogCode code, string message) { throw null; }
+
+        public static RestoreLogMessage CreateWarning(NuGetLogCode code, string message, string libraryId, params string[] targetGraphs) { throw null; }
+
+        public static RestoreLogMessage CreateWarning(NuGetLogCode code, string message) { throw null; }
+    }
+
+    public enum RevocationMode
+    {
+        Online = 0,
+        Offline = 1
+    }
+
+    public static partial class RuntimeEnvironmentHelper
+    {
+        public static bool IsLinux { get { throw null; } }
+
+        public static bool IsMacOSX { get { throw null; } }
+
+        public static bool IsMono { get { throw null; } }
+
+        public static bool IsRunningInVisualStudio { get { throw null; } }
+
+        public static bool IsWindows { get { throw null; } }
+    }
+
+    public enum SignatureAlgorithmName
+    {
+        Unknown = 0,
+        SHA256RSA = 1,
+        SHA384RSA = 2,
+        SHA512RSA = 3
+    }
+
+    public enum SignatureValidationMode
+    {
+        Accept = 0,
+        Require = 1
+    }
+
+    public partial class TelemetryActivity : System.IDisposable
+    {
+        public static INuGetTelemetryService NuGetTelemetryService { get { throw null; } set { } }
+
+        public System.Guid OperationId { get { throw null; } }
+
+        public System.Guid ParentId { get { throw null; } }
+
+        public TelemetryEvent TelemetryEvent { get { throw null; } set { } }
+
+        public static TelemetryActivity Create(TelemetryEvent telemetryEvent) { throw null; }
+
+        public static TelemetryActivity Create(System.Guid parentId, TelemetryEvent telemetryEvent) { throw null; }
+
+        public static TelemetryActivity Create(System.Guid parentId, string eventName) { throw null; }
+
+        public static TelemetryActivity Create(string eventName) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public static void EmitTelemetryEvent(TelemetryEvent TelemetryEvent) { }
+
+        public void EndIntervalMeasure(string propertyName) { }
+
+        public System.IDisposable StartIndependentInterval(string propertyName) { throw null; }
+
+        public void StartIntervalMeasure() { }
+    }
+
+    public partial class TelemetryEvent
+    {
+        public TelemetryEvent(string eventName, System.Collections.Generic.Dictionary<string, object> properties) { }
+
+        public TelemetryEvent(string eventName) { }
+
+        public System.Collections.Generic.IDictionary<string, object> ComplexData { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public object this[string key] { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public void AddPiiData(string key, object value) { }
+
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>> GetEnumerator() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> GetPiiData() { throw null; }
+    }
+
+    public static partial class TelemetryServiceUtility
+    {
+        public static System.TimeSpan GetTimerElapsedTime() { throw null; }
+
+        public static double GetTimerElapsedTimeInSeconds() { throw null; }
+
+        public static void StartOrResumeTimer() { }
+
+        public static void StopTimer() { }
+    }
+
+    public partial class Token
+    {
+        public Token(TokenCategory category, string value) { }
+
+        public TokenCategory Category { get { throw null; } }
+
+        public string Value { get { throw null; } }
+    }
+
+    public enum TokenCategory
+    {
+        Text = 0,
+        Variable = 1
+    }
+
+    public partial class Tokenizer
+    {
+        public Tokenizer(string text) { }
+
+        public Token Read() { throw null; }
+    }
+
+    public static partial class UriUtility
+    {
+        public static System.Uri CreateSourceUri(string source, System.UriKind kind = System.UriKind.Absolute) { throw null; }
+
+        public static string GetAbsolutePath(string rootDirectory, string path) { throw null; }
+
+        public static string GetAbsolutePathFromFile(string sourceFile, string path) { throw null; }
+
+        public static string GetLocalPath(string localOrUriPath) { throw null; }
+
+        public static bool IsNuGetOrg(string source) { throw null; }
+
+        public static System.Uri TryCreateSourceUri(string source, System.UriKind kind) { throw null; }
+
+        public static string UrlEncodeOdataParameter(string value) { throw null; }
+    }
+
+    public enum WarningLevel
+    {
+        Severe = 1,
+        Important = 2,
+        Minimal = 3,
+        Default = 4
+    }
+
+    [System.Obsolete("This class is obsolete and will be removed in a future release.")]
+    public static partial class XmlUtility
+    {
+        public static System.Xml.Linq.XDocument Load(string filePath) { throw null; }
+    }
+}
+
+namespace NuGet.Common.Migrations
+{
+    public static partial class MigrationRunner
+    {
+        public static void Run() { }
+    }
+}

--- a/src/referencePackages/src/nuget.common/6.2.2/nuget.common.nuspec
+++ b/src/referencePackages/src/nuget.common/6.2.2/nuget.common.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Common</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>Common utilities and interfaces for all NuGet libraries.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Frameworks" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Core" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.IO.Compression" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.configuration/6.2.2/NuGet.Configuration.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.configuration/6.2.2/NuGet.Configuration.6.2.2.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Configuration</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Common" Version="6.2.2" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.configuration/6.2.2/lib/netstandard2.0/NuGet.Configuration.cs
+++ b/src/referencePackages/src/nuget.configuration/6.2.2/lib/netstandard2.0/NuGet.Configuration.cs
@@ -1,0 +1,1016 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Credentials.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.SolutionRestoreManager.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.VisualStudio.Implementation.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Configuration.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.DependencyResolver.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's configuration settings implementation.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Configuration")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Configuration
+{
+    public partial class AddItem : SettingItem
+    {
+        public AddItem(string key, string value, System.Collections.Generic.IReadOnlyDictionary<string, string> additionalAttributes) { }
+
+        public AddItem(string key, string value) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> AdditionalAttributes { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>> DisallowedValues { get { throw null; } }
+
+        public override string ElementName { get { throw null; } }
+
+        public string Key { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public virtual string Value { get { throw null; } set { } }
+
+        public void AddOrUpdateAdditionalAttribute(string attributeName, string value) { }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public virtual string GetValueAsPath() { throw null; }
+    }
+
+    public sealed partial class AuthorItem : TrustedSignerItem
+    {
+        public AuthorItem(string name, params CertificateItem[] certificates) : base(default!, default!) { }
+
+        public override string ElementName { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class CertificateItem : SettingItem
+    {
+        public CertificateItem(string fingerprint, Common.HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot = false) { }
+
+        public bool AllowUntrustedRoot { get { throw null; } set { } }
+
+        public override string ElementName { get { throw null; } }
+
+        public string Fingerprint { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName HashAlgorithm { get { throw null; } set { } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class ClearItem : SettingItem
+    {
+        public ClearItem() { }
+
+        public override string ElementName { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override bool IsEmpty() { throw null; }
+    }
+
+    public partial class ClientCertificateProvider : IClientCertificateProvider
+    {
+        public ClientCertificateProvider(ISettings settings) { }
+
+        public void AddOrUpdate(ClientCertItem item) { }
+
+        public ClientCertItem GetClientCertificate(string packageSourceName) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<ClientCertItem> GetClientCertificates() { throw null; }
+
+        public void Remove(System.Collections.Generic.IReadOnlyList<ClientCertItem> items) { }
+    }
+
+    public abstract partial class ClientCertItem : SettingItem
+    {
+        protected ClientCertItem(string packageSource) { }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public string PackageSource { get { throw null; } }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public abstract System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate> Search();
+        protected void SetPackageSource(string value) { }
+    }
+
+    public static partial class ConfigurationConstants
+    {
+        public static readonly string ActivePackageSourceSectionName;
+        public static readonly string Add;
+        public static readonly string AllowUntrustedRoot;
+        public static readonly string ApiKeys;
+        public static readonly string Author;
+        public static readonly string BeginIgnoreMarker;
+        public static readonly string BindingRedirectsSection;
+        public static readonly string Certificate;
+        public static readonly string Clear;
+        public static readonly string ClearTextPasswordAttribute;
+        public static readonly string ClearTextPasswordToken;
+        public static readonly string ClientCertificates;
+        public static readonly string Config;
+        public static readonly string Configuration;
+        public static readonly string ConfigurationDefaultsFile;
+        public static readonly string CredentialsSectionName;
+        public static readonly string DefaultPackageManagementFormatKey;
+        public static readonly string DefaultPushSource;
+        public static readonly string DependencyVersion;
+        public static readonly string DisabledPackageSources;
+        public static readonly string DoNotShowPackageManagementSelectionKey;
+        public static readonly string Enabled;
+        public static readonly string EndIgnoreMarker;
+        public static readonly string FailOnBindingRedirects;
+        public static readonly string FallbackPackageFolders;
+        public static readonly string FileCertificate;
+        public static readonly string FindByAttribute;
+        public static readonly string FindValueAttribute;
+        public static readonly string Fingerprint;
+        public static readonly string FingerprintAlgorithm;
+        public static readonly string GlobalPackagesFolder;
+        public static readonly string HashAlgorithm;
+        public static readonly string HostKey;
+        public static readonly string KeyAttribute;
+        public static readonly string MaxHttpRequestsPerSource;
+        public static readonly string NameAttribute;
+        public static readonly string NoProxy;
+        public static readonly string Owners;
+        public static readonly string Package;
+        public static readonly string PackageManagementSection;
+        public static readonly string PackageRestore;
+        public static readonly string PackageSourceAttribute;
+        public static readonly string PackageSourceMapping;
+        public static readonly string PackageSources;
+        public static readonly string PasswordAttribute;
+        public static readonly string PasswordKey;
+        public static readonly string PasswordToken;
+        public static readonly string PathAttribute;
+        public static readonly string PatternAttribute;
+        public static readonly string ProtocolVersionAttribute;
+        public static readonly string Repository;
+        public static readonly string RepositoryPath;
+        public static readonly string ServiceIndex;
+        public static readonly string SignatureValidationMode;
+        public static readonly string SkipBindingRedirectsKey;
+        public static readonly string StoreCertificate;
+        public static readonly string StoreLocationAttribute;
+        public static readonly string StoreNameAttribute;
+        public static readonly string TrustedSigners;
+        public static readonly string UpdatePackageLastAccessTime;
+        public static readonly string UserKey;
+        public static readonly string UsernameToken;
+        public static readonly string ValidAuthenticationTypesToken;
+        public static readonly string ValueAttribute;
+    }
+
+    public partial class ConfigurationDefaults
+    {
+        public string DefaultPackageRestoreConsent { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PackageSource> DefaultPackageSources { get { throw null; } }
+
+        public string DefaultPushSource { get { throw null; } }
+
+        public static ConfigurationDefaults Instance { get { throw null; } }
+    }
+
+    public enum CredentialRequestType
+    {
+        Proxy = 0,
+        Unauthorized = 1,
+        Forbidden = 2
+    }
+
+    public sealed partial class CredentialsItem : SettingItem
+    {
+        public CredentialsItem(string name, string username, string password, bool isPasswordClearText, string validAuthenticationTypes) { }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public override string ElementName { get { throw null; } protected set { } }
+
+        public bool IsPasswordClearText { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        public string Username { get { throw null; } set { } }
+
+        public string ValidAuthenticationTypes { get { throw null; } set { } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override bool IsEmpty() { throw null; }
+
+        public void UpdatePassword(string password, bool isPasswordClearText = true) { }
+    }
+
+    public static partial class EncryptionUtility
+    {
+        public static string DecryptString(string encryptedString) { throw null; }
+
+        public static string EncryptString(string value) { throw null; }
+    }
+
+    public sealed partial class FileClientCertItem : ClientCertItem
+    {
+        public FileClientCertItem(string packageSource, string filePath, string password, bool storePasswordInClearText, string settingsFilePath) : base(default!) { }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> AllowedAttributes { get { throw null; } }
+
+        public override string ElementName { get { throw null; } }
+
+        public string FilePath { get { throw null; } }
+
+        public bool IsPasswordIsClearText { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate> Search() { throw null; }
+
+        public void Update(string filePath, string password, bool storePasswordInClearText) { }
+    }
+
+    public partial interface IClientCertificateProvider
+    {
+        void AddOrUpdate(ClientCertItem item);
+        System.Collections.Generic.IReadOnlyList<ClientCertItem> GetClientCertificates();
+        void Remove(System.Collections.Generic.IReadOnlyList<ClientCertItem> items);
+    }
+
+    public partial interface ICredentialCache
+    {
+        void Add(System.Uri uri, System.Net.ICredentials credentials);
+        System.Net.ICredentials GetCredentials(System.Uri uri);
+    }
+
+    public partial interface ICredentialService
+    {
+        bool HandlesDefaultCredentials { get; }
+
+        System.Threading.Tasks.Task<System.Net.ICredentials> GetCredentialsAsync(System.Uri uri, System.Net.IWebProxy proxy, CredentialRequestType type, string message, System.Threading.CancellationToken cancellationToken);
+        bool TryGetLastKnownGoodCredentialsFromCache(System.Uri uri, bool isProxy, out System.Net.ICredentials credentials);
+    }
+
+    public partial interface IExtensionLocator
+    {
+        System.Collections.Generic.IEnumerable<string> FindCredentialProviders();
+        System.Collections.Generic.IEnumerable<string> FindExtensions();
+    }
+
+    public partial interface IMachineWideSettings
+    {
+        ISettings Settings { get; }
+    }
+
+    public partial interface IPackageSourceProvider
+    {
+        string ActivePackageSourceName { get; }
+
+        string DefaultPushSource { get; }
+
+        event System.EventHandler PackageSourcesChanged;
+        void AddPackageSource(PackageSource source);
+        void DisablePackageSource(string name);
+        void EnablePackageSource(string name);
+        PackageSource GetPackageSourceByName(string name);
+        PackageSource GetPackageSourceBySource(string source);
+        bool IsPackageSourceEnabled(string name);
+        System.Collections.Generic.IEnumerable<PackageSource> LoadPackageSources();
+        void RemovePackageSource(string name);
+        void SaveActivePackageSource(PackageSource source);
+        void SavePackageSources(System.Collections.Generic.IEnumerable<PackageSource> sources);
+        void UpdatePackageSource(PackageSource source, bool updateCredentials, bool updateEnabled);
+    }
+
+    [System.Obsolete("https://github.com/NuGet/Home/issues/10098")]
+    public partial interface IPackageSourceProvider2 : IPackageSourceProvider
+    {
+        void SavePackageSources(System.Collections.Generic.IEnumerable<PackageSource> sources, PackageSourceUpdateOptions packageSourceUpdateOptions);
+    }
+
+    public partial interface IProxyCache
+    {
+        void Add(System.Net.IWebProxy proxy);
+        System.Net.IWebProxy GetProxy(System.Uri uri);
+    }
+
+    public partial interface IProxyCredentialCache : System.Net.ICredentials
+    {
+        System.Guid Version { get; }
+
+        void UpdateCredential(System.Uri proxyAddress, System.Net.NetworkCredential credentials);
+    }
+
+    public partial interface ISettings
+    {
+        event System.EventHandler SettingsChanged;
+        void AddOrUpdate(string sectionName, SettingItem item);
+        System.Collections.Generic.IList<string> GetConfigFilePaths();
+        System.Collections.Generic.IList<string> GetConfigRoots();
+        SettingSection GetSection(string sectionName);
+        void Remove(string sectionName, SettingItem item);
+        void SaveToDisk();
+    }
+
+    public partial class NuGetConfigurationException : System.Exception
+    {
+        public NuGetConfigurationException(string message, System.Exception innerException) { }
+
+        public NuGetConfigurationException(string message) { }
+    }
+
+    public static partial class NuGetConstants
+    {
+        public static readonly string DefaultConfigContent;
+        public static readonly string DefaultGalleryServerUrl;
+        public static readonly string FeedName;
+        public static readonly string ManifestExtension;
+        public static readonly string ManifestSymbolsExtension;
+        public static readonly string NuGetHostName;
+        public static readonly string NuGetSolutionSettingsFolder;
+        public static readonly string NuGetSymbolHostName;
+        public static readonly string PackageExtension;
+        public static readonly string PackageReferenceFile;
+        public static readonly string PackageSpecFileName;
+        public static readonly string ReadmeExtension;
+        public static readonly string ReadmeFileName;
+        public static readonly string SnupkgExtension;
+        public static readonly string SymbolsExtension;
+        public static readonly string V1FeedUrl;
+        public const string V2FeedUrl = "https://www.nuget.org/api/v2/";
+        public static readonly string V2LegacyFeedUrl;
+        public static readonly string V2LegacyOfficialPackageSourceUrl;
+        public const string V3FeedUrl = "https://api.nuget.org/v3/index.json";
+    }
+
+    public partial class NuGetPathContext : Common.INuGetPathContext
+    {
+        public NuGetPathContext() { }
+
+        public System.Collections.Generic.IReadOnlyList<string> FallbackPackageFolders { get { throw null; } }
+
+        public string HttpCacheFolder { get { throw null; } }
+
+        public string UserPackageFolder { get { throw null; } }
+
+        public static NuGetPathContext Create(ISettings settings) { throw null; }
+
+        public static NuGetPathContext Create(string settingsRoot) { throw null; }
+    }
+
+    public partial class NullSettings : ISettings
+    {
+        public NullSettings() { }
+
+        public static NullSettings Instance { get { throw null; } }
+
+        public event System.EventHandler SettingsChanged { add { } remove { } }
+
+        public void AddOrUpdate(string sectionName, SettingItem item) { }
+
+        public System.Collections.Generic.IList<string> GetConfigFilePaths() { throw null; }
+
+        public System.Collections.Generic.IList<string> GetConfigRoots() { throw null; }
+
+        public SettingSection GetSection(string sectionName) { throw null; }
+
+        public void Remove(string sectionName, SettingItem item) { }
+
+        public void SaveToDisk() { }
+    }
+
+    public sealed partial class OwnersItem : SettingItem
+    {
+        public static readonly char OwnersListSeparator;
+        public OwnersItem(string owners) { }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> Content { get { throw null; } }
+
+        public override string ElementName { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class PackagePatternItem : SettingItem
+    {
+        public PackagePatternItem(string pattern) { }
+
+        public override string ElementName { get { throw null; } }
+
+        public string Pattern { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackageSource : System.IEquatable<PackageSource>
+    {
+        public const int DefaultProtocolVersion = 2;
+        public PackageSource(string source, string name, bool isEnabled, bool isOfficial, bool isPersistable = true) { }
+
+        public PackageSource(string source, string name, bool isEnabled) { }
+
+        public PackageSource(string source, string name) { }
+
+        public PackageSource(string source) { }
+
+        public System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate> ClientCertificates { get { throw null; } set { } }
+
+        public PackageSourceCredential Credentials { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public bool IsEnabled { get { throw null; } set { } }
+
+        public bool IsHttp { get { throw null; } }
+
+        public bool IsHttps { get { throw null; } }
+
+        public bool IsLocal { get { throw null; } }
+
+        public bool IsMachineWide { get { throw null; } set { } }
+
+        public bool IsOfficial { get { throw null; } set { } }
+
+        public bool IsPersistable { get { throw null; } }
+
+        public int MaxHttpRequestsPerSource { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public int ProtocolVersion { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public System.Uri SourceUri { get { throw null; } }
+
+        public System.Uri TrySourceAsUri { get { throw null; } }
+
+        public SourceItem AsSourceItem() { throw null; }
+
+        public PackageSource Clone() { throw null; }
+
+        public bool Equals(PackageSource other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageSourceCredential : System.IEquatable<PackageSourceCredential>
+    {
+        public PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText, string validAuthenticationTypesText) { }
+
+        public bool IsPasswordClearText { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        public string PasswordText { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public string Username { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> ValidAuthenticationTypes { get { throw null; } }
+
+        public string ValidAuthenticationTypesText { get { throw null; } }
+
+        public CredentialsItem AsCredentialsItem() { throw null; }
+
+        public bool Equals(PackageSourceCredential other) { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public static PackageSourceCredential FromUserInput(string source, string username, string password, bool storePasswordInClearText, string validAuthenticationTypesText) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool IsValid() { throw null; }
+
+        public System.Net.ICredentials ToICredentials() { throw null; }
+    }
+
+    public partial class PackageSourceMapping
+    {
+        public bool IsEnabled { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetConfiguredPackageSources(string packageId) { throw null; }
+
+        public static PackageSourceMapping GetPackageSourceMapping(ISettings settings) { throw null; }
+    }
+
+    public partial class PackageSourceMappingSourceItem : SettingItem
+    {
+        public PackageSourceMappingSourceItem(string name, System.Collections.Generic.IEnumerable<PackagePatternItem> packagePatternItems) { }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public override string ElementName { get { throw null; } }
+
+        public virtual string Key { get { throw null; } }
+
+        public System.Collections.Generic.IList<PackagePatternItem> Patterns { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        protected void SetKey(string value) { }
+    }
+
+    public partial class PackageSourceProvider : IPackageSourceProvider, IPackageSourceProvider2
+    {
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public PackageSourceProvider(ISettings settings, bool enablePackageSourcesChangedEvent) { }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public PackageSourceProvider(ISettings settings, System.Collections.Generic.IEnumerable<PackageSource> configurationDefaultSources, bool enablePackageSourcesChangedEvent) { }
+
+        public PackageSourceProvider(ISettings settings, System.Collections.Generic.IEnumerable<PackageSource> configurationDefaultSources) { }
+
+        public PackageSourceProvider(ISettings settings) { }
+
+        public string ActivePackageSourceName { get { throw null; } }
+
+        public string DefaultPushSource { get { throw null; } }
+
+        public ISettings Settings { get { throw null; } }
+
+        public event System.EventHandler PackageSourcesChanged { add { } remove { } }
+
+        public void AddPackageSource(PackageSource source) { }
+
+        [System.Obsolete("DisablePackageSource(PackageSource source) is deprecated. Please use DisablePackageSource(string name) instead.")]
+        public void DisablePackageSource(PackageSource source) { }
+
+        public void DisablePackageSource(string name) { }
+
+        public void EnablePackageSource(string name) { }
+
+        public PackageSource GetPackageSourceByName(string name) { throw null; }
+
+        public PackageSource GetPackageSourceBySource(string source) { throw null; }
+
+        public System.Collections.Generic.HashSet<string> GetPackageSourceNamesMatchingNamePrefix(string namePrefix) { throw null; }
+
+        [System.Obsolete("IsPackageSourceEnabled(PackageSource source) is deprecated. Please use IsPackageSourceEnabled(string name) instead.")]
+        public bool IsPackageSourceEnabled(PackageSource source) { throw null; }
+
+        public bool IsPackageSourceEnabled(string name) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageSource> LoadPackageSources() { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<PackageSource> LoadPackageSources(ISettings settings) { throw null; }
+
+        public void RemovePackageSource(string name) { }
+
+        public void SaveActivePackageSource(PackageSource source) { }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/10098")]
+        public void SavePackageSources(System.Collections.Generic.IEnumerable<PackageSource> sources, PackageSourceUpdateOptions sourceUpdateSettings) { }
+
+        public void SavePackageSources(System.Collections.Generic.IEnumerable<PackageSource> sources) { }
+
+        public void UpdatePackageSource(PackageSource source, bool updateCredentials, bool updateEnabled) { }
+    }
+
+    [System.Obsolete("https://github.com/NuGet/Home/issues/10098")]
+    public sealed partial class PackageSourceUpdateOptions
+    {
+        public static readonly PackageSourceUpdateOptions Default;
+        public PackageSourceUpdateOptions(bool updateCredentials, bool updateEnabled) { }
+
+        public bool UpdateCredentials { get { throw null; } }
+
+        public bool UpdateEnabled { get { throw null; } }
+    }
+
+    public partial class ProxyCache : IProxyCache, IProxyCredentialCache, System.Net.ICredentials
+    {
+        public ProxyCache(ISettings settings, Common.IEnvironmentVariableReader environment) { }
+
+        public static ProxyCache Instance { get { throw null; } }
+
+        public System.Guid Version { get { throw null; } }
+
+        [System.Obsolete("Retained for backcompat only. Use UpdateCredential instead")]
+        public void Add(System.Net.IWebProxy proxy) { }
+
+        public System.Net.NetworkCredential GetCredential(System.Uri proxyAddress, string authType) { throw null; }
+
+        public System.Net.IWebProxy GetProxy(System.Uri sourceUri) { throw null; }
+
+        public WebProxy GetUserConfiguredProxy() { throw null; }
+
+        public void UpdateCredential(System.Uri proxyAddress, System.Net.NetworkCredential credentials) { }
+    }
+
+    public sealed partial class RepositoryItem : TrustedSignerItem
+    {
+        public RepositoryItem(string name, string serviceIndex, params CertificateItem[] certificates) : base(default!, default!) { }
+
+        public RepositoryItem(string name, string serviceIndex, string owners, params CertificateItem[] certificates) : base(default!, default!) { }
+
+        public override string ElementName { get { throw null; } }
+
+        public new string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> Owners { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public string ServiceIndex { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public abstract partial class SettingBase
+    {
+        protected SettingBase() { }
+
+        public abstract SettingBase Clone();
+        public abstract bool IsEmpty();
+    }
+
+    public abstract partial class SettingElement : SettingBase
+    {
+        protected SettingElement() { }
+
+        protected SettingElement(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes) { }
+
+        protected virtual System.Collections.Generic.IReadOnlyCollection<string> AllowedAttributes { get { throw null; } }
+
+        protected virtual System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>> AllowedValues { get { throw null; } }
+
+        protected virtual System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>> DisallowedValues { get { throw null; } }
+
+        public virtual string ElementName { get { throw null; } protected set { } }
+
+        protected System.Collections.Generic.Dictionary<string, string> MutableAttributes { get { throw null; } }
+
+        protected virtual System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        protected void AddAttribute(string attributeName, string value) { }
+
+        protected void AddOrUpdateAttribute(string attributeName, string value) { }
+
+        public override bool IsEmpty() { throw null; }
+    }
+
+    public enum SettingElementType
+    {
+        Unknown = 0,
+        Configuration = 1,
+        ActivePackageSource = 2,
+        BindingRedirects = 3,
+        Config = 4,
+        PackageManagement = 5,
+        PackageRestore = 6,
+        PackageSourceCredentials = 7,
+        PackageSources = 8,
+        Add = 9,
+        Author = 10,
+        Certificate = 11,
+        Clear = 12,
+        Owners = 13,
+        Repository = 14,
+        FileCert = 15,
+        StoreCert = 16,
+        PackageSourceMapping = 17,
+        PackageSource = 18,
+        Package = 19
+    }
+
+    public abstract partial class SettingItem : SettingElement
+    {
+        protected SettingItem() { }
+
+        protected SettingItem(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes) { }
+
+        protected virtual bool CanHaveChildren { get { throw null; } }
+    }
+
+    public partial class Settings : ISettings
+    {
+        public static readonly string DefaultSettingsFileName;
+        public static readonly string[] OrderedSettingsFileNames;
+        public static readonly string[] SupportedMachineWideConfigExtension;
+        public Settings(string root, string fileName, bool isMachineWide) { }
+
+        public Settings(string root, string fileName) { }
+
+        public Settings(string root) { }
+
+        public event System.EventHandler SettingsChanged { add { } remove { } }
+
+        public void AddOrUpdate(string sectionName, SettingItem item) { }
+
+        public static string ApplyEnvironmentTransform(string value) { throw null; }
+
+        public System.Collections.Generic.IList<string> GetConfigFilePaths() { throw null; }
+
+        public System.Collections.Generic.IList<string> GetConfigRoots() { throw null; }
+
+        public static System.Tuple<string, string> GetFileNameAndItsRoot(string root, string settingsPath) { throw null; }
+
+        public SettingSection GetSection(string sectionName) { throw null; }
+
+        public static ISettings LoadDefaultSettings(string root, string configFileName, IMachineWideSettings machineWideSettings, SettingsLoadingContext settingsLoadingContext) { throw null; }
+
+        public static ISettings LoadDefaultSettings(string root, string configFileName, IMachineWideSettings machineWideSettings) { throw null; }
+
+        public static ISettings LoadDefaultSettings(string root) { throw null; }
+
+        public static ISettings LoadImmutableSettingsGivenConfigPaths(System.Collections.Generic.IList<string> configFilePaths, SettingsLoadingContext settingsLoadingContext) { throw null; }
+
+        public static ISettings LoadMachineWideSettings(string root, params string[] paths) { throw null; }
+
+        public static ISettings LoadSettingsGivenConfigPaths(System.Collections.Generic.IList<string> configFilePaths) { throw null; }
+
+        public static ISettings LoadSpecificSettings(string root, string configFileName) { throw null; }
+
+        public void Remove(string sectionName, SettingItem item) { }
+
+        public void SaveToDisk() { }
+    }
+
+    public abstract partial class SettingSection : SettingsGroup<SettingItem>
+    {
+        protected SettingSection(string name, System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<SettingItem> children) { }
+
+        public override string ElementName { get { throw null; } protected set { } }
+
+        public System.Collections.Generic.IReadOnlyCollection<SettingItem> Items { get { throw null; } }
+
+        public override bool Equals(object other) { throw null; }
+
+        public T GetFirstItemWithAttribute<T>(string attributeName, string expectedAttributeValue)
+            where T : SettingItem { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public abstract partial class SettingsGroup<T> : SettingElement where T : SettingElement
+    {
+        protected SettingsGroup() { }
+
+        protected SettingsGroup(System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<T> children) { }
+
+        protected virtual bool CanBeCleared { get { throw null; } }
+
+        protected System.Collections.Generic.IList<T> Children { get { throw null; } }
+
+        public override bool IsEmpty() { throw null; }
+
+        protected bool TryGetChild(T expectedChild, out T currentChild) { throw null; }
+    }
+
+    public sealed partial class SettingsLoadingContext : System.IDisposable
+    {
+        public SettingsLoadingContext() { }
+
+        public void Dispose() { }
+    }
+
+    public static partial class SettingsUtility
+    {
+        public static readonly string DefaultGlobalPackagesFolderPath;
+        public static bool DeleteConfigValue(ISettings settings, string key) { throw null; }
+
+        public static bool DeleteValue(ISettings settings, string section, string attributeKey, string attributeValue) { throw null; }
+
+        public static string GetConfigValue(ISettings settings, string key, bool decrypt = false, bool isPath = false) { throw null; }
+
+        public static string GetDecryptedValueForAddItem(ISettings settings, string section, string key, bool isPath = false) { throw null; }
+
+        public static string GetDefaultPushSource(ISettings settings) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<PackageSource> GetEnabledSources(ISettings settings) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<string> GetFallbackPackageFolders(ISettings settings) { throw null; }
+
+        public static string GetGlobalPackagesFolder(ISettings settings) { throw null; }
+
+        public static string GetHttpCacheFolder() { throw null; }
+
+        public static int GetMaxHttpRequest(ISettings settings) { throw null; }
+
+        public static string GetPluginsCacheFolder() { throw null; }
+
+        public static string GetRepositoryPath(ISettings settings) { throw null; }
+
+        public static Common.RevocationMode GetRevocationMode(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static Common.SignatureValidationMode GetSignatureValidationMode(ISettings settings) { throw null; }
+
+        public static bool GetUpdatePackageLastAccessTimeEnabledStatus(ISettings settings) { throw null; }
+
+        public static string GetValueForAddItem(ISettings settings, string section, string key, bool isPath = false) { throw null; }
+
+        public static void SetConfigValue(ISettings settings, string key, string value, bool encrypt = false) { }
+
+        public static void SetEncryptedValueForAddItem(ISettings settings, string section, string key, string value) { }
+    }
+
+    public sealed partial class SettingText : SettingBase
+    {
+        public SettingText(string value) { }
+
+        public string Value { get { throw null; } set { } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override bool IsEmpty() { throw null; }
+    }
+
+    public sealed partial class SourceItem : AddItem
+    {
+        public SourceItem(string key, string value, string protocolVersion = "") : base(default!, default!) { }
+
+        public string ProtocolVersion { get { throw null; } set { } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class StoreClientCertItem : ClientCertItem
+    {
+        public StoreClientCertItem(string packageSource, string findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) : base(default!) { }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> AllowedAttributes { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyCollection<string>> AllowedValues { get { throw null; } }
+
+        public override string ElementName { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.X509FindType FindType { get { throw null; } }
+
+        public string FindValue { get { throw null; } }
+
+        protected override System.Collections.Generic.IReadOnlyCollection<string> RequiredAttributes { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.StoreLocation StoreLocation { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.StoreName StoreName { get { throw null; } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public static string GetString(System.Security.Cryptography.X509Certificates.StoreLocation storeLocation) { throw null; }
+
+        public static string GetString(System.Security.Cryptography.X509Certificates.StoreName storeName) { throw null; }
+
+        public static string GetString(System.Security.Cryptography.X509Certificates.X509FindType type) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate> Search() { throw null; }
+
+        public void Update(string findValue, System.Security.Cryptography.X509Certificates.StoreLocation? storeLocation = null, System.Security.Cryptography.X509Certificates.StoreName? storeName = null, System.Security.Cryptography.X509Certificates.X509FindType? findBy = null) { }
+    }
+
+    public abstract partial class TrustedSignerItem : SettingItem
+    {
+        protected TrustedSignerItem(string name, System.Collections.Generic.IEnumerable<CertificateItem> certificates) { }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public System.Collections.Generic.IList<CertificateItem> Certificates { get { throw null; } }
+
+        public virtual string Name { get { throw null; } }
+
+        protected void SetName(string value) { }
+    }
+
+    public sealed partial class UnknownItem : SettingItem
+    {
+        public UnknownItem(string name, System.Collections.Generic.IReadOnlyDictionary<string, string> attributes, System.Collections.Generic.IEnumerable<SettingBase> children) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Attributes { get { throw null; } }
+
+        protected override bool CanHaveChildren { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<SettingBase> Children { get { throw null; } }
+
+        public override string ElementName { get { throw null; } protected set { } }
+
+        public override SettingBase Clone() { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override bool IsEmpty() { throw null; }
+    }
+
+    public sealed partial class VirtualSettingSection : SettingSection
+    {
+        internal VirtualSettingSection() : base(default!, default!, default!) { }
+
+        public override SettingBase Clone() { throw null; }
+    }
+
+    public partial class WebProxy : System.Net.IWebProxy
+    {
+        public WebProxy(string proxyAddress) { }
+
+        public WebProxy(System.Uri proxyAddress) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> BypassList { get { throw null; } set { } }
+
+        public System.Net.ICredentials Credentials { get { throw null; } set { } }
+
+        public System.Uri ProxyAddress { get { throw null; } }
+
+        public System.Uri GetProxy(System.Uri destination) { throw null; }
+
+        public bool IsBypassed(System.Uri uri) { throw null; }
+    }
+
+    public partial class XPlatMachineWideSetting : IMachineWideSettings
+    {
+        public XPlatMachineWideSetting() { }
+
+        public ISettings Settings { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/nuget.configuration/6.2.2/nuget.configuration.nuspec
+++ b/src/referencePackages/src/nuget.configuration/6.2.2/nuget.configuration.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Configuration</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's configuration settings implementation.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Common" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.ProtectedData" version="4.4.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Security" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Xml" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+      <frameworkAssembly assemblyName="System.Xml.Linq" targetFramework=".NETFramework4.5, .NETFramework4.7.2" />
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/NuGet.DependencyResolver.Core.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/NuGet.DependencyResolver.Core.6.2.2.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.DependencyResolver.Core</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.2.2" />
+    <PackageReference Include="NuGet.LibraryModel" Version="6.2.2" />
+    <PackageReference Include="NuGet.Protocol" Version="6.2.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.2.2" />
+    <PackageReference Include="NuGet.LibraryModel" Version="6.2.2" />
+    <PackageReference Include="NuGet.Protocol" Version="6.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/lib/net5.0/NuGet.DependencyResolver.Core.cs
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/lib/net5.0/NuGet.DependencyResolver.Core.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.DependencyResolver.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's PackageReference dependency resolver implementation.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.DependencyResolver.Core")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.DependencyResolver
+{
+    public partial class AnalyzeResult<TItem>
+    {
+        public AnalyzeResult() { }
+
+        public System.Collections.Generic.List<GraphNode<TItem>> Cycles { get { throw null; } }
+
+        public System.Collections.Generic.List<DowngradeResult<TItem>> Downgrades { get { throw null; } }
+
+        public System.Collections.Generic.List<VersionConflictResult<TItem>> VersionConflicts { get { throw null; } }
+
+        public void Combine(AnalyzeResult<TItem> result) { }
+    }
+
+    public enum Disposition
+    {
+        Acceptable = 0,
+        Rejected = 1,
+        Accepted = 2,
+        PotentiallyDowngraded = 3,
+        Cycle = 4
+    }
+
+    public partial class DowngradeResult<TItem>
+    {
+        public DowngradeResult() { }
+
+        public GraphNode<TItem> DowngradedFrom { get { throw null; } set { } }
+
+        public GraphNode<TItem> DowngradedTo { get { throw null; } set { } }
+    }
+
+    public partial class GraphEdge<TItem>
+    {
+        public GraphEdge(GraphEdge<TItem> outerEdge, GraphItem<TItem> item, LibraryModel.LibraryDependency edge) { }
+
+        public LibraryModel.LibraryDependency Edge { get { throw null; } }
+
+        public GraphItem<TItem> Item { get { throw null; } }
+
+        public GraphEdge<TItem> OuterEdge { get { throw null; } }
+    }
+
+    public sealed partial class GraphItemKeyComparer<T> : System.Collections.Generic.IEqualityComparer<GraphItem<T>>
+    {
+        public static GraphItemKeyComparer<T> Instance { get { throw null; } }
+
+        public bool Equals(GraphItem<T> x, GraphItem<T> y) { throw null; }
+
+        public int GetHashCode(GraphItem<T> obj) { throw null; }
+    }
+
+    public partial class GraphItem<TItem> : System.IEquatable<GraphItem<TItem>>
+    {
+        public GraphItem(LibraryModel.LibraryIdentity key) { }
+
+        public TItem Data { get { throw null; } set { } }
+
+        public bool IsCentralTransitive { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIdentity Key { get { throw null; } set { } }
+
+        public bool Equals(GraphItem<TItem> other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class GraphNode<TItem>
+    {
+        public GraphNode(LibraryModel.LibraryRange key) { }
+
+        public Disposition Disposition { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> InnerNodes { get { throw null; } set { } }
+
+        public GraphItem<TItem> Item { get { throw null; } set { } }
+
+        public LibraryModel.LibraryRange Key { get { throw null; } set { } }
+
+        public GraphNode<TItem> OuterNode { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class GraphOperations
+    {
+        public static AnalyzeResult<RemoteResolveResult> Analyze(this GraphNode<RemoteResolveResult> root) { throw null; }
+
+        public static void Dump<TItem>(this GraphNode<TItem> root, System.Action<string> write) { }
+
+        public static void ForEach<TItem>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem>(this System.Collections.Generic.IEnumerable<GraphNode<TItem>> roots, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem, TContext>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>, TContext> visitor, TContext context) { }
+
+        public static string GetId<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndVersionOrRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPath<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPathWithLastRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionOrDefault<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.VersionRange GetVersionRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static bool IsPackage<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static GraphNode<TItem> Path<TItem>(this GraphNode<TItem> node, params string[] path) { throw null; }
+
+        public static void ReleaseDowngradesDictionary(System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> dictionary) { }
+
+        public static System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> RentDowngradesDictionary() { throw null; }
+    }
+
+    public partial interface IDependencyProvider
+    {
+        LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework);
+        bool SupportsType(LibraryModel.LibraryDependencyTarget libraryTypeFlag);
+    }
+
+    public partial interface IRemoteDependencyProvider
+    {
+        bool IsHttp { get; }
+
+        Configuration.PackageSource Source { get; }
+
+        System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial class LibraryRangeCacheKey : System.IEquatable<LibraryRangeCacheKey>
+    {
+        public LibraryRangeCacheKey(LibraryModel.LibraryRange range, Frameworks.NuGetFramework framework) { }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryModel.LibraryRange LibraryRange { get { throw null; } }
+
+        public bool Equals(LibraryRangeCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LocalDependencyProvider : IRemoteDependencyProvider
+    {
+        public LocalDependencyProvider(IDependencyProvider dependencyProvider) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalMatch : RemoteMatch
+    {
+        public LocalMatch() { }
+
+        public LibraryModel.Library LocalLibrary { get { throw null; } set { } }
+
+        public IDependencyProvider LocalProvider { get { throw null; } set { } }
+    }
+
+    public partial class LockFileCacheKey : System.IEquatable<LockFileCacheKey>
+    {
+        public LockFileCacheKey(Frameworks.NuGetFramework framework, string runtimeIdentifier) { }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(LockFileCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class PackagingUtility
+    {
+        public static LibraryModel.LibraryDependency GetLibraryDependencyFromNuspec(Packaging.Core.PackageDependency dependency) { throw null; }
+    }
+
+    public partial class RemoteDependencyWalker
+    {
+        public RemoteDependencyWalker(RemoteWalkContext context) { }
+
+        public static bool IsGreaterThanOrEqualTo(Versioning.VersionRange nearVersion, Versioning.VersionRange farVersion) { throw null; }
+
+        public System.Threading.Tasks.Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryModel.LibraryRange library, Frameworks.NuGetFramework framework, string runtimeIdentifier, RuntimeModel.RuntimeGraph runtimeGraph, bool recursive) { throw null; }
+    }
+
+    public partial class RemoteMatch : System.IEquatable<RemoteMatch>
+    {
+        public RemoteMatch() { }
+
+        public LibraryModel.LibraryIdentity Library { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public IRemoteDependencyProvider Provider { get { throw null; } set { } }
+
+        public bool Equals(RemoteMatch other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class RemoteResolveResult
+    {
+        public RemoteResolveResult() { }
+
+        public System.Collections.Generic.List<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public RemoteMatch Match { get { throw null; } set { } }
+    }
+
+    public partial class RemoteWalkContext
+    {
+        public RemoteWalkContext(Protocol.Core.Types.SourceCacheContext cacheContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger logger) { }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } }
+
+        public System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> FindLibraryEntryCache { get { throw null; } }
+
+        public bool IsMsBuildBased { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> LocalLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> LockFileLibraries { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Collections.Generic.IList<IDependencyProvider> ProjectLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> RemoteLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> FilterDependencyProvidersForLibrary(LibraryModel.LibraryRange libraryRange) { throw null; }
+    }
+
+    public static partial class ResolverUtility
+    {
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryByVersionAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> providers, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> cache, LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> remoteProviders, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> localProviders, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> lockFileLibraries, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>> FindPackageLibraryMatchCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryModel.LibraryRange, System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>>> cache, LibraryModel.LibraryRange libraryRange, RemoteWalkContext remoteWalkContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindProjectMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class Tracker<TItem>
+    {
+        public Tracker() { }
+
+        public System.Collections.Generic.IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) { throw null; }
+
+        public bool IsAmbiguous(GraphItem<TItem> item) { throw null; }
+
+        public bool IsBestVersion(GraphItem<TItem> item) { throw null; }
+
+        public bool IsDisputed(GraphItem<TItem> item) { throw null; }
+
+        public void MarkAmbiguous(GraphItem<TItem> item) { }
+
+        public void Track(GraphItem<TItem> item) { }
+    }
+
+    public partial class VersionConflictResult<TItem>
+    {
+        public VersionConflictResult() { }
+
+        public GraphNode<TItem> Conflicting { get { throw null; } set { } }
+
+        public GraphNode<TItem> Selected { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/lib/netstandard2.0/NuGet.DependencyResolver.Core.cs
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/lib/netstandard2.0/NuGet.DependencyResolver.Core.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.DependencyResolver.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's PackageReference dependency resolver implementation.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.DependencyResolver.Core")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.DependencyResolver
+{
+    public partial class AnalyzeResult<TItem>
+    {
+        public AnalyzeResult() { }
+
+        public System.Collections.Generic.List<GraphNode<TItem>> Cycles { get { throw null; } }
+
+        public System.Collections.Generic.List<DowngradeResult<TItem>> Downgrades { get { throw null; } }
+
+        public System.Collections.Generic.List<VersionConflictResult<TItem>> VersionConflicts { get { throw null; } }
+
+        public void Combine(AnalyzeResult<TItem> result) { }
+    }
+
+    public enum Disposition
+    {
+        Acceptable = 0,
+        Rejected = 1,
+        Accepted = 2,
+        PotentiallyDowngraded = 3,
+        Cycle = 4
+    }
+
+    public partial class DowngradeResult<TItem>
+    {
+        public DowngradeResult() { }
+
+        public GraphNode<TItem> DowngradedFrom { get { throw null; } set { } }
+
+        public GraphNode<TItem> DowngradedTo { get { throw null; } set { } }
+    }
+
+    public partial class GraphEdge<TItem>
+    {
+        public GraphEdge(GraphEdge<TItem> outerEdge, GraphItem<TItem> item, LibraryModel.LibraryDependency edge) { }
+
+        public LibraryModel.LibraryDependency Edge { get { throw null; } }
+
+        public GraphItem<TItem> Item { get { throw null; } }
+
+        public GraphEdge<TItem> OuterEdge { get { throw null; } }
+    }
+
+    public sealed partial class GraphItemKeyComparer<T> : System.Collections.Generic.IEqualityComparer<GraphItem<T>>
+    {
+        public static GraphItemKeyComparer<T> Instance { get { throw null; } }
+
+        public bool Equals(GraphItem<T> x, GraphItem<T> y) { throw null; }
+
+        public int GetHashCode(GraphItem<T> obj) { throw null; }
+    }
+
+    public partial class GraphItem<TItem> : System.IEquatable<GraphItem<TItem>>
+    {
+        public GraphItem(LibraryModel.LibraryIdentity key) { }
+
+        public TItem Data { get { throw null; } set { } }
+
+        public bool IsCentralTransitive { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIdentity Key { get { throw null; } set { } }
+
+        public bool Equals(GraphItem<TItem> other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class GraphNode<TItem>
+    {
+        public GraphNode(LibraryModel.LibraryRange key) { }
+
+        public Disposition Disposition { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> InnerNodes { get { throw null; } set { } }
+
+        public GraphItem<TItem> Item { get { throw null; } set { } }
+
+        public LibraryModel.LibraryRange Key { get { throw null; } set { } }
+
+        public GraphNode<TItem> OuterNode { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class GraphOperations
+    {
+        public static AnalyzeResult<RemoteResolveResult> Analyze(this GraphNode<RemoteResolveResult> root) { throw null; }
+
+        public static void Dump<TItem>(this GraphNode<TItem> root, System.Action<string> write) { }
+
+        public static void ForEach<TItem>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem>(this System.Collections.Generic.IEnumerable<GraphNode<TItem>> roots, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem, TContext>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>, TContext> visitor, TContext context) { }
+
+        public static string GetId<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndVersionOrRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPath<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPathWithLastRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionOrDefault<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.VersionRange GetVersionRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static bool IsPackage<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static GraphNode<TItem> Path<TItem>(this GraphNode<TItem> node, params string[] path) { throw null; }
+
+        public static void ReleaseDowngradesDictionary(System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> dictionary) { }
+
+        public static System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> RentDowngradesDictionary() { throw null; }
+    }
+
+    public partial interface IDependencyProvider
+    {
+        LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework);
+        bool SupportsType(LibraryModel.LibraryDependencyTarget libraryTypeFlag);
+    }
+
+    public partial interface IRemoteDependencyProvider
+    {
+        bool IsHttp { get; }
+
+        Configuration.PackageSource Source { get; }
+
+        System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial class LibraryRangeCacheKey : System.IEquatable<LibraryRangeCacheKey>
+    {
+        public LibraryRangeCacheKey(LibraryModel.LibraryRange range, Frameworks.NuGetFramework framework) { }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryModel.LibraryRange LibraryRange { get { throw null; } }
+
+        public bool Equals(LibraryRangeCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LocalDependencyProvider : IRemoteDependencyProvider
+    {
+        public LocalDependencyProvider(IDependencyProvider dependencyProvider) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalMatch : RemoteMatch
+    {
+        public LocalMatch() { }
+
+        public LibraryModel.Library LocalLibrary { get { throw null; } set { } }
+
+        public IDependencyProvider LocalProvider { get { throw null; } set { } }
+    }
+
+    public partial class LockFileCacheKey : System.IEquatable<LockFileCacheKey>
+    {
+        public LockFileCacheKey(Frameworks.NuGetFramework framework, string runtimeIdentifier) { }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(LockFileCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class PackagingUtility
+    {
+        public static LibraryModel.LibraryDependency GetLibraryDependencyFromNuspec(Packaging.Core.PackageDependency dependency) { throw null; }
+    }
+
+    public partial class RemoteDependencyWalker
+    {
+        public RemoteDependencyWalker(RemoteWalkContext context) { }
+
+        public static bool IsGreaterThanOrEqualTo(Versioning.VersionRange nearVersion, Versioning.VersionRange farVersion) { throw null; }
+
+        public System.Threading.Tasks.Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryModel.LibraryRange library, Frameworks.NuGetFramework framework, string runtimeIdentifier, RuntimeModel.RuntimeGraph runtimeGraph, bool recursive) { throw null; }
+    }
+
+    public partial class RemoteMatch : System.IEquatable<RemoteMatch>
+    {
+        public RemoteMatch() { }
+
+        public LibraryModel.LibraryIdentity Library { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public IRemoteDependencyProvider Provider { get { throw null; } set { } }
+
+        public bool Equals(RemoteMatch other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class RemoteResolveResult
+    {
+        public RemoteResolveResult() { }
+
+        public System.Collections.Generic.List<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public RemoteMatch Match { get { throw null; } set { } }
+    }
+
+    public partial class RemoteWalkContext
+    {
+        public RemoteWalkContext(Protocol.Core.Types.SourceCacheContext cacheContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger logger) { }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } }
+
+        public System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> FindLibraryEntryCache { get { throw null; } }
+
+        public bool IsMsBuildBased { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> LocalLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> LockFileLibraries { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Collections.Generic.IList<IDependencyProvider> ProjectLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> RemoteLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> FilterDependencyProvidersForLibrary(LibraryModel.LibraryRange libraryRange) { throw null; }
+    }
+
+    public static partial class ResolverUtility
+    {
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryByVersionAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> providers, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> cache, LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> remoteProviders, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> localProviders, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> lockFileLibraries, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>> FindPackageLibraryMatchCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryModel.LibraryRange, System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>>> cache, LibraryModel.LibraryRange libraryRange, RemoteWalkContext remoteWalkContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindProjectMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class Tracker<TItem>
+    {
+        public Tracker() { }
+
+        public System.Collections.Generic.IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) { throw null; }
+
+        public bool IsAmbiguous(GraphItem<TItem> item) { throw null; }
+
+        public bool IsBestVersion(GraphItem<TItem> item) { throw null; }
+
+        public bool IsDisputed(GraphItem<TItem> item) { throw null; }
+
+        public void MarkAmbiguous(GraphItem<TItem> item) { }
+
+        public void Track(GraphItem<TItem> item) { }
+    }
+
+    public partial class VersionConflictResult<TItem>
+    {
+        public VersionConflictResult() { }
+
+        public GraphNode<TItem> Conflicting { get { throw null; } set { } }
+
+        public GraphNode<TItem> Selected { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/nuget.dependencyresolver.core.nuspec
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.2.2/nuget.dependencyresolver.core.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.DependencyResolver.Core</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's PackageReference dependency resolver implementation.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.Configuration" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.LibraryModel" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Protocol" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Configuration" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.LibraryModel" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Protocol" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.frameworks/6.2.2/NuGet.Frameworks.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.frameworks/6.2.2/NuGet.Frameworks.6.2.2.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Frameworks</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.frameworks/6.2.2/lib/netstandard2.0/NuGet.Frameworks.cs
+++ b/src/referencePackages/src/nuget.frameworks/6.2.2/lib/netstandard2.0/NuGet.Frameworks.cs
@@ -1,0 +1,712 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's understanding of target frameworks.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Frameworks")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Frameworks
+{
+    public partial class AssetTargetFallbackFramework : NuGetFramework, System.IEquatable<AssetTargetFallbackFramework>
+    {
+        public AssetTargetFallbackFramework(NuGetFramework framework, System.Collections.Generic.IReadOnlyList<NuGetFramework> fallbackFrameworks) : base(framework) { }
+
+        public System.Collections.Generic.IReadOnlyList<NuGetFramework> Fallback { get { throw null; } }
+
+        public NuGetFramework RootFramework { get { throw null; } }
+
+        public FallbackFramework AsFallbackFramework() { throw null; }
+
+        public bool Equals(AssetTargetFallbackFramework other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class CompatibilityListProvider : IFrameworkCompatibilityListProvider
+    {
+        public CompatibilityListProvider(IFrameworkNameProvider nameProvider, IFrameworkCompatibilityProvider compatibilityProvider) { }
+
+        public static IFrameworkCompatibilityListProvider Default { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> GetFrameworksSupporting(NuGetFramework target) { throw null; }
+    }
+
+    public partial class CompatibilityMappingComparer : System.Collections.Generic.IEqualityComparer<OneWayCompatibilityMappingEntry>
+    {
+        public CompatibilityMappingComparer() { }
+
+        public bool Equals(OneWayCompatibilityMappingEntry x, OneWayCompatibilityMappingEntry y) { throw null; }
+
+        public int GetHashCode(OneWayCompatibilityMappingEntry obj) { throw null; }
+    }
+
+    public partial class CompatibilityProvider : IFrameworkCompatibilityProvider
+    {
+        public CompatibilityProvider(IFrameworkNameProvider mappings) { }
+
+        public bool IsCompatible(NuGetFramework target, NuGetFramework candidate) { throw null; }
+    }
+
+    public partial class CompatibilityTable
+    {
+        public CompatibilityTable(System.Collections.Generic.IEnumerable<NuGetFramework> frameworks, IFrameworkNameProvider mappings, IFrameworkCompatibilityProvider compat) { }
+
+        public CompatibilityTable(System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> GetNearest(NuGetFramework framework) { throw null; }
+
+        public bool HasFramework(NuGetFramework framework) { throw null; }
+
+        public bool TryGetCompatible(NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGetFramework> compatible) { throw null; }
+    }
+
+    public sealed partial class DefaultCompatibilityProvider : CompatibilityProvider
+    {
+        public DefaultCompatibilityProvider() : base(default!) { }
+
+        public static IFrameworkCompatibilityProvider Instance { get { throw null; } }
+    }
+
+    public sealed partial class DefaultFrameworkMappings : IFrameworkMappings
+    {
+        public DefaultFrameworkMappings() { }
+
+        public System.Collections.Generic.IEnumerable<OneWayCompatibilityMappingEntry> CompatibilityMappings { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> EquivalentFrameworkPrecedence { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> EquivalentFrameworks { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificMapping> EquivalentProfiles { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> FullNameReplacements { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> IdentifierShortNames { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> IdentifierSynonyms { get { throw null; } }
+
+        public static IFrameworkMappings Instance { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> NonPackageBasedFrameworkPrecedence { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> PackageBasedFrameworkPrecedence { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificMapping> ProfileShortNames { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> SubSetFrameworks { get { throw null; } }
+    }
+
+    public sealed partial class DefaultFrameworkNameProvider : FrameworkNameProvider
+    {
+        public DefaultFrameworkNameProvider() : base(default!, default!) { }
+
+        public static IFrameworkNameProvider Instance { get { throw null; } }
+    }
+
+    public partial class DefaultPortableFrameworkMappings : IPortableFrameworkMappings
+    {
+        public DefaultPortableFrameworkMappings() { }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, FrameworkRange>> CompatibilityMappings { get { throw null; } }
+
+        public static IPortableFrameworkMappings Instance { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGetFramework[]>> ProfileFrameworks { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGetFramework[]>> ProfileOptionalFrameworks { get { throw null; } }
+    }
+
+    public partial class DualCompatibilityFramework : NuGetFramework
+    {
+        public DualCompatibilityFramework(NuGetFramework framework, NuGetFramework secondaryFramework) : base(framework) { }
+
+        public NuGetFramework RootFramework { get { throw null; } }
+
+        public NuGetFramework SecondaryFramework { get { throw null; } }
+
+        public FallbackFramework AsFallbackFramework() { throw null; }
+
+        public bool Equals(DualCompatibilityFramework other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class FallbackFramework : NuGetFramework, System.IEquatable<FallbackFramework>
+    {
+        public FallbackFramework(NuGetFramework framework, System.Collections.Generic.IReadOnlyList<NuGetFramework> fallbackFrameworks) : base(framework) { }
+
+        public System.Collections.Generic.IReadOnlyList<NuGetFramework> Fallback { get { throw null; } }
+
+        public bool Equals(FallbackFramework other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class FrameworkConstants
+    {
+        public static readonly FrameworkRange DotNetAll;
+        public static readonly System.Version EmptyVersion;
+        public static readonly System.Version MaxVersion;
+        public static readonly System.Version Version10;
+        public static readonly System.Version Version5;
+        public static readonly System.Version Version6;
+        public static partial class CommonFrameworks
+        {
+            public static readonly NuGetFramework AspNet;
+            public static readonly NuGetFramework AspNet50;
+            public static readonly NuGetFramework AspNetCore;
+            public static readonly NuGetFramework AspNetCore50;
+            public static readonly NuGetFramework Dnx;
+            public static readonly NuGetFramework Dnx45;
+            public static readonly NuGetFramework Dnx451;
+            public static readonly NuGetFramework Dnx452;
+            public static readonly NuGetFramework DnxCore;
+            public static readonly NuGetFramework DnxCore50;
+            public static readonly NuGetFramework DotNet;
+            public static readonly NuGetFramework DotNet50;
+            public static readonly NuGetFramework DotNet51;
+            public static readonly NuGetFramework DotNet52;
+            public static readonly NuGetFramework DotNet53;
+            public static readonly NuGetFramework DotNet54;
+            public static readonly NuGetFramework DotNet55;
+            public static readonly NuGetFramework DotNet56;
+            public static readonly NuGetFramework Native;
+            public static readonly NuGetFramework Net11;
+            public static readonly NuGetFramework Net2;
+            public static readonly NuGetFramework Net35;
+            public static readonly NuGetFramework Net4;
+            public static readonly NuGetFramework Net403;
+            public static readonly NuGetFramework Net45;
+            public static readonly NuGetFramework Net451;
+            public static readonly NuGetFramework Net452;
+            public static readonly NuGetFramework Net46;
+            public static readonly NuGetFramework Net461;
+            public static readonly NuGetFramework Net462;
+            public static readonly NuGetFramework Net463;
+            public static readonly NuGetFramework Net47;
+            public static readonly NuGetFramework Net471;
+            public static readonly NuGetFramework Net472;
+            public static readonly NuGetFramework Net50;
+            public static readonly NuGetFramework Net60;
+            public static readonly NuGetFramework NetCore45;
+            public static readonly NuGetFramework NetCore451;
+            public static readonly NuGetFramework NetCore50;
+            public static readonly NuGetFramework NetCoreApp10;
+            public static readonly NuGetFramework NetCoreApp11;
+            public static readonly NuGetFramework NetCoreApp20;
+            public static readonly NuGetFramework NetCoreApp21;
+            public static readonly NuGetFramework NetCoreApp22;
+            public static readonly NuGetFramework NetCoreApp30;
+            public static readonly NuGetFramework NetCoreApp31;
+            public static readonly NuGetFramework NetStandard;
+            public static readonly NuGetFramework NetStandard10;
+            public static readonly NuGetFramework NetStandard11;
+            public static readonly NuGetFramework NetStandard12;
+            public static readonly NuGetFramework NetStandard13;
+            public static readonly NuGetFramework NetStandard14;
+            public static readonly NuGetFramework NetStandard15;
+            public static readonly NuGetFramework NetStandard16;
+            public static readonly NuGetFramework NetStandard17;
+            public static readonly NuGetFramework NetStandard20;
+            public static readonly NuGetFramework NetStandard21;
+            public static readonly NuGetFramework NetStandardApp15;
+            public static readonly NuGetFramework SL4;
+            public static readonly NuGetFramework SL5;
+            public static readonly NuGetFramework Tizen3;
+            public static readonly NuGetFramework Tizen4;
+            public static readonly NuGetFramework Tizen6;
+            public static readonly NuGetFramework UAP10;
+            public static readonly NuGetFramework Win10;
+            public static readonly NuGetFramework Win8;
+            public static readonly NuGetFramework Win81;
+            public static readonly NuGetFramework WP7;
+            public static readonly NuGetFramework WP75;
+            public static readonly NuGetFramework WP8;
+            public static readonly NuGetFramework WP81;
+            public static readonly NuGetFramework WPA81;
+        }
+
+        public static partial class FrameworkIdentifiers
+        {
+            public const string AspNet = "ASP.NET";
+            public const string AspNetCore = "ASP.NETCore";
+            public const string Dnx = "DNX";
+            public const string DnxCore = "DNXCore";
+            public const string DotNet = "dotnet";
+            public const string MonoAndroid = "MonoAndroid";
+            public const string MonoMac = "MonoMac";
+            public const string MonoTouch = "MonoTouch";
+            public const string NanoFramework = ".NETnanoFramework";
+            public const string Native = "native";
+            public const string Net = ".NETFramework";
+            public const string NetCore = ".NETCore";
+            public const string NetCoreApp = ".NETCoreApp";
+            public const string NetMicro = ".NETMicroFramework";
+            public const string NetPlatform = ".NETPlatform";
+            public const string NetStandard = ".NETStandard";
+            public const string NetStandardApp = ".NETStandardApp";
+            public const string Portable = ".NETPortable";
+            public const string Silverlight = "Silverlight";
+            public const string Tizen = "Tizen";
+            public const string UAP = "UAP";
+            public const string Windows = "Windows";
+            public const string WindowsPhone = "WindowsPhone";
+            public const string WindowsPhoneApp = "WindowsPhoneApp";
+            public const string WinRT = "WinRT";
+            public const string XamarinIOs = "Xamarin.iOS";
+            public const string XamarinMac = "Xamarin.Mac";
+            public const string XamarinPlayStation3 = "Xamarin.PlayStation3";
+            public const string XamarinPlayStation4 = "Xamarin.PlayStation4";
+            public const string XamarinPlayStationVita = "Xamarin.PlayStationVita";
+            public const string XamarinTVOS = "Xamarin.TVOS";
+            public const string XamarinWatchOS = "Xamarin.WatchOS";
+            public const string XamarinXbox360 = "Xamarin.Xbox360";
+            public const string XamarinXboxOne = "Xamarin.XboxOne";
+        }
+
+        public static partial class PlatformIdentifiers
+        {
+            public const string Windows = "Windows";
+            public const string WindowsPhone = "WindowsPhone";
+        }
+
+        public static partial class SpecialIdentifiers
+        {
+            public const string Agnostic = "Agnostic";
+            public const string Any = "Any";
+            public const string Unsupported = "Unsupported";
+        }
+    }
+
+    public partial class FrameworkException : System.Exception
+    {
+        public FrameworkException(string message) { }
+    }
+
+    public partial class FrameworkExpander
+    {
+        public FrameworkExpander() { }
+
+        public FrameworkExpander(IFrameworkNameProvider mappings) { }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> Expand(NuGetFramework framework) { throw null; }
+    }
+
+    public static partial class FrameworkNameHelpers
+    {
+        public static string GetFolderName(string identifierShortName, string versionString, string profileShortName) { throw null; }
+
+        public static string GetPortableProfileNumberString(int profileNumber) { throw null; }
+
+        public static System.Version GetVersion(string versionString) { throw null; }
+
+        public static string GetVersionString(System.Version version) { throw null; }
+    }
+
+    public partial class FrameworkNameProvider : IFrameworkNameProvider
+    {
+        public FrameworkNameProvider(System.Collections.Generic.IEnumerable<IFrameworkMappings> mappings, System.Collections.Generic.IEnumerable<IPortableFrameworkMappings> portableMappings) { }
+
+        public void AddFrameworkPrecedenceMappings(System.Collections.Generic.IDictionary<string, int> destination, System.Collections.Generic.IEnumerable<string> mappings) { }
+
+        public int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y) { throw null; }
+
+        public int CompareFrameworks(NuGetFramework x, NuGetFramework y) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> GetCompatibleCandidates() { throw null; }
+
+        public NuGetFramework GetFullNameReplacement(NuGetFramework framework) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> GetNetStandardVersions() { throw null; }
+
+        public NuGetFramework GetShortNameReplacement(NuGetFramework framework) { throw null; }
+
+        public string GetVersionString(string framework, System.Version version) { throw null; }
+
+        public bool TryGetCompatibilityMappings(NuGetFramework framework, out System.Collections.Generic.IEnumerable<FrameworkRange> supportedFrameworkRanges) { throw null; }
+
+        public bool TryGetEquivalentFrameworks(FrameworkRange range, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetEquivalentFrameworks(NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetIdentifier(string framework, out string identifier) { throw null; }
+
+        public bool TryGetPlatformVersion(string versionString, out System.Version version) { throw null; }
+
+        public bool TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<FrameworkRange> supportedFrameworkRanges) { throw null; }
+
+        public bool TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetPortableFrameworks(string profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetPortableFrameworks(string shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public bool TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGetFramework> supportedFrameworks, out int profileNumber) { throw null; }
+
+        public bool TryGetPortableProfileNumber(string profile, out int profileNumber) { throw null; }
+
+        public bool TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile) { throw null; }
+
+        public bool TryGetShortIdentifier(string identifier, out string identifierShortName) { throw null; }
+
+        public bool TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName) { throw null; }
+
+        public bool TryGetSubSetFrameworks(string frameworkIdentifier, out System.Collections.Generic.IEnumerable<string> subSetFrameworks) { throw null; }
+
+        public bool TryGetVersion(string versionString, out System.Version version) { throw null; }
+    }
+
+    public partial class FrameworkPrecedenceSorter : System.Collections.Generic.IComparer<NuGetFramework>
+    {
+        public FrameworkPrecedenceSorter(IFrameworkNameProvider mappings, bool allEquivalent) { }
+
+        public int Compare(NuGetFramework x, NuGetFramework y) { throw null; }
+    }
+
+    public partial class FrameworkRange : System.IEquatable<FrameworkRange>
+    {
+        public FrameworkRange(NuGetFramework min, NuGetFramework max, bool includeMin, bool includeMax) { }
+
+        public FrameworkRange(NuGetFramework min, NuGetFramework max) { }
+
+        public string FrameworkIdentifier { get { throw null; } }
+
+        public bool IncludeMax { get { throw null; } }
+
+        public bool IncludeMin { get { throw null; } }
+
+        public NuGetFramework Max { get { throw null; } }
+
+        public NuGetFramework Min { get { throw null; } }
+
+        public bool Equals(FrameworkRange other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool Satisfies(NuGetFramework framework) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FrameworkRangeComparer : System.Collections.Generic.IEqualityComparer<FrameworkRange>
+    {
+        public FrameworkRangeComparer() { }
+
+        public bool Equals(FrameworkRange x, FrameworkRange y) { throw null; }
+
+        public int GetHashCode(FrameworkRange obj) { throw null; }
+    }
+
+    public partial class FrameworkReducer
+    {
+        public FrameworkReducer() { }
+
+        public FrameworkReducer(IFrameworkNameProvider mappings, IFrameworkCompatibilityProvider compat) { }
+
+        public NuGetFramework GetNearest(NuGetFramework framework, System.Collections.Generic.IEnumerable<NuGetFramework> possibleFrameworks) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> ReduceDownwards(System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> ReduceEquivalent(System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<NuGetFramework> ReduceUpwards(System.Collections.Generic.IEnumerable<NuGetFramework> frameworks) { throw null; }
+    }
+
+    public partial class FrameworkRuntimePair : System.IEquatable<FrameworkRuntimePair>, System.IComparable<FrameworkRuntimePair>
+    {
+        public FrameworkRuntimePair(NuGetFramework framework, string runtimeIdentifier) { }
+
+        public NuGetFramework Framework { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public FrameworkRuntimePair Clone() { throw null; }
+
+        public int CompareTo(FrameworkRuntimePair other) { throw null; }
+
+        public bool Equals(FrameworkRuntimePair other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static string GetName(NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public static string GetTargetGraphName(NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FrameworkSpecificMapping
+    {
+        public FrameworkSpecificMapping(string frameworkIdentifier, System.Collections.Generic.KeyValuePair<string, string> mapping) { }
+
+        public FrameworkSpecificMapping(string frameworkIdentifier, string key, string value) { }
+
+        public string FrameworkIdentifier { get { throw null; } }
+
+        public System.Collections.Generic.KeyValuePair<string, string> Mapping { get { throw null; } }
+    }
+
+    public partial interface IFrameworkCompatibilityListProvider
+    {
+        System.Collections.Generic.IEnumerable<NuGetFramework> GetFrameworksSupporting(NuGetFramework target);
+    }
+
+    public partial interface IFrameworkCompatibilityProvider
+    {
+        bool IsCompatible(NuGetFramework framework, NuGetFramework other);
+    }
+
+    public partial interface IFrameworkMappings
+    {
+        System.Collections.Generic.IEnumerable<OneWayCompatibilityMappingEntry> CompatibilityMappings { get; }
+
+        System.Collections.Generic.IEnumerable<string> EquivalentFrameworkPrecedence { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> EquivalentFrameworks { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkSpecificMapping> EquivalentProfiles { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> FullNameReplacements { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> IdentifierShortNames { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> IdentifierSynonyms { get; }
+
+        System.Collections.Generic.IEnumerable<string> NonPackageBasedFrameworkPrecedence { get; }
+
+        System.Collections.Generic.IEnumerable<string> PackageBasedFrameworkPrecedence { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkSpecificMapping> ProfileShortNames { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> SubSetFrameworks { get; }
+    }
+
+    public partial interface IFrameworkNameProvider
+    {
+        int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y);
+        int CompareFrameworks(NuGetFramework x, NuGetFramework y);
+        System.Collections.Generic.IEnumerable<NuGetFramework> GetCompatibleCandidates();
+        NuGetFramework GetFullNameReplacement(NuGetFramework framework);
+        System.Collections.Generic.IEnumerable<NuGetFramework> GetNetStandardVersions();
+        NuGetFramework GetShortNameReplacement(NuGetFramework framework);
+        string GetVersionString(string framework, System.Version version);
+        bool TryGetCompatibilityMappings(NuGetFramework framework, out System.Collections.Generic.IEnumerable<FrameworkRange> supportedFrameworkRanges);
+        bool TryGetEquivalentFrameworks(FrameworkRange range, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetEquivalentFrameworks(NuGetFramework framework, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetIdentifier(string identifierShortName, out string identifier);
+        bool TryGetPlatformVersion(string versionString, out System.Version version);
+        bool TryGetPortableCompatibilityMappings(int profile, out System.Collections.Generic.IEnumerable<FrameworkRange> supportedFrameworkRanges);
+        bool TryGetPortableFrameworks(int profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(int profile, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(string profile, bool includeOptional, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableFrameworks(string shortPortableProfiles, out System.Collections.Generic.IEnumerable<NuGetFramework> frameworks);
+        bool TryGetPortableProfile(System.Collections.Generic.IEnumerable<NuGetFramework> supportedFrameworks, out int profileNumber);
+        bool TryGetPortableProfileNumber(string profile, out int profileNumber);
+        bool TryGetProfile(string frameworkIdentifier, string profileShortName, out string profile);
+        bool TryGetShortIdentifier(string identifier, out string identifierShortName);
+        bool TryGetShortProfile(string frameworkIdentifier, string profile, out string profileShortName);
+        bool TryGetSubSetFrameworks(string frameworkIdentifier, out System.Collections.Generic.IEnumerable<string> subSetFrameworkIdentifiers);
+        bool TryGetVersion(string versionString, out System.Version version);
+    }
+
+    public partial interface IFrameworkSpecific
+    {
+        NuGetFramework TargetFramework { get; }
+    }
+
+    public partial interface IFrameworkTargetable
+    {
+        System.Collections.Generic.IEnumerable<NuGetFramework> SupportedFrameworks { get; }
+    }
+
+    public partial interface IPortableFrameworkMappings
+    {
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, FrameworkRange>> CompatibilityMappings { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGetFramework[]>> ProfileFrameworks { get; }
+
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<int, NuGetFramework[]>> ProfileOptionalFrameworks { get; }
+    }
+
+    public partial class NuGetFramework : System.IEquatable<NuGetFramework>
+    {
+        public static readonly NuGetFramework AgnosticFramework;
+        public static readonly NuGetFramework AnyFramework;
+        public static readonly System.Collections.Generic.IEqualityComparer<NuGetFramework> Comparer;
+        public static readonly System.Collections.Generic.IEqualityComparer<NuGetFramework> FrameworkNameComparer;
+        public static readonly NuGetFramework UnsupportedFramework;
+        public NuGetFramework(NuGetFramework framework) { }
+
+        public NuGetFramework(string frameworkIdentifier, System.Version frameworkVersion, string platform, System.Version platformVersion) { }
+
+        public NuGetFramework(string frameworkIdentifier, System.Version frameworkVersion, string frameworkProfile) { }
+
+        public NuGetFramework(string framework, System.Version version) { }
+
+        public NuGetFramework(string framework) { }
+
+        public bool AllFrameworkVersions { get { throw null; } }
+
+        public string DotNetFrameworkName { get { throw null; } }
+
+        public string DotNetPlatformName { get { throw null; } }
+
+        public string Framework { get { throw null; } }
+
+        public bool HasPlatform { get { throw null; } }
+
+        public bool HasProfile { get { throw null; } }
+
+        public bool IsAgnostic { get { throw null; } }
+
+        public bool IsAny { get { throw null; } }
+
+        public bool IsPackageBased { get { throw null; } }
+
+        public bool IsPCL { get { throw null; } }
+
+        public bool IsSpecificFramework { get { throw null; } }
+
+        public bool IsUnsupported { get { throw null; } }
+
+        public string Platform { get { throw null; } }
+
+        public System.Version PlatformVersion { get { throw null; } }
+
+        public string Profile { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public bool Equals(NuGetFramework other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public string GetDotNetFrameworkName(IFrameworkNameProvider mappings) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public string GetShortFolderName() { throw null; }
+
+        public virtual string GetShortFolderName(IFrameworkNameProvider mappings) { throw null; }
+
+        public static bool operator ==(NuGetFramework left, NuGetFramework right) { throw null; }
+
+        public static bool operator !=(NuGetFramework left, NuGetFramework right) { throw null; }
+
+        public static NuGetFramework Parse(string folderName, IFrameworkNameProvider mappings) { throw null; }
+
+        public static NuGetFramework Parse(string folderName) { throw null; }
+
+        public static NuGetFramework ParseComponents(string targetFrameworkMoniker, string targetPlatformMoniker) { throw null; }
+
+        public static NuGetFramework ParseFolder(string folderName, IFrameworkNameProvider mappings) { throw null; }
+
+        public static NuGetFramework ParseFolder(string folderName) { throw null; }
+
+        public static NuGetFramework ParseFrameworkName(string frameworkName, IFrameworkNameProvider mappings) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class NuGetFrameworkExtensions
+    {
+        public static T GetNearest<T>(this System.Collections.Generic.IEnumerable<T> items, NuGetFramework projectFramework)
+            where T : class, IFrameworkSpecific { throw null; }
+
+        public static bool IsDesktop(this NuGetFramework framework) { throw null; }
+    }
+
+    public partial class NuGetFrameworkFullComparer : System.Collections.Generic.IEqualityComparer<NuGetFramework>
+    {
+        public NuGetFrameworkFullComparer() { }
+
+        public bool Equals(NuGetFramework x, NuGetFramework y) { throw null; }
+
+        public int GetHashCode(NuGetFramework obj) { throw null; }
+    }
+
+    public partial class NuGetFrameworkNameComparer : System.Collections.Generic.IEqualityComparer<NuGetFramework>
+    {
+        public NuGetFrameworkNameComparer() { }
+
+        public bool Equals(NuGetFramework x, NuGetFramework y) { throw null; }
+
+        public int GetHashCode(NuGetFramework obj) { throw null; }
+    }
+
+    public partial class NuGetFrameworkSorter : System.Collections.Generic.IComparer<NuGetFramework>
+    {
+        public NuGetFrameworkSorter() { }
+
+        public int Compare(NuGetFramework x, NuGetFramework y) { throw null; }
+    }
+
+    public static partial class NuGetFrameworkUtility
+    {
+        public static T GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGetFramework framework, IFrameworkNameProvider frameworkMappings, IFrameworkCompatibilityProvider compatibilityProvider, System.Func<T, NuGetFramework> selector)
+            where T : class { throw null; }
+
+        public static T GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGetFramework framework, IFrameworkNameProvider frameworkMappings, IFrameworkCompatibilityProvider compatibilityProvider)
+            where T : IFrameworkSpecific { throw null; }
+
+        public static T GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGetFramework framework, System.Func<T, NuGetFramework> selector)
+            where T : class { throw null; }
+
+        public static T GetNearest<T>(System.Collections.Generic.IEnumerable<T> items, NuGetFramework framework)
+            where T : IFrameworkSpecific { throw null; }
+
+        public static bool IsCompatibleWithFallbackCheck(NuGetFramework projectFramework, NuGetFramework candidate) { throw null; }
+
+        public static bool IsNetCore50AndUp(NuGetFramework framework) { throw null; }
+    }
+
+    public partial class OneWayCompatibilityMappingEntry : System.IEquatable<OneWayCompatibilityMappingEntry>
+    {
+        public OneWayCompatibilityMappingEntry(FrameworkRange targetFramework, FrameworkRange supportedFramework) { }
+
+        public static CompatibilityMappingComparer Comparer { get { throw null; } }
+
+        public FrameworkRange SupportedFrameworkRange { get { throw null; } }
+
+        public FrameworkRange TargetFrameworkRange { get { throw null; } }
+
+        public bool Equals(OneWayCompatibilityMappingEntry other) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.frameworks/6.2.2/nuget.frameworks.nuspec
+++ b/src/referencePackages/src/nuget.frameworks/6.2.2/nuget.frameworks.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Frameworks</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's understanding of target frameworks.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.librarymodel/6.2.2/NuGet.LibraryModel.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/6.2.2/NuGet.LibraryModel.6.2.2.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.LibraryModel</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Common" Version="6.2.2" />
+    <PackageReference Include="NuGet.Versioning" Version="6.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.librarymodel/6.2.2/lib/netstandard2.0/NuGet.LibraryModel.cs
+++ b/src/referencePackages/src/nuget.librarymodel/6.2.2/lib/netstandard2.0/NuGet.LibraryModel.cs
@@ -1,0 +1,357 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's types and interfaces for understanding dependencies.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.LibraryModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.LibraryModel
+{
+    public sealed partial class CentralPackageVersion : System.IEquatable<CentralPackageVersion>
+    {
+        public CentralPackageVersion(string name, Versioning.VersionRange versionRange) { }
+
+        public string Name { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public bool Equals(CentralPackageVersion other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CentralPackageVersionNameComparer : System.Collections.Generic.IEqualityComparer<CentralPackageVersion>
+    {
+        public static CentralPackageVersionNameComparer Default { get { throw null; } }
+
+        public bool Equals(CentralPackageVersion x, CentralPackageVersion y) { throw null; }
+
+        public int GetHashCode(CentralPackageVersion obj) { throw null; }
+    }
+
+    public partial class DownloadDependency : System.IEquatable<DownloadDependency>, System.IComparable<DownloadDependency>
+    {
+        public DownloadDependency(string name, Versioning.VersionRange versionRange) { }
+
+        public string Name { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public DownloadDependency Clone() { throw null; }
+
+        public int CompareTo(DownloadDependency other) { throw null; }
+
+        public bool Equals(DownloadDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static implicit operator LibraryRange(DownloadDependency library) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class FrameworkDependency : System.IEquatable<FrameworkDependency>, System.IComparable<FrameworkDependency>
+    {
+        public FrameworkDependency(string name, FrameworkDependencyFlags privateAssets) { }
+
+        public string Name { get { throw null; } }
+
+        public FrameworkDependencyFlags PrivateAssets { get { throw null; } }
+
+        public int CompareTo(FrameworkDependency other) { throw null; }
+
+        public bool Equals(FrameworkDependency other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    [System.Flags]
+    public enum FrameworkDependencyFlags : ushort
+    {
+        None = 0,
+        All = ushort.MaxValue
+    }
+
+    public static partial class FrameworkDependencyFlagsUtils
+    {
+        public static readonly FrameworkDependencyFlags Default;
+        public static FrameworkDependencyFlags GetFlags(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static FrameworkDependencyFlags GetFlags(string flags) { throw null; }
+
+        public static string GetFlagString(FrameworkDependencyFlags flags) { throw null; }
+    }
+
+    public static partial class KnownLibraryProperties
+    {
+        public static readonly string AssemblyPath;
+        public static readonly string FrameworkAssemblies;
+        public static readonly string FrameworkReferences;
+        public static readonly string LockFileLibrary;
+        public static readonly string LockFileTargetLibrary;
+        public static readonly string MSBuildProjectPath;
+        public static readonly string PackageSpec;
+        public static readonly string ProjectFrameworks;
+        public static readonly string ProjectRestoreMetadataFiles;
+        public static readonly string ProjectStyle;
+        public static readonly string TargetFrameworkInformation;
+    }
+
+    public partial class Library
+    {
+        public static readonly System.Collections.Generic.IEqualityComparer<Library> IdentityComparer;
+        public Library() { }
+
+        public System.Collections.Generic.IEnumerable<LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public LibraryIdentity Identity { get { throw null; } set { } }
+
+        public object this[string key] { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, object> Items { get { throw null; } set { } }
+
+        public LibraryRange LibraryRange { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public bool Resolved { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LibraryDependency : System.IEquatable<LibraryDependency>
+    {
+        public LibraryDependency() { }
+
+        public string Aliases { get { throw null; } set { } }
+
+        public bool AutoReferenced { get { throw null; } set { } }
+
+        public bool GeneratePathProperty { get { throw null; } set { } }
+
+        public LibraryIncludeFlags IncludeType { get { throw null; } set { } }
+
+        public LibraryRange LibraryRange { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<Common.NuGetLogCode> NoWarn { get { throw null; } set { } }
+
+        public LibraryDependencyReferenceType ReferenceType { get { throw null; } set { } }
+
+        public LibraryIncludeFlags SuppressParent { get { throw null; } set { } }
+
+        public bool VersionCentrallyManaged { get { throw null; } set { } }
+
+        public Versioning.VersionRange VersionOverride { get { throw null; } set { } }
+
+        public static void ApplyCentralVersionInformation(System.Collections.Generic.IList<LibraryDependency> packageReferences, System.Collections.Generic.IDictionary<string, CentralPackageVersion> centralPackageVersions) { }
+
+        public LibraryDependency Clone() { throw null; }
+
+        public bool Equals(LibraryDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LibraryDependencyInfo
+    {
+        public LibraryDependencyInfo(LibraryIdentity library, bool resolved, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryDependency> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<LibraryDependency> Dependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryIdentity Library { get { throw null; } }
+
+        public bool Resolved { get { throw null; } }
+
+        public static LibraryDependencyInfo Create(LibraryIdentity library, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryDependency> dependencies) { throw null; }
+
+        public static LibraryDependencyInfo CreateUnresolved(LibraryIdentity library, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public enum LibraryDependencyReferenceType
+    {
+        None = 0,
+        Transitive = 1,
+        Direct = 2
+    }
+
+    [System.Flags]
+    public enum LibraryDependencyTarget : ushort
+    {
+        None = 0,
+        Package = 1,
+        Project = 2,
+        ExternalProject = 4,
+        PackageProjectExternal = 7,
+        Assembly = 8,
+        Reference = 16,
+        WinMD = 32,
+        All = 63
+    }
+
+    public static partial class LibraryDependencyTargetUtils
+    {
+        public static string GetFlagString(LibraryDependencyTarget flags) { throw null; }
+
+        public static LibraryDependencyTarget Parse(string flag) { throw null; }
+    }
+
+    public static partial class LibraryExtensions
+    {
+        public static T GetItem<T>(this Library library, string key) { throw null; }
+
+        public static T GetRequiredItem<T>(this Library library, string key) { throw null; }
+
+        public static bool IsEclipsedBy(this LibraryRange library, LibraryRange other) { throw null; }
+    }
+
+    public partial class LibraryIdentity : System.IEquatable<LibraryIdentity>, System.IComparable<LibraryIdentity>
+    {
+        public LibraryIdentity() { }
+
+        public LibraryIdentity(string name, Versioning.NuGetVersion version, LibraryType type) { }
+
+        public string Name { get { throw null; } set { } }
+
+        public LibraryType Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public int CompareTo(LibraryIdentity other) { throw null; }
+
+        public bool Equals(LibraryIdentity other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryIdentity left, LibraryIdentity right) { throw null; }
+
+        public static implicit operator LibraryRange(LibraryIdentity library) { throw null; }
+
+        public static bool operator !=(LibraryIdentity left, LibraryIdentity right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    [System.Flags]
+    public enum LibraryIncludeFlags : ushort
+    {
+        None = 0,
+        Runtime = 1,
+        Compile = 2,
+        Build = 4,
+        Native = 8,
+        ContentFiles = 16,
+        Analyzers = 32,
+        BuildTransitive = 64,
+        All = 127
+    }
+
+    public static partial class LibraryIncludeFlagUtils
+    {
+        public static readonly LibraryIncludeFlags DefaultSuppressParent;
+        public static readonly LibraryIncludeFlags NoContent;
+        public static LibraryIncludeFlags GetFlags(System.Collections.Generic.IEnumerable<string> flags) { throw null; }
+
+        public static LibraryIncludeFlags GetFlags(string flags, LibraryIncludeFlags defaultFlags) { throw null; }
+
+        public static string GetFlagString(LibraryIncludeFlags flags) { throw null; }
+    }
+
+    public partial class LibraryRange : System.IEquatable<LibraryRange>
+    {
+        public LibraryRange() { }
+
+        public LibraryRange(string name, LibraryDependencyTarget typeConstraint) { }
+
+        public LibraryRange(string name, Versioning.VersionRange versionRange, LibraryDependencyTarget typeConstraint) { }
+
+        public string Name { get { throw null; } set { } }
+
+        public LibraryDependencyTarget TypeConstraint { get { throw null; } set { } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } set { } }
+
+        public bool Equals(LibraryRange other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryRange left, LibraryRange right) { throw null; }
+
+        public static bool operator !=(LibraryRange left, LibraryRange right) { throw null; }
+
+        public string ToLockFileDependencyGroupString() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TypeConstraintAllows(LibraryDependencyTarget flag) { throw null; }
+
+        public bool TypeConstraintAllowsAnyOf(LibraryDependencyTarget flag) { throw null; }
+    }
+
+    public partial struct LibraryType : System.IEquatable<LibraryType>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly LibraryType Assembly;
+        public static readonly LibraryType ExternalProject;
+        public static readonly LibraryType Package;
+        public static readonly LibraryType Project;
+        public static readonly LibraryType Reference;
+        public static readonly LibraryType Unresolved;
+        public static readonly LibraryType WinMD;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(LibraryType other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryType left, LibraryType right) { throw null; }
+
+        public static implicit operator string(LibraryType libraryType) { throw null; }
+
+        public static bool operator !=(LibraryType left, LibraryType right) { throw null; }
+
+        public static LibraryType Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.librarymodel/6.2.2/nuget.librarymodel.nuspec
+++ b/src/referencePackages/src/nuget.librarymodel/6.2.2/nuget.librarymodel.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.LibraryModel</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's types and interfaces for understanding dependencies.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Common" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Versioning" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.packaging/6.2.2/NuGet.Packaging.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.2.2/NuGet.Packaging.6.2.2.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Packaging</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.2.2" />
+    <PackageReference Include="NuGet.Versioning" Version="6.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.2.2" />
+    <PackageReference Include="NuGet.Versioning" Version="6.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.packaging/6.2.2/lib/net5.0/NuGet.Packaging.cs
+++ b/src/referencePackages/src/nuget.packaging/6.2.2/lib/net5.0/NuGet.Packaging.cs
@@ -1,0 +1,3686 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Packaging.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Packaging.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's understanding of packages. Reading nuspec, nupkgs and package signing.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Packaging")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Client
+{
+    public partial class ManagedCodeConventions
+    {
+        public ManagedCodeConventions(RuntimeModel.RuntimeGraph runtimeGraph) { }
+
+        public ManagedCodeCriteria Criteria { get { throw null; } }
+
+        public ManagedCodePatterns Patterns { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentModel.ContentPropertyDefinition> Properties { get { throw null; } }
+
+        public partial class ManagedCodeCriteria
+        {
+            public ContentModel.SelectionCriteria ForFramework(Frameworks.NuGetFramework framework) { throw null; }
+
+            public ContentModel.SelectionCriteria ForFrameworkAndRuntime(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+            public ContentModel.SelectionCriteria ForRuntime(string runtimeIdentifier) { throw null; }
+        }
+
+        public partial class ManagedCodePatterns
+        {
+            public ContentModel.PatternSet AnyTargettedFile { get { throw null; } }
+
+            public ContentModel.PatternSet CompileLibAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet CompileRefAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet ContentFiles { get { throw null; } }
+
+            public ContentModel.PatternSet EmbedAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildFiles { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildMultiTargetingFiles { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildTransitiveFiles { get { throw null; } }
+
+            public ContentModel.PatternSet NativeLibraries { get { throw null; } }
+
+            public ContentModel.PatternSet ResourceAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet RuntimeAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet ToolsAssemblies { get { throw null; } }
+        }
+
+        public static partial class PropertyNames
+        {
+            public static readonly string AnyValue;
+            public static readonly string CodeLanguage;
+            public static readonly string Locale;
+            public static readonly string ManagedAssembly;
+            public static readonly string MSBuild;
+            public static readonly string RuntimeIdentifier;
+            public static readonly string SatelliteAssembly;
+            public static readonly string TargetFrameworkMoniker;
+        }
+    }
+}
+
+namespace NuGet.ContentModel
+{
+    public partial class Asset
+    {
+        public Asset() { }
+
+        public string Link { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ContentItem
+    {
+        public ContentItem() { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, object> Properties { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ContentItemCollection
+    {
+        public ContentItemCollection() { }
+
+        public bool HasContract { get { throw null; } }
+
+        public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params PatternSet[] definitions) { throw null; }
+
+        [System.Obsolete("This method causes excessive memory allocation with yield return. Use ContentItemCollection.PopulateItemGroups instead.")]
+        public System.Collections.Generic.IEnumerable<ContentItemGroup> FindItemGroups(PatternSet definition) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<ContentItem> FindItems(PatternSet definition) { throw null; }
+
+        public bool HasItemGroup(SelectionCriteria criteria, params PatternSet[] definitions) { throw null; }
+
+        public void Load(System.Collections.Generic.IEnumerable<string> paths) { }
+
+        public void PopulateItemGroups(PatternSet definition, System.Collections.Generic.IList<ContentItemGroup> contentItemGroupList) { }
+    }
+
+    public partial class ContentItemGroup
+    {
+        public ContentItemGroup() { }
+
+        public System.Collections.Generic.IList<ContentItem> Items { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
+    }
+
+    public partial class ContentPropertyDefinition
+    {
+        public ContentPropertyDefinition(string name, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Collections.Generic.IEnumerable<string> fileExtensions) { }
+
+        public ContentPropertyDefinition(string name, System.Func<object, object, bool> compatibilityTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Collections.Generic.IEnumerable<string> fileExtensions) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest, System.Func<object, object, object, int> compareTest, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest, System.Func<object, object, object, int> compareTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser) { }
+
+        public ContentPropertyDefinition(string name) { }
+
+        public System.Func<object, object, object, int> CompareTest { get { throw null; } }
+
+        public System.Func<object, object, bool> CompatibilityTest { get { throw null; } }
+
+        public bool FileExtensionAllowSubFolders { get { throw null; } }
+
+        public System.Collections.Generic.List<string> FileExtensions { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Func<string, PatternTable, object> Parser { get { throw null; } }
+
+        public virtual int Compare(object criteriaValue, object candidateValue1, object candidateValue2) { throw null; }
+
+        public virtual bool IsCriteriaSatisfied(object critieriaValue, object candidateValue) { throw null; }
+
+        public virtual bool TryLookup(string name, PatternTable table, out object value) { throw null; }
+    }
+
+    public partial class PatternDefinition
+    {
+        public PatternDefinition(string pattern, PatternTable table, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> defaults) { }
+
+        public PatternDefinition(string pattern, PatternTable table) { }
+
+        public PatternDefinition(string pattern) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, object> Defaults { get { throw null; } }
+
+        public string Pattern { get { throw null; } }
+
+        public PatternTable Table { get { throw null; } }
+
+        public static implicit operator PatternDefinition(string pattern) { throw null; }
+    }
+
+    public partial class PatternSet
+    {
+        public PatternSet(System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> properties, System.Collections.Generic.IEnumerable<PatternDefinition> groupPatterns, System.Collections.Generic.IEnumerable<PatternDefinition> pathPatterns) { }
+
+        public System.Collections.Generic.IEnumerable<PatternDefinition> GroupPatterns { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PatternDefinition> PathPatterns { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get { throw null; } set { } }
+    }
+
+    public partial class PatternTable
+    {
+        public PatternTable() { }
+
+        public PatternTable(System.Collections.Generic.IEnumerable<PatternTableEntry> entries) { }
+
+        public bool TryLookup(string propertyName, string name, out object value) { throw null; }
+    }
+
+    public partial class PatternTableEntry
+    {
+        public PatternTableEntry(string propertyName, string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public string PropertyName { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public partial class SelectionCriteria
+    {
+        public SelectionCriteria() { }
+
+        public System.Collections.Generic.IList<SelectionCriteriaEntry> Entries { get { throw null; } set { } }
+    }
+
+    public partial class SelectionCriteriaBuilder
+    {
+        public SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> properties) { }
+
+        public virtual SelectionCriteriaEntryBuilder Add { get { throw null; } }
+
+        public virtual SelectionCriteria Criteria { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> Properties { get { throw null; } }
+    }
+
+    public partial class SelectionCriteriaEntry
+    {
+        public SelectionCriteriaEntry() { }
+
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } set { } }
+    }
+
+    public partial class SelectionCriteriaEntryBuilder : SelectionCriteriaBuilder
+    {
+        internal SelectionCriteriaEntryBuilder() : base(default!) { }
+
+        public override SelectionCriteriaEntryBuilder Add { get { throw null; } }
+
+        public SelectionCriteriaBuilder Builder { get { throw null; } }
+
+        public override SelectionCriteria Criteria { get { throw null; } }
+
+        public SelectionCriteriaEntry Entry { get { throw null; } }
+
+        public SelectionCriteriaEntryBuilder this[string key, object value] { get { throw null; } }
+
+        public SelectionCriteriaEntryBuilder this[string key, string value] { get { throw null; } }
+    }
+}
+
+namespace NuGet.ContentModel.Infrastructure
+{
+    public partial class PatternExpression
+    {
+        public PatternExpression(PatternDefinition pattern) { }
+
+        public ContentItem Match(string path, System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging
+{
+    public static partial class CollectionExtensions
+    {
+        public static void AddRange<T>(this System.Collections.Generic.ICollection<T> collection, System.Collections.Generic.IEnumerable<T> items) { }
+    }
+
+    public enum ExtractionSource
+    {
+        RestoreCommand = 0,
+        DownloadResource = 1,
+        NuGetFolderProject = 2
+    }
+
+    public partial class FallbackPackagePathInfo
+    {
+        public FallbackPackagePathInfo(string id, Versioning.NuGetVersion version, VersionFolderPathResolver resolver) { }
+
+        public string Id { get { throw null; } }
+
+        public VersionFolderPathResolver PathResolver { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+    }
+
+    public partial class FallbackPackagePathResolver
+    {
+        public FallbackPackagePathResolver(Common.INuGetPathContext pathContext) { }
+
+        public FallbackPackagePathResolver(string userPackageFolder, System.Collections.Generic.IEnumerable<string> fallbackPackageFolders) { }
+
+        public string GetPackageDirectory(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageDirectory(string packageId, string version) { throw null; }
+
+        public FallbackPackagePathInfo GetPackageInfo(string packageId, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class FrameworkAssemblyReference
+    {
+        public FrameworkAssemblyReference(string assemblyName, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> supportedFrameworks) { }
+
+        public string AssemblyName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> SupportedFrameworks { get { throw null; } }
+    }
+
+    public static partial class FrameworkNameUtility
+    {
+        public static System.Runtime.Versioning.FrameworkName ParseFrameworkFolderName(string path, bool strictParsing, out string effectivePath) { throw null; }
+
+        public static System.Runtime.Versioning.FrameworkName ParseFrameworkNameFromFilePath(string filePath, out string effectivePath) { throw null; }
+
+        public static Frameworks.NuGetFramework ParseNuGetFrameworkFolderName(string path, bool strictParsing, out string effectivePath) { throw null; }
+
+        public static Frameworks.NuGetFramework ParseNuGetFrameworkFromFilePath(string filePath, out string effectivePath) { throw null; }
+    }
+
+    public sealed partial class FrameworkReference : System.IEquatable<FrameworkReference>, System.Collections.Generic.IComparer<FrameworkReference>, System.IComparable<FrameworkReference>
+    {
+        public FrameworkReference(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public int Compare(FrameworkReference x, FrameworkReference y) { throw null; }
+
+        public int CompareTo(FrameworkReference other) { throw null; }
+
+        public bool Equals(FrameworkReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class FrameworkReferenceGroup : System.IEquatable<FrameworkReferenceGroup>, Frameworks.IFrameworkSpecific
+    {
+        public FrameworkReferenceGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<FrameworkReference> frameworkReferences) { }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReference> FrameworkReferences { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(FrameworkReferenceGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class FrameworksExtensions
+    {
+        public static string GetFrameworkString(this Frameworks.NuGetFramework self) { throw null; }
+    }
+
+    public partial class FrameworkSpecificGroup : System.IEquatable<FrameworkSpecificGroup>, Frameworks.IFrameworkSpecific
+    {
+        public FrameworkSpecificGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<string> items) { }
+
+        public bool HasEmptyFolder { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Items { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(FrameworkSpecificGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial interface IAsyncPackageContentReader
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IHashFunction : System.IDisposable
+    {
+        string GetHash();
+        void Update(byte[] data, int offset, int count);
+    }
+
+    public partial interface INuspecReader : Core.INuspecCoreReader
+    {
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkReferenceGroups();
+        string GetLanguage();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceGroups();
+    }
+
+    public partial interface IPackageContentReader
+    {
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetBuildItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetContentItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetLibItems();
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetPackageDependencies();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetToolItems();
+    }
+
+    public partial interface IPackageDownloader : System.IDisposable
+    {
+        IAsyncPackageContentReader ContentReader { get; }
+
+        Core.IAsyncPackageCoreReader CoreReader { get; }
+
+        Signing.ISignedPackageReader SignedPackageReader { get; }
+
+        string Source { get; }
+
+        System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken);
+        void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync);
+        void SetThrottle(System.Threading.SemaphoreSlim throttle);
+    }
+
+    public partial interface IPackageFile
+    {
+        string EffectivePath { get; }
+
+        System.DateTimeOffset LastWriteTime { get; }
+
+        Frameworks.NuGetFramework NuGetFramework { get; }
+
+        string Path { get; }
+
+        [System.Obsolete("Use NuGetFramework instead. This property will be null for any frameworks net5.0 or above.")]
+        System.Runtime.Versioning.FrameworkName TargetFramework { get; }
+
+        System.IO.Stream GetStream();
+    }
+
+    public partial interface IPackageMetadata
+    {
+        System.Collections.Generic.IEnumerable<string> Authors { get; }
+
+        System.Collections.Generic.IEnumerable<ManifestContentFiles> ContentFiles { get; }
+
+        string Copyright { get; }
+
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> DependencyGroups { get; }
+
+        string Description { get; }
+
+        bool DevelopmentDependency { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get; }
+
+        string Icon { get; }
+
+        System.Uri IconUrl { get; }
+
+        string Id { get; }
+
+        string Language { get; }
+
+        LicenseMetadata LicenseMetadata { get; }
+
+        System.Uri LicenseUrl { get; }
+
+        System.Version MinClientVersion { get; }
+
+        System.Collections.Generic.IEnumerable<string> Owners { get; }
+
+        System.Collections.Generic.IEnumerable<PackageReferenceSet> PackageAssemblyReferences { get; }
+
+        System.Collections.Generic.IEnumerable<Core.PackageType> PackageTypes { get; }
+
+        System.Uri ProjectUrl { get; }
+
+        string Readme { get; }
+
+        string ReleaseNotes { get; }
+
+        Core.RepositoryMetadata Repository { get; }
+
+        bool RequireLicenseAcceptance { get; }
+
+        bool Serviceable { get; }
+
+        string Summary { get; }
+
+        string Tags { get; }
+
+        string Title { get; }
+
+        Versioning.NuGetVersion Version { get; }
+    }
+
+    public partial interface IPackageResolver
+    {
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<Core.PackageIdentity> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Collections.Generic.IEnumerable<PackageReference> installedPackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<Core.PackageIdentity> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<string> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Collections.Generic.IEnumerable<PackageReference> installedPackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<string> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Threading.CancellationToken token);
+    }
+
+    public partial class LicenseMetadata : System.IEquatable<LicenseMetadata>
+    {
+        public static readonly System.Version CurrentVersion;
+        public static readonly System.Version EmptyVersion;
+        public static readonly System.Uri LicenseFileDeprecationUrl;
+        public static readonly string LicenseServiceLinkTemplate;
+        public LicenseMetadata(LicenseType type, string license, Licenses.NuGetLicenseExpression expression, System.Collections.Generic.IReadOnlyList<string> warningsAndErrors, System.Version version) { }
+
+        public string License { get { throw null; } }
+
+        public Licenses.NuGetLicenseExpression LicenseExpression { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public LicenseType Type { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> WarningsAndErrors { get { throw null; } }
+
+        public bool Equals(LicenseMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum LicenseType
+    {
+        File = 0,
+        Expression = 1
+    }
+
+    [System.Obsolete("Use NuGet.Protocol.LocalPackageArchiveDownloader")]
+    public sealed partial class LocalPackageArchiveDownloader : IPackageDownloader, System.IDisposable
+    {
+        public LocalPackageArchiveDownloader(string source, string packageFilePath, Core.PackageIdentity packageIdentity, Common.ILogger logger) { }
+
+        public IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class Manifest
+    {
+        public Manifest(ManifestMetadata metadata, System.Collections.Generic.ICollection<ManifestFile> files) { }
+
+        public Manifest(ManifestMetadata metadata) { }
+
+        public System.Collections.Generic.ICollection<ManifestFile> Files { get { throw null; } }
+
+        public bool HasFilesNode { get { throw null; } }
+
+        public ManifestMetadata Metadata { get { throw null; } }
+
+        public static Manifest Create(IPackageMetadata metadata) { throw null; }
+
+        public static Manifest ReadFrom(System.IO.Stream stream, bool validateSchema) { throw null; }
+
+        public static Manifest ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema) { throw null; }
+
+        public void Save(System.IO.Stream stream, bool generateBackwardsCompatible) { }
+
+        public void Save(System.IO.Stream stream, int minimumManifestVersion, bool generateBackwardsCompatible) { }
+
+        public void Save(System.IO.Stream stream, int minimumManifestVersion) { }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public static void Validate(Manifest manifest) { }
+    }
+
+    public partial class ManifestContentFiles
+    {
+        public ManifestContentFiles() { }
+
+        public string BuildAction { get { throw null; } set { } }
+
+        public string CopyToOutput { get { throw null; } set { } }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Flatten { get { throw null; } set { } }
+
+        public string Include { get { throw null; } set { } }
+    }
+
+    public partial class ManifestFile
+    {
+        public ManifestFile() { }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public string Target { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    public partial class ManifestMetadata : IPackageMetadata
+    {
+        public ManifestMetadata() { }
+
+        public ManifestMetadata(IPackageMetadata copy) { }
+
+        public System.Collections.Generic.IEnumerable<string> Authors { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<ManifestContentFiles> ContentFiles { get { throw null; } set { } }
+
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> DependencyGroups { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public bool DevelopmentDependency { get { throw null; } set { } }
+
+        public bool EmitRequireLicenseAcceptance { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get { throw null; } set { } }
+
+        public string Icon { get { throw null; } set { } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public string Id { get { throw null; } set { } }
+
+        public string Language { get { throw null; } set { } }
+
+        public LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public System.Version MinClientVersion { get { throw null; } }
+
+        public string MinClientVersionString { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<PackageReferenceSet> PackageAssemblyReferences { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Core.PackageType> PackageTypes { get { throw null; } set { } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public string Readme { get { throw null; } set { } }
+
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        public Core.RepositoryMetadata Repository { get { throw null; } set { } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string Summary { get { throw null; } set { } }
+
+        public string Tags { get { throw null; } set { } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public void SetIconUrl(string iconUrl) { }
+
+        public void SetLicenseUrl(string licenseUrl) { }
+
+        public void SetProjectUrl(string projectUrl) { }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    public static partial class ManifestSchemaUtility
+    {
+        public static string GetSchemaNamespace(int version) { throw null; }
+
+        public static int GetVersionFromNamespace(string @namespace) { throw null; }
+
+        public static bool IsKnownSchema(string schemaNamespace) { throw null; }
+    }
+
+    public static partial class ManifestVersionUtility
+    {
+        public const int DefaultVersion = 1;
+        public const int SemverVersion = 3;
+        public const int TargetFrameworkSupportForDependencyContentsAndToolsVersion = 4;
+        public const int TargetFrameworkSupportForReferencesVersion = 5;
+        public const int XdtTransformationVersion = 6;
+        public static int GetManifestVersion(ManifestMetadata metadata) { throw null; }
+    }
+
+    public partial class MinClientVersionException : Core.PackagingException, Common.ILogMessageException
+    {
+        public MinClientVersionException(string message) : base(default!) { }
+
+        public override Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public static partial class MinClientVersionUtility
+    {
+        public static Versioning.NuGetVersion GetNuGetClientVersion() { throw null; }
+
+        public static bool IsMinClientVersionCompatible(Core.NuspecCoreReaderBase nuspecReader) { throw null; }
+
+        public static bool IsMinClientVersionCompatible(Versioning.NuGetVersion packageMinClientVersion) { throw null; }
+
+        public static void VerifyMinClientVersion(Core.NuspecCoreReaderBase nuspecReader) { }
+    }
+
+    public partial class NupkgMetadataFile : System.IEquatable<NupkgMetadataFile>
+    {
+        public NupkgMetadataFile() { }
+
+        public string ContentHash { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(NupkgMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class NupkgMetadataFileFormat
+    {
+        public static readonly int Version;
+        public static NupkgMetadataFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static NupkgMetadataFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static NupkgMetadataFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static NupkgMetadataFile Read(string filePath) { throw null; }
+
+        public static void Write(System.IO.Stream stream, NupkgMetadataFile hashFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, NupkgMetadataFile hashFile) { }
+
+        public static void Write(string filePath, NupkgMetadataFile hashFile) { }
+    }
+
+    public partial class NuspecReader : Core.NuspecCoreReaderBase
+    {
+        public NuspecReader(System.IO.Stream stream, Frameworks.IFrameworkNameProvider frameworkProvider, bool leaveStreamOpen) : base(stream) { }
+
+        public NuspecReader(System.IO.Stream stream) : base(stream) { }
+
+        public NuspecReader(string path, Frameworks.IFrameworkNameProvider frameworkProvider) : base(path) { }
+
+        public NuspecReader(string path) : base(path) { }
+
+        public NuspecReader(System.Xml.Linq.XDocument xml, Frameworks.IFrameworkNameProvider frameworkProvider) : base(xml) { }
+
+        public NuspecReader(System.Xml.Linq.XDocument xml) : base(xml) { }
+
+        public string GetAuthors() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Core.ContentFilesEntry> GetContentFiles() { throw null; }
+
+        public string GetCopyright() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups(bool useStrictVersionCheck) { throw null; }
+
+        public string GetDescription() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkAssemblyGroups() { throw null; }
+
+        [System.Obsolete("GetFrameworkReferenceGroups() is deprecated. Please use GetFrameworkAssemblyGroups() instead.")]
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkReferenceGroups() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> GetFrameworkRefGroups() { throw null; }
+
+        public string GetIcon() { throw null; }
+
+        public string GetIconUrl() { throw null; }
+
+        public string GetLanguage() { throw null; }
+
+        public LicenseMetadata GetLicenseMetadata() { throw null; }
+
+        public string GetLicenseUrl() { throw null; }
+
+        public string GetOwners() { throw null; }
+
+        public string GetProjectUrl() { throw null; }
+
+        public string GetReadme() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceGroups() { throw null; }
+
+        public string GetReleaseNotes() { throw null; }
+
+        public Core.RepositoryMetadata GetRepositoryMetadata() { throw null; }
+
+        public bool GetRequireLicenseAcceptance() { throw null; }
+
+        public string GetSummary() { throw null; }
+
+        public string GetTags() { throw null; }
+
+        public string GetTitle() { throw null; }
+    }
+
+    public partial class PackageArchiveReader : PackageReaderBase
+    {
+        public PackageArchiveReader(System.IO.Compression.ZipArchive zipArchive, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Compression.ZipArchive zipArchive) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, bool leaveStreamOpen, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, bool leaveStreamOpen) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream) : base(default!) { }
+
+        public PackageArchiveReader(string filePath, Frameworks.IFrameworkNameProvider frameworkProvider = null, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider = null) : base(default!) { }
+
+        protected Signing.SigningSpecifications SigningSpecifications { get { throw null; } }
+
+        protected System.IO.Stream ZipReadStream { get { throw null; } set { } }
+
+        public override bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public System.Collections.Generic.IEnumerable<ZipFilePair> EnumeratePackageEntries(System.Collections.Generic.IEnumerable<string> packageFiles, string packageDirectory) { throw null; }
+
+        public string ExtractFile(string packageFile, string targetFilePath, Common.ILogger logger) { throw null; }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithmName, System.Threading.CancellationToken token) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public System.IO.Compression.ZipArchiveEntry GetEntry(string packageFile) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        protected void ThrowIfZipReadStreamIsNull() { }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task ValidatePackageEntriesAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageBuilder : IPackageMetadata
+    {
+        public const int MaxIconFileSize = 1048576;
+        public PackageBuilder() { }
+
+        public PackageBuilder(bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(bool deterministic) { }
+
+        public PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider) { }
+
+        public PackageBuilder(System.IO.Stream stream, string basePath) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories) { }
+
+        public System.Collections.Generic.ISet<string> Authors { get { throw null; } }
+
+        public System.Collections.Generic.ICollection<ManifestContentFiles> ContentFiles { get { throw null; } }
+
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.ObjectModel.Collection<PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public string Description { get { throw null; } set { } }
+
+        public bool DevelopmentDependency { get { throw null; } set { } }
+
+        public bool EmitRequireLicenseAcceptance { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<IPackageFile> Files { get { throw null; } }
+
+        public System.Collections.ObjectModel.Collection<FrameworkReferenceGroup> FrameworkReferenceGroups { get { throw null; } }
+
+        public System.Collections.ObjectModel.Collection<FrameworkAssemblyReference> FrameworkReferences { get { throw null; } }
+
+        public bool HasSnapshotVersion { get { throw null; } set { } }
+
+        public string Icon { get { throw null; } set { } }
+
+        public System.Uri IconUrl { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public string Language { get { throw null; } set { } }
+
+        public LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+        public System.Uri LicenseUrl { get { throw null; } set { } }
+
+        public System.Version MinClientVersion { get { throw null; } set { } }
+
+        System.Collections.Generic.IEnumerable<string> IPackageMetadata.Authors { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<ManifestContentFiles> IPackageMetadata.ContentFiles { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> IPackageMetadata.DependencyGroups { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> IPackageMetadata.FrameworkReferenceGroups { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> IPackageMetadata.FrameworkReferences { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<string> IPackageMetadata.Owners { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<PackageReferenceSet> IPackageMetadata.PackageAssemblyReferences { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<Core.PackageType> IPackageMetadata.PackageTypes { get { throw null; } }
+
+        string IPackageMetadata.Tags { get { throw null; } }
+
+        public string OutputName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> Owners { get { throw null; } }
+
+        public System.Collections.Generic.ICollection<PackageReferenceSet> PackageAssemblyReferences { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<Core.PackageType> PackageTypes { get { throw null; } set { } }
+
+        public System.Uri ProjectUrl { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> Properties { get { throw null; } }
+
+        public string Readme { get { throw null; } set { } }
+
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        public Core.RepositoryMetadata Repository { get { throw null; } set { } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string Summary { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> Tags { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> TargetFrameworks { get { throw null; } set { } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public void AddFiles(string basePath, string source, string destination, string exclude = null) { }
+
+        public void Populate(ManifestMetadata manifestMetadata) { }
+
+        public void PopulateFiles(string basePath, System.Collections.Generic.IEnumerable<ManifestFile> files) { }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public static void ValidateReferenceAssemblies(System.Collections.Generic.IEnumerable<IPackageFile> files, System.Collections.Generic.IEnumerable<PackageReferenceSet> packageAssemblyReferences) { }
+    }
+
+    public partial class PackageDependencyGroup : System.IEquatable<PackageDependencyGroup>, Frameworks.IFrameworkSpecific
+    {
+        public PackageDependencyGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<Core.PackageDependency> packages) { }
+
+        public System.Collections.Generic.IEnumerable<Core.PackageDependency> Packages { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(PackageDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageExtractionContext
+    {
+        public PackageExtractionContext(PackageSaveMode packageSaveMode, XmlDocFileSaveMode xmlDocFileSaveMode, Signing.ClientPolicyContext clientPolicyContext, Common.ILogger logger) { }
+
+        public Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } }
+
+        public bool CopySatelliteFiles { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public Signing.IPackageSignatureVerifier SignedPackageVerifier { get { throw null; } set { } }
+
+        public XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+
+    public partial class PackageExtractionResult
+    {
+        public PackageExtractionResult(bool cached, System.TimeSpan signVerifyDelay, PackageSignType packageType, bool success, System.DateTimeOffset signVerifyStartTime, System.DateTimeOffset signVerifyEndTime) { }
+
+        public PackageExtractionResult(bool cached, System.TimeSpan signVerifyDelay, PackageSignType packageType, bool success, System.TimeSpan duration) { }
+
+        public bool Cached { get { throw null; } }
+
+        public System.TimeSpan Duration { get { throw null; } set { } }
+
+        public PackageSignType PackageType { get { throw null; } }
+
+        public System.TimeSpan SignVerifyDelay { get { throw null; } }
+
+        public System.DateTimeOffset SignVerifyEndTime { get { throw null; } }
+
+        public System.DateTimeOffset SignVerifyStartTime { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+    }
+
+    public partial class PackageExtractionTelemetryEvent : Common.TelemetryEvent
+    {
+        public const string EventName = "PackageExtractionInformation";
+        public PackageExtractionTelemetryEvent(PackageSaveMode packageSaveMode, Common.NuGetOperationStatus status, ExtractionSource extractionSource, Core.PackageIdentity packageId = null) : base(default!) { }
+
+        public ExtractionSource ExtractionSource { get { throw null; } }
+
+        public string PackageId { get { throw null; } }
+
+        public PackageSaveMode PackageSaveMode { get { throw null; } }
+
+        public string PackageVersion { get { throw null; } }
+
+        public Common.NuGetOperationStatus Status { get { throw null; } }
+
+        public void LogPackageIdentity(Core.PackageIdentity packageId) { }
+
+        public void SetResult(Common.NuGetOperationStatus status) { }
+    }
+
+    public static partial class PackageExtractor
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopySatelliteFilesAsync(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, PackageReaderBase packageReader, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, PackageReaderBase packageReader, System.IO.Stream packageStream, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, System.IO.Stream packageStream, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> InstallFromSourceAsync(Core.PackageIdentity packageIdentity, IPackageDownloader packageDownloader, VersionFolderPathResolver versionFolderPathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> InstallFromSourceAsync(string source, Core.PackageIdentity packageIdentity, System.Func<System.IO.Stream, System.Threading.Tasks.Task> copyToAsync, VersionFolderPathResolver versionFolderPathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+    }
+
+    public partial class PackageFileExtractor
+    {
+        public PackageFileExtractor(System.Collections.Generic.IEnumerable<string> packageFiles, XmlDocFileSaveMode xmlDocFileSaveMode) { }
+
+        public string ExtractPackageFile(string source, string target, System.IO.Stream stream) { throw null; }
+    }
+
+    public partial class PackageFolderReader : PackageReaderBase
+    {
+        public PackageFolderReader(System.IO.DirectoryInfo folder, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageFolderReader(System.IO.DirectoryInfo folder) : base(default!) { }
+
+        public PackageFolderReader(string folderPath, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageFolderReader(string folderPath) : base(default!) { }
+
+        public override bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override string GetNuspecFile() { throw null; }
+
+        public override System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class PackageHelper
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<ZipFilePair>> GetInstalledPackageFilesAsync(PackageArchiveReader packageReader, Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<string, System.Collections.Generic.IEnumerable<ZipFilePair>>> GetInstalledSatelliteFilesAsync(PackageArchiveReader packageReader, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<string, System.Collections.Generic.IEnumerable<string>>> GetSatelliteFilesAsync(PackageReaderBase packageReader, PackagePathResolver packagePathResolver, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static bool IsAssembly(string path) { throw null; }
+
+        public static bool IsManifest(string path) { throw null; }
+
+        public static bool IsNuspec(string path) { throw null; }
+
+        public static bool IsPackageFile(string packageFileName, PackageSaveMode packageSaveMode) { throw null; }
+
+        public static bool IsRoot(string path) { throw null; }
+    }
+
+    public static partial class PackageIdValidator
+    {
+        public const int MaxPackageIdLength = 100;
+        public static bool IsValidPackageId(string packageId) { throw null; }
+
+        public static void ValidatePackageId(string packageId) { }
+    }
+
+    public static partial class PackagePathHelper
+    {
+        public static string GetInstalledPackageFilePath(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPackageLookupPaths(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver) { throw null; }
+    }
+
+    public partial class PackagePathResolver
+    {
+        public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true) { }
+
+        protected internal string Root { get { throw null; } }
+
+        public bool UseSideBySidePaths { get { throw null; } }
+
+        public virtual string GetInstalledPackageFilePath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetInstalledPath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetInstallPath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public string GetManifestFileName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetPackageDirectoryName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public string GetPackageDownloadMarkerFileName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetPackageFileName(Core.PackageIdentity packageIdentity) { throw null; }
+    }
+
+    public abstract partial class PackageReaderBase : Core.IPackageCoreReader, System.IDisposable, IPackageContentReader, Core.IAsyncPackageCoreReader, IAsyncPackageContentReader, Signing.ISignedPackageReader
+    {
+        public PackageReaderBase(Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) { }
+
+        public PackageReaderBase(Frameworks.IFrameworkNameProvider frameworkProvider) { }
+
+        protected Frameworks.IFrameworkCompatibilityProvider CompatibilityProvider { get { throw null; } set { } }
+
+        protected Frameworks.IFrameworkNameProvider FrameworkProvider { get { throw null; } set { } }
+
+        public virtual NuspecReader NuspecReader { get { throw null; } }
+
+        public abstract bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings);
+        public abstract System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetBuildItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetContentItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual bool GetDevelopmentDependency() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFileGroups(string folder) { throw null; }
+
+        public abstract System.Collections.Generic.IEnumerable<string> GetFiles();
+        public abstract System.Collections.Generic.IEnumerable<string> GetFiles(string folder);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected Frameworks.NuGetFramework GetFrameworkFromPath(string path, bool allowSubFolders = false) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual Core.PackageIdentity GetIdentity() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Core.PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetItems(string folderName) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetLibItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.IO.Stream GetNuspec() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual string GetNuspecFile() { throw null; }
+
+        protected static string GetNuspecFile(System.Collections.Generic.IEnumerable<string> files) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<NuspecReader> GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetPackageDependencies() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<Core.PackageType> GetPackageTypes() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Core.PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.IO.Stream GetStream(string path);
+        public virtual System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetSupportedFrameworks() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework>> GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetToolItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected static bool IsAllowedBuildFile(string packageId, string path) { throw null; }
+
+        protected static bool IsReferenceAssembly(string path) { throw null; }
+
+        public virtual bool IsServiceable() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> IsServiceableAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token);
+        protected string NormalizeDirectoryPath(string path) { throw null; }
+
+        public abstract System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token);
+        protected static void ValidatePackageEntries(string normalizedDestination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.PackageIdentity packageIdentity) { }
+
+        protected static void ValidatePackageEntry(string normalizedDestination, string normalizedFilePath, Core.PackageIdentity packageIdentity) { }
+    }
+
+    public static partial class PackageReaderExtensions
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetPackageFilesAsync(this Core.IAsyncPackageCoreReader packageReader, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetSatelliteFilesAsync(this IAsyncPackageContentReader packageReader, string packageLanguage, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageReference
+    {
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled, bool developmentDependency, bool requireReinstallation, Versioning.VersionRange allowedVersions) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled, bool developmentDependency, bool requireReinstallation) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public Versioning.VersionRange AllowedVersions { get { throw null; } }
+
+        public bool HasAllowedVersions { get { throw null; } }
+
+        public bool IsDevelopmentDependency { get { throw null; } }
+
+        public bool IsUserInstalled { get { throw null; } }
+
+        public Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public bool RequireReinstallation { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageReferenceSet
+    {
+        public PackageReferenceSet(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<string> references) { }
+
+        public PackageReferenceSet(System.Collections.Generic.IEnumerable<string> references) { }
+
+        public PackageReferenceSet(string targetFramework, System.Collections.Generic.IEnumerable<string> references) { }
+
+        public System.Collections.Generic.IReadOnlyCollection<string> References { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    [System.Flags]
+    public enum PackageSaveMode
+    {
+        None = 0,
+        Nuspec = 1,
+        Nupkg = 2,
+        Files = 4,
+        Defaultv2 = 6,
+        Defaultv3 = 7
+    }
+
+    public static partial class PackagesConfig
+    {
+        public static readonly string allowedVersionsAttributeName;
+        public static readonly string developmentDependencyAttributeName;
+        public static readonly string IdAttributeName;
+        public static readonly string MinClientAttributeName;
+        public static readonly string PackageNodeName;
+        public static readonly string PackagesNodeName;
+        public static readonly string RequireInstallAttributeName;
+        public static readonly string TargetFrameworkAttributeName;
+        public static readonly string UserInstalledAttributeName;
+        public static readonly string VersionAttributeName;
+        public static bool BoolAttribute(System.Xml.Linq.XElement node, string name, bool defaultValue = false) { throw null; }
+
+        public static bool HasAttributeValue(System.Xml.Linq.XElement node, string attributeName, string targetValue, out System.Xml.Linq.XElement element) { throw null; }
+
+        public static bool TryGetAttribute(System.Xml.Linq.XElement node, string name, out string value) { throw null; }
+    }
+
+    public partial class PackagesConfigReader
+    {
+        public PackagesConfigReader(Frameworks.IFrameworkNameProvider frameworkMappings, System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public PackagesConfigReader(Frameworks.IFrameworkNameProvider frameworkMappings, System.Xml.Linq.XDocument xml) { }
+
+        public PackagesConfigReader(System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public PackagesConfigReader(System.IO.Stream stream) { }
+
+        public PackagesConfigReader(System.Xml.Linq.XDocument xml) { }
+
+        public Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageReference> GetPackages() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageReference> GetPackages(bool allowDuplicatePackageIds) { throw null; }
+    }
+
+    public partial class PackagesConfigReaderException : Core.PackagingException
+    {
+        public PackagesConfigReaderException(string message, System.Exception innerException) : base(default!) { }
+
+        public PackagesConfigReaderException(string message) : base(default!) { }
+    }
+
+    public partial class PackagesConfigWriter : System.IDisposable
+    {
+        public PackagesConfigWriter(System.IO.Stream stream, bool createNew, Frameworks.IFrameworkNameProvider frameworkMappings) { }
+
+        public PackagesConfigWriter(System.IO.Stream stream, bool createNew) { }
+
+        public PackagesConfigWriter(string fullPath, bool createNew, Frameworks.IFrameworkNameProvider frameworkMappings) { }
+
+        public PackagesConfigWriter(string fullPath, bool createNew) { }
+
+        public void AddPackageEntry(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public void AddPackageEntry(PackageReference entry) { }
+
+        public void AddPackageEntry(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework targetFramework) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public void RemovePackageEntry(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public void RemovePackageEntry(PackageReference entry) { }
+
+        public void RemovePackageEntry(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework targetFramework) { }
+
+        public void UpdateOrAddPackageEntry(System.Xml.Linq.XDocument originalConfig, PackageReference newEntry) { }
+
+        public void UpdatePackageEntry(PackageReference oldEntry, PackageReference newEntry) { }
+
+        public void WriteFile(string fullPath) { }
+
+        public void WriteMinClientVersion(Versioning.NuGetVersion version) { }
+    }
+
+    public partial class PackagesConfigWriterException : Core.PackagingException
+    {
+        public PackagesConfigWriterException(string message, System.Exception innerException) : base(default!) { }
+
+        public PackagesConfigWriterException(string message) : base(default!) { }
+    }
+
+    public partial class PackageSigningTelemetryEvent : Common.TelemetryEvent
+    {
+        public const string EventName = "SigningInformation";
+        public PackageSigningTelemetryEvent() : base(default!) { }
+
+        public string ExtractionId { get { throw null; } }
+
+        public PackageSignType PackageSignType { get { throw null; } }
+
+        public Common.NuGetOperationStatus Status { get { throw null; } }
+
+        public void SetResult(PackageSignType packageSignType, Common.NuGetOperationStatus status) { }
+    }
+
+    public enum PackageSignType
+    {
+        Signed = 0,
+        Unsigned = 1
+    }
+
+    public static partial class PackagingConstants
+    {
+        public static readonly string AgnosticFramework;
+        public static readonly string AnyCodeLanguage;
+        public static readonly string AnyFramework;
+        public static readonly string ContentFilesDefaultBuildAction;
+        public static readonly string ManifestExtension;
+        public static readonly string PackageVerifyDurationName;
+        public static readonly string SnupkgFormat;
+        public static readonly string SymbolsNupkgFormat;
+        public static readonly string TargetFrameworkPropertyKey;
+        public static partial class Folders
+        {
+            public static readonly string Analyzers;
+            public static readonly string Build;
+            public static readonly string BuildCrossTargeting;
+            public static readonly string BuildTransitive;
+            public static readonly string Content;
+            public static readonly string ContentFiles;
+            public static readonly string Lib;
+            public static readonly string Native;
+            public static readonly string Ref;
+            public static readonly string Runtimes;
+            public static readonly string Source;
+            public static readonly string Tools;
+            public static string[] Known { get { throw null; } }
+        }
+    }
+
+    public partial class PhysicalPackageFile : IPackageFile
+    {
+        public PhysicalPackageFile() { }
+
+        public PhysicalPackageFile(System.IO.MemoryStream stream) { }
+
+        public string EffectivePath { get { throw null; } }
+
+        public System.DateTimeOffset LastWriteTime { get { throw null; } }
+
+        public Frameworks.NuGetFramework NuGetFramework { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        public System.Runtime.Versioning.FrameworkName TargetFramework { get { throw null; } }
+
+        public string TargetPath { get { throw null; } set { } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public System.IO.Stream GetStream() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RepositorySignatureInfo
+    {
+        public RepositorySignatureInfo(bool allRepositorySigned, System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> repositoryCertificateInfos) { }
+
+        public bool AllRepositorySigned { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> RepositoryCertificateInfos { get { throw null; } }
+    }
+
+    public partial class RepositorySignatureInfoProvider
+    {
+        public RepositorySignatureInfoProvider() { }
+
+        public static RepositorySignatureInfoProvider Instance { get { throw null; } }
+
+        public void AddOrUpdateRepositorySignatureInfo(string source, RepositorySignatureInfo repositorySignatureInfo) { }
+
+        public bool TryGetRepositorySignatureInfo(string source, out RepositorySignatureInfo repositorySignatureInfo) { throw null; }
+    }
+
+    public sealed partial class Sha512HashFunction : IHashFunction, System.IDisposable
+    {
+        public Sha512HashFunction() { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public byte[] GetHashBytes() { throw null; }
+
+        public void Update(byte[] data, int offset, int count) { }
+    }
+
+    public static partial class StreamExtensions
+    {
+        public static string CopyToFile(this System.IO.Stream inputStream, string fileFullPath) { throw null; }
+    }
+
+    public static partial class TopologicalSortUtility
+    {
+        public static System.Collections.Generic.IReadOnlyList<Core.PackageDependencyInfo> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> packages) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<T> SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T> items, System.StringComparer comparer, System.Func<T, string> getId, System.Func<T, string[]> getDependencies)
+            where T : class { throw null; }
+    }
+
+    public partial class UnsafePackageEntryException : Core.PackagingException, Common.ILogMessageException
+    {
+        public UnsafePackageEntryException(string message) : base(default!) { }
+
+        public override Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class VersionFolderPathResolver
+    {
+        public VersionFolderPathResolver(string rootPath, bool isLowercase) { }
+
+        public VersionFolderPathResolver(string rootPath) { }
+
+        public bool IsLowerCase { get { throw null; } }
+
+        public string RootPath { get { throw null; } }
+
+        public string GetHashFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetHashPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetInstallPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetManifestFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetManifestFilePath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetNupkgMetadataPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetPackageDirectory(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageDownloadMarkerFileName(string packageId) { throw null; }
+
+        public virtual string GetPackageFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageFilePath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetVersionListDirectory(string packageId) { throw null; }
+
+        public string GetVersionListPath(string packageId) { throw null; }
+    }
+
+    public static partial class XElementExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> ElementsNoNamespace(this System.Xml.Linq.XContainer container, string localName) { throw null; }
+
+        public static System.Xml.Linq.XElement Except(this System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) { throw null; }
+
+        public static string GetOptionalAttributeValue(this System.Xml.Linq.XElement element, string localName, string namespaceName = null) { throw null; }
+    }
+
+    public enum XmlDocFileSaveMode
+    {
+        None = 0,
+        Skip = 1,
+        Compress = 2
+    }
+
+    [System.Obsolete("This class is obsolete and will be removed in a future release.")]
+    public static partial class XmlUtility
+    {
+        public static System.Xml.Linq.XDocument LoadSafe(System.IO.Stream input, bool ignoreWhiteSpace) { throw null; }
+
+        public static System.Xml.Linq.XDocument LoadSafe(System.IO.Stream input) { throw null; }
+    }
+
+    public static partial class ZipArchiveExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<string> GetFiles(this System.IO.Compression.ZipArchive zipArchive) { throw null; }
+
+        public static System.IO.Compression.ZipArchiveEntry LookupEntry(this System.IO.Compression.ZipArchive zipArchive, string path) { throw null; }
+
+        public static System.IO.Stream OpenFile(this System.IO.Compression.ZipArchive zipArchive, string path) { throw null; }
+
+        public static string SaveAsFile(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, Common.ILogger logger) { throw null; }
+
+        public static void UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, Common.ILogger logger) { }
+    }
+
+    public partial class ZipFilePair
+    {
+        public ZipFilePair(string fileFullPath, System.IO.Compression.ZipArchiveEntry entry) { }
+
+        public string FileFullPath { get { throw null; } }
+
+        public System.IO.Compression.ZipArchiveEntry PackageEntry { get { throw null; } }
+
+        public bool IsInstalled() { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Core
+{
+    public partial class ContentFilesEntry
+    {
+        public ContentFilesEntry(string include, string exclude, string buildAction, bool? copyToOutput, bool? flatten) { }
+
+        public string BuildAction { get { throw null; } }
+
+        public bool? CopyToOutput { get { throw null; } }
+
+        public string Exclude { get { throw null; } }
+
+        public bool? Flatten { get { throw null; } }
+
+        public string Include { get { throw null; } }
+    }
+
+    public delegate string ExtractPackageFileDelegate(string sourceFile, string targetPath, System.IO.Stream fileStream);
+    public partial class Fingerprints
+    {
+        public Fingerprints(System.Collections.Generic.IDictionary<string, string> fingerPrints) { }
+
+        public string this[string key] { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() { throw null; }
+    }
+
+    public partial interface IAsyncPackageCoreReader : System.IDisposable
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface INuspecCoreReader
+    {
+        string GetId();
+        PackageIdentity GetIdentity();
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetMetadata();
+        Versioning.NuGetVersion GetMinClientVersion();
+        System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes();
+        Versioning.NuGetVersion GetVersion();
+    }
+
+    public partial interface IPackageCoreReader : System.IDisposable
+    {
+        System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<string> GetFiles();
+        System.Collections.Generic.IEnumerable<string> GetFiles(string folder);
+        PackageIdentity GetIdentity();
+        Versioning.NuGetVersion GetMinClientVersion();
+        System.IO.Stream GetNuspec();
+        string GetNuspecFile();
+        System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes();
+        System.IO.Stream GetStream(string path);
+    }
+
+    public partial interface IPackageIdentityComparer : System.Collections.Generic.IEqualityComparer<PackageIdentity>, System.Collections.Generic.IComparer<PackageIdentity>
+    {
+    }
+
+    public partial interface IRepositoryCertificateInfo
+    {
+        string ContentUrl { get; }
+
+        Fingerprints Fingerprints { get; }
+
+        string Issuer { get; }
+
+        System.DateTimeOffset NotAfter { get; }
+
+        System.DateTimeOffset NotBefore { get; }
+
+        string Subject { get; }
+    }
+
+    public partial class NuspecCoreReader : NuspecCoreReaderBase
+    {
+        public NuspecCoreReader(System.IO.Stream stream) : base(stream) { }
+
+        public NuspecCoreReader(System.Xml.Linq.XDocument xml) : base(xml) { }
+
+        public virtual System.Collections.Generic.IEnumerable<PackageDependency> GetDependencies() { throw null; }
+    }
+
+    public abstract partial class NuspecCoreReaderBase : INuspecCoreReader
+    {
+        protected const string DevelopmentDependency = "developmentDependency";
+        protected const string Id = "id";
+        protected const string Metadata = "metadata";
+        protected const string MinClientVersion = "minClientVersion";
+        protected const string Version = "version";
+        public NuspecCoreReaderBase(System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public NuspecCoreReaderBase(System.IO.Stream stream) { }
+
+        public NuspecCoreReaderBase(string path) { }
+
+        public NuspecCoreReaderBase(System.Xml.Linq.XDocument xml) { }
+
+        protected System.Xml.Linq.XElement MetadataNode { get { throw null; } }
+
+        protected System.Collections.Generic.Dictionary<string, string> MetadataValues { get { throw null; } }
+
+        public System.Xml.Linq.XDocument Xml { get { throw null; } }
+
+        public virtual bool GetDevelopmentDependency() { throw null; }
+
+        public virtual string GetId() { throw null; }
+
+        public virtual PackageIdentity GetIdentity() { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetMetadata() { throw null; }
+
+        public virtual string GetMetadataValue(string name) { throw null; }
+
+        public virtual Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes() { throw null; }
+
+        public virtual Versioning.NuGetVersion GetVersion() { throw null; }
+
+        public virtual bool IsServiceable() { throw null; }
+    }
+
+    public static partial class NuspecUtility
+    {
+        public static readonly string FrameworkReference;
+        public static readonly string FrameworkReferences;
+        public static readonly string Group;
+        public static readonly string License;
+        public static readonly string Name;
+        public static readonly string PackageType;
+        public static readonly string PackageTypes;
+        public static readonly string Repository;
+        public static readonly string RepositoryBranch;
+        public static readonly string RepositoryCommit;
+        public static readonly string RepositoryUrl;
+        public static readonly string Serviceable;
+        public static readonly string TargetFramework;
+        public static readonly string Type;
+        public static readonly string Version;
+        public static System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes(System.Xml.Linq.XElement metadataNode, bool useMetadataNamespace) { throw null; }
+
+        public static bool IsServiceable(System.Xml.Linq.XElement metadataNode) { throw null; }
+    }
+
+    public partial class PackageDependency : System.IEquatable<PackageDependency>
+    {
+        public PackageDependency(string id, Versioning.VersionRange versionRange, System.Collections.Generic.IReadOnlyList<string> include, System.Collections.Generic.IReadOnlyList<string> exclude) { }
+
+        public PackageDependency(string id, Versioning.VersionRange versionRange) { }
+
+        public PackageDependency(string id) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public bool Equals(PackageDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageDependencyComparer : System.Collections.Generic.IEqualityComparer<PackageDependency>
+    {
+        public static readonly PackageDependencyComparer Default;
+        public PackageDependencyComparer() { }
+
+        public PackageDependencyComparer(Versioning.IVersionRangeComparer versionRangeComparer) { }
+
+        public bool Equals(PackageDependency x, PackageDependency y) { throw null; }
+
+        public int GetHashCode(PackageDependency obj) { throw null; }
+    }
+
+    public partial class PackageDependencyInfo : PackageIdentity, System.IEquatable<PackageDependencyInfo>
+    {
+        public PackageDependencyInfo(PackageIdentity identity, System.Collections.Generic.IEnumerable<PackageDependency> dependencies) : base(default!, default!) { }
+
+        public PackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<PackageDependency> dependencies) : base(default!, default!) { }
+
+        public PackageDependencyInfo(string id, Versioning.NuGetVersion version) : base(default!, default!) { }
+
+        public System.Collections.Generic.IEnumerable<PackageDependency> Dependencies { get { throw null; } }
+
+        public bool Equals(PackageDependencyInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageDependencyInfoComparer : System.Collections.Generic.IEqualityComparer<PackageDependencyInfo>
+    {
+        public PackageDependencyInfoComparer() { }
+
+        public PackageDependencyInfoComparer(IPackageIdentityComparer identityComparer, PackageDependencyComparer dependencyComparer) { }
+
+        public static PackageDependencyInfoComparer Default { get { throw null; } }
+
+        public bool Equals(PackageDependencyInfo x, PackageDependencyInfo y) { throw null; }
+
+        public int GetHashCode(PackageDependencyInfo obj) { throw null; }
+    }
+
+    public partial class PackageIdentity : System.IEquatable<PackageIdentity>, System.IComparable<PackageIdentity>
+    {
+        public PackageIdentity(string id, Versioning.NuGetVersion version) { }
+
+        public static PackageIdentityComparer Comparer { get { throw null; } }
+
+        public bool HasVersion { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public int CompareTo(PackageIdentity other) { throw null; }
+
+        public virtual bool Equals(PackageIdentity other, Versioning.VersionComparison versionComparison) { throw null; }
+
+        public bool Equals(PackageIdentity other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageIdentityComparer : IPackageIdentityComparer, System.Collections.Generic.IEqualityComparer<PackageIdentity>, System.Collections.Generic.IComparer<PackageIdentity>
+    {
+        public PackageIdentityComparer() { }
+
+        public PackageIdentityComparer(Versioning.IVersionComparer versionComparer) { }
+
+        public PackageIdentityComparer(Versioning.VersionComparison versionComparison) { }
+
+        public static PackageIdentityComparer Default { get { throw null; } }
+
+        public int Compare(PackageIdentity x, PackageIdentity y) { throw null; }
+
+        public bool Equals(PackageIdentity x, PackageIdentity y) { throw null; }
+
+        public int GetHashCode(PackageIdentity obj) { throw null; }
+    }
+
+    public partial class PackageType : System.IEquatable<PackageType>, System.IComparable<PackageType>
+    {
+        public static readonly PackageType Dependency;
+        public static readonly PackageType DotnetCliTool;
+        public static readonly PackageType DotnetPlatform;
+        public static readonly PackageType DotnetTool;
+        public static readonly System.Version EmptyVersion;
+        public static readonly PackageType Legacy;
+        public static readonly System.StringComparer PackageTypeNameComparer;
+        public static readonly PackageType SymbolsPackage;
+        public PackageType(string name, System.Version version) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public int CompareTo(PackageType other) { throw null; }
+
+        public bool Equals(PackageType other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(PackageType a, PackageType b) { throw null; }
+
+        public static bool operator !=(PackageType a, PackageType b) { throw null; }
+    }
+
+    public static partial class PackagingCoreConstants
+    {
+        public static readonly string EmptyFolder;
+        public static readonly string ForwardSlashEmptyFolder;
+        public static readonly string HashFileExtension;
+        public static readonly string NupkgExtension;
+        public static readonly string NupkgMetadataFileExtension;
+        public static readonly string NuspecExtension;
+        public static readonly string PackageDownloadMarkerFileExtension;
+    }
+
+    public partial class PackagingException : System.Exception, Common.ILogMessageException
+    {
+        public PackagingException(Common.NuGetLogCode logCode, string message, System.Exception innerException) { }
+
+        public PackagingException(Common.NuGetLogCode logCode, string message) { }
+
+        public PackagingException(string message, System.Exception innerException) { }
+
+        public PackagingException(string message) { }
+
+        public virtual Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class RepositoryMetadata : System.IEquatable<RepositoryMetadata>
+    {
+        public RepositoryMetadata() { }
+
+        public RepositoryMetadata(string type, string url, string branch, string commit) { }
+
+        public string Branch { get { throw null; } set { } }
+
+        public string Commit { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public string Url { get { throw null; } set { } }
+
+        public bool Equals(RepositoryMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(RepositoryMetadata a, RepositoryMetadata b) { throw null; }
+
+        public static bool operator !=(RepositoryMetadata a, RepositoryMetadata b) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Licenses
+{
+    public partial class ExceptionData
+    {
+        public ExceptionData(string licenseID, bool isDeprecatedLicenseId) { }
+
+        public bool IsDeprecatedLicenseId { get { throw null; } }
+
+        public string LicenseExceptionID { get { throw null; } }
+    }
+
+    public partial class LicenseData
+    {
+        public LicenseData(string licenseID, bool isOsiApproved, bool isDeprecatedLicenseId, bool isFsfLibre) { }
+
+        public bool IsDeprecatedLicenseId { get { throw null; } }
+
+        public bool IsFsfLibre { get { throw null; } }
+
+        public bool IsOsiApproved { get { throw null; } }
+
+        public string LicenseID { get { throw null; } }
+    }
+
+    public enum LicenseExpressionType
+    {
+        License = 0,
+        Operator = 1
+    }
+
+    public abstract partial class LicenseOperator : NuGetLicenseExpression
+    {
+        protected LicenseOperator(LicenseOperatorType operatorType) { }
+
+        public LicenseOperatorType OperatorType { get { throw null; } }
+    }
+
+    public enum LicenseOperatorType
+    {
+        WithOperator = 0,
+        LogicalOperator = 1
+    }
+
+    public partial class LogicalOperator : LicenseOperator
+    {
+        public LogicalOperator(LogicalOperatorType logicalOperatorType, NuGetLicenseExpression left, NuGetLicenseExpression right) : base(default) { }
+
+        public NuGetLicenseExpression Left { get { throw null; } }
+
+        public LogicalOperatorType LogicalOperatorType { get { throw null; } }
+
+        public NuGetLicenseExpression Right { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum LogicalOperatorType
+    {
+        And = 0,
+        Or = 1
+    }
+
+    public partial class NuGetLicense : NuGetLicenseExpression
+    {
+        public string Identifier { get { throw null; } }
+
+        public bool IsStandardLicense { get { throw null; } }
+
+        public bool Plus { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class NuGetLicenseData
+    {
+        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, ExceptionData> ExceptionList;
+        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, LicenseData> LicenseList;
+        public static string LicenseListVersion { get { throw null; } }
+    }
+
+    public partial class NuGetLicenseException
+    {
+        public string Identifier { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class NuGetLicenseExpression
+    {
+        protected NuGetLicenseExpression() { }
+
+        public LicenseExpressionType Type { get { throw null; } protected set { } }
+
+        public static NuGetLicenseExpression Parse(string expression) { throw null; }
+    }
+
+    public static partial class NuGetLicenseExpressionExtensions
+    {
+        public static bool HasOnlyStandardIdentifiers(this NuGetLicenseExpression expression) { throw null; }
+
+        public static bool IsUnlicensed(this NuGetLicense license) { throw null; }
+
+        public static bool IsUnlicensed(this NuGetLicenseExpression expression) { throw null; }
+
+        public static void OnEachLeafNode(this NuGetLicenseExpression expression, System.Action<NuGetLicense> licenseProcessor, System.Action<NuGetLicenseException> exceptionProcessor) { }
+    }
+
+    public partial class NuGetLicenseExpressionParsingException : System.Exception
+    {
+        public NuGetLicenseExpressionParsingException(string message, System.Exception innerException) { }
+
+        public NuGetLicenseExpressionParsingException(string message) { }
+    }
+
+    public partial class WithOperator : LicenseOperator
+    {
+        public WithOperator(NuGetLicense license, NuGetLicenseException exception) : base(default) { }
+
+        public NuGetLicenseException Exception { get { throw null; } }
+
+        public NuGetLicense License { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.PackageExtraction
+{
+    public static partial class PackageExtractionBehavior
+    {
+        public static XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+}
+
+namespace NuGet.Packaging.Rules
+{
+    [System.CodeDom.Compiler.GeneratedCode("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    public partial class AnalysisResources
+    {
+        public static string AssemblyDirectlyUnderLibWarning { get { throw null; } }
+
+        public static string AssemblyOutsideLibWarning { get { throw null; } }
+
+        public static string BuildConventionIsViolatedWarning { get { throw null; } }
+
+        public static System.Globalization.CultureInfo Culture { get { throw null; } set { } }
+
+        public static string DefaultSpecValueWarning { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMBeginningToFiles { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMBeginningToNuspec { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMEndingToFile { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMEndingToNuspec { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMHasCompatMatch { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMHasNoExactMatch { get { throw null; } }
+
+        public static string FilePathTooLongWarning { get { throw null; } }
+
+        public static string IconUrlDeprecationWarning { get { throw null; } }
+
+        public static string InvalidFrameworkWarning { get { throw null; } }
+
+        public static string InvalidPlaceholderFileWarning { get { throw null; } }
+
+        public static string InvalidPrereleaseDependencyWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInDependencyGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInFilesWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInReferenceGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkWarning { get { throw null; } }
+
+        public static string LegacyVersionWarning { get { throw null; } }
+
+        public static string LicenseUrlDeprecationWarning { get { throw null; } }
+
+        public static string Migrator_AssemblyDirectlyUnderLibWarning { get { throw null; } }
+
+        public static string Migrator_PackageHasContentFolder { get { throw null; } }
+
+        public static string Migrator_PackageHasInstallScript { get { throw null; } }
+
+        public static string Migrator_XdtTransformInPackage { get { throw null; } }
+
+        public static string MisplacedInitScriptWarning { get { throw null; } }
+
+        public static string MisplacedTransformFileWarning { get { throw null; } }
+
+        public static string NoRefOrLibFolderInPackage { get { throw null; } }
+
+        public static string PlaceholderFileInPackageWarning { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarning { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecNoTfmListItemFormat { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat { get { throw null; } }
+
+        public static System.Resources.ResourceManager ResourceManager { get { throw null; } }
+
+        public static string ScriptOutsideToolsWarning { get { throw null; } }
+
+        public static string UnrecognizedLicenseIdentifier { get { throw null; } }
+
+        public static string UnrecognizedScriptWarning { get { throw null; } }
+
+        public static string UnspecifiedDependencyVersionWarning { get { throw null; } }
+
+        public static string WinRTObsoleteWarning { get { throw null; } }
+    }
+
+    public partial class DefaultManifestValuesRule : IPackageRule
+    {
+        public DefaultManifestValuesRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial class IconUrlDeprecationWarning : IPackageRule
+    {
+        public IconUrlDeprecationWarning(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial interface IPackageRule
+    {
+        string MessageFormat { get; }
+
+        System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder);
+    }
+
+    public partial class LicenseUrlDeprecationWarning : IPackageRule
+    {
+        public LicenseUrlDeprecationWarning(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial class PathTooLongRule : IPackageRule
+    {
+        public PathTooLongRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public static partial class RuleSet
+    {
+        public static System.Collections.Generic.IEnumerable<IPackageRule> PackageCreationRuleSet { get { throw null; } }
+
+        public static System.Collections.Generic.IEnumerable<IPackageRule> PackagesConfigToPackageReferenceMigrationRuleSet { get { throw null; } }
+    }
+
+    public partial class UnspecifiedDependencyVersionRule : IPackageRule
+    {
+        public UnspecifiedDependencyVersionRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Signing
+{
+    public sealed partial class Accuracy
+    {
+        public int? Microseconds { get { throw null; } }
+
+        public int? Milliseconds { get { throw null; } }
+
+        public int? Seconds { get { throw null; } }
+
+        public long? GetTotalMicroseconds() { throw null; }
+
+        public static Accuracy Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class AlgorithmIdentifier
+    {
+        public System.Security.Cryptography.Oid Algorithm { get { throw null; } }
+
+        public static AlgorithmIdentifier Read(byte[] bytes) { throw null; }
+    }
+
+    public partial class AllowListVerificationProvider : ISignatureVerificationProvider
+    {
+        public AllowListVerificationProvider(System.Collections.Generic.IReadOnlyCollection<VerificationAllowListEntry> allowList, bool requireNonEmptyAllowList = false, string emptyListErrorMessage = "", string noMatchErrorMessage = "") { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class AttributeUtility
+    {
+        public static System.Security.Cryptography.CryptographicAttributeObject CreateCommitmentTypeIndication(SignatureType type) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObject CreateNuGetPackageOwners(System.Collections.Generic.IReadOnlyList<string> packageOwners) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObject CreateNuGetV3ServiceIndexUrl(System.Uri v3ServiceIndexUrl) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObject CreateSigningCertificateV2(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObject GetAttribute(this System.Security.Cryptography.CryptographicAttributeObjectCollection attributes, string oid) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.Security.Cryptography.CryptographicAttributeObject> GetAttributes(this System.Security.Cryptography.CryptographicAttributeObjectCollection attributes, string oid) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<string> GetNuGetPackageOwners(System.Security.Cryptography.CryptographicAttributeObjectCollection signedAttributes) { throw null; }
+
+        public static System.Uri GetNuGetV3ServiceIndexUrl(System.Security.Cryptography.CryptographicAttributeObjectCollection signedAttributes) { throw null; }
+
+        public static SignatureType GetSignatureType(System.Security.Cryptography.CryptographicAttributeObjectCollection signedAttributes) { throw null; }
+
+        public static SignatureType GetSignatureType(string oid) { throw null; }
+
+        public static string GetSignatureTypeOid(SignatureType signatureType) { throw null; }
+    }
+
+    public sealed partial class AuthorPrimarySignature : PrimarySignature
+    {
+        public AuthorPrimarySignature(System.Security.Cryptography.Pkcs.SignedCms signedCms) : base(default!, default) { }
+
+        public override string FriendlyName { get { throw null; } }
+
+        public override SignatureVerificationSummary Verify(Timestamp timestamp, SignatureVerifySettings settings, Common.HashAlgorithmName fingerprintAlgorithm, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificateExtraStore) { throw null; }
+    }
+
+    public sealed partial class AuthorSignPackageRequest : SignPackageRequest
+    {
+        public AuthorSignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm) : base(default!, default, default) { }
+
+        public AuthorSignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) : base(default!, default, default) { }
+
+        public override SignatureType SignatureType { get { throw null; } }
+    }
+
+    public sealed partial class CentralDirectoryHeaderMetadata
+    {
+        public CentralDirectoryHeaderMetadata() { }
+
+        public long ChangeInOffset { get { throw null; } set { } }
+
+        public long FileEntryTotalSize { get { throw null; } set { } }
+
+        public long HeaderSize { get { throw null; } set { } }
+
+        public int IndexInHeaders { get { throw null; } set { } }
+
+        public bool IsPackageSignatureFile { get { throw null; } set { } }
+
+        public long OffsetToLocalFileHeader { get { throw null; } set { } }
+
+        public long Position { get { throw null; } set { } }
+    }
+
+    public static partial class CertificateChainUtility
+    {
+        public static IX509CertificateChain GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, Common.ILogger logger, CertificateType certificateType) { throw null; }
+
+        public static IX509CertificateChain GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Chain x509Chain) { throw null; }
+    }
+
+    public partial class CertificateHashAllowListEntry : VerificationAllowListEntry
+    {
+        public CertificateHashAllowListEntry(VerificationTarget target, SignaturePlacement placement, string fingerprint, Common.HashAlgorithmName algorithm) : base(default, default) { }
+
+        public string Fingerprint { get { throw null; } }
+
+        public Common.HashAlgorithmName FingerprintAlgorithm { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum CertificateType
+    {
+        Signature = 0,
+        Timestamp = 1
+    }
+
+    public static partial class CertificateUtility
+    {
+        public static byte[] GetHash(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static string GetHashString(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<byte[]> GetRawDataForCollection(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { throw null; }
+
+        public static bool HasExtendedKeyUsage(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string ekuOid) { throw null; }
+
+        public static bool HasLifetimeSigningEku(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsCertificatePublicKeyValid(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsCertificateValidityPeriodInTheFuture(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsDateInsideValidityPeriod(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.DateTimeOffset date) { throw null; }
+
+        public static bool IsSelfIssued(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsSignatureAlgorithmSupported(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsValidForPurposeFast(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string ekuOid) { throw null; }
+
+        public static string X509Certificate2CollectionToString(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+
+        public static string X509Certificate2ToString(System.Security.Cryptography.X509Certificates.X509Certificate2 cert, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+
+        public static string X509ChainToString(System.Security.Cryptography.X509Certificates.X509Chain chain, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+    }
+
+    public partial class ClientPolicyContext
+    {
+        public System.Collections.Generic.IReadOnlyCollection<TrustedSignerAllowListEntry> AllowList { get { throw null; } }
+
+        public Common.SignatureValidationMode Policy { get { throw null; } }
+
+        public SignedPackageVerifierSettings VerifierSettings { get { throw null; } }
+
+        public static ClientPolicyContext GetClientPolicy(Configuration.ISettings settings, Common.ILogger logger) { throw null; }
+    }
+
+    public sealed partial class CommitmentTypeIndication
+    {
+        public System.Security.Cryptography.Oid CommitmentTypeId { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<CommitmentTypeQualifier> Qualifiers { get { throw null; } }
+
+        public static CommitmentTypeIndication Create(System.Security.Cryptography.Oid commitmentTypeId) { throw null; }
+
+        public static CommitmentTypeIndication Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class CommitmentTypeQualifier
+    {
+        public System.Security.Cryptography.Oid CommitmentTypeIdentifier { get { throw null; } }
+
+        public byte[] Qualifier { get { throw null; } }
+
+        public static CommitmentTypeQualifier Read(byte[] bytes) { throw null; }
+    }
+
+    public static partial class Crc32
+    {
+        [System.CLSCompliant(false)]
+        public static uint CalculateCrc(byte[] data) { throw null; }
+    }
+
+    public sealed partial class EssCertId
+    {
+        public byte[] CertificateHash { get { throw null; } }
+
+        public IssuerSerial IssuerSerial { get { throw null; } }
+
+        public static EssCertId Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class EssCertIdV2
+    {
+        public byte[] CertificateHash { get { throw null; } }
+
+        public AlgorithmIdentifier HashAlgorithm { get { throw null; } }
+
+        public IssuerSerial IssuerSerial { get { throw null; } }
+
+        public static EssCertIdV2 Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static EssCertIdV2 Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class Extension
+    {
+        public bool Critical { get { throw null; } }
+
+        public System.Security.Cryptography.Oid Id { get { throw null; } }
+
+        public byte[] Value { get { throw null; } }
+    }
+
+    public sealed partial class Extensions
+    {
+        public System.Collections.Generic.IReadOnlyList<Extension> ExtensionsList { get { throw null; } }
+
+        public static Extensions Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class GeneralName
+    {
+        public System.Security.Cryptography.X509Certificates.X500DistinguishedName DirectoryName { get { throw null; } }
+
+        public static GeneralName Create(System.Security.Cryptography.X509Certificates.X500DistinguishedName distinguishedName) { throw null; }
+
+        public static GeneralName Read(byte[] bytes) { throw null; }
+    }
+
+    public partial class IntegrityVerificationProvider : ISignatureVerificationProvider
+    {
+        public IntegrityVerificationProvider() { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class InvalidSignaturePackageVerificationResult : PackageVerificationResult
+    {
+        public InvalidSignaturePackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+    }
+
+    public partial interface IPackageSignatureVerifier
+    {
+        System.Threading.Tasks.Task<VerifySignaturesResult> VerifySignaturesAsync(ISignedPackageReader package, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token, System.Guid telemetryOperationId);
+    }
+
+    public partial interface IRepositorySignature : ISignature
+    {
+        System.Collections.Generic.IReadOnlyList<string> PackageOwners { get; }
+
+        System.Uri V3ServiceIndexUrl { get; }
+    }
+
+    public partial interface ISignature
+    {
+        System.Security.Cryptography.Pkcs.SignerInfo SignerInfo { get; }
+
+        SignatureType Type { get; }
+    }
+
+    public partial interface ISignatureProvider
+    {
+        System.Threading.Tasks.Task<PrimarySignature> CreatePrimarySignatureAsync(SignPackageRequest request, SignatureContent signatureContent, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<PrimarySignature> CreateRepositoryCountersignatureAsync(RepositorySignPackageRequest request, PrimarySignature primarySignature, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignatureVerificationProvider
+    {
+        System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignedPackage : ISignedPackageReader, System.IDisposable, ISignedPackageWriter
+    {
+    }
+
+    public partial interface ISignedPackageReader : System.IDisposable
+    {
+        bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
+        System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token);
+        string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null);
+        System.Threading.Tasks.Task<PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task ValidateIntegrityAsync(SignatureContent signatureContent, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignedPackageWriter
+    {
+        System.Threading.Tasks.Task AddSignatureAsync(System.IO.Stream signatureStream, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<bool> IsZip64Async(System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task RemoveSignatureAsync(System.Threading.CancellationToken token);
+    }
+
+    public sealed partial class IssuerSerial
+    {
+        public System.Collections.Generic.IReadOnlyList<GeneralName> GeneralNames { get { throw null; } }
+
+        public byte[] SerialNumber { get { throw null; } }
+
+        public static IssuerSerial Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static IssuerSerial Read(byte[] bytes) { throw null; }
+    }
+
+    public partial interface ITimestampProvider
+    {
+        System.Threading.Tasks.Task<PrimarySignature> TimestampSignatureAsync(PrimarySignature primarySignature, TimestampRequest request, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ITrustedSignersProvider
+    {
+        void AddOrUpdateTrustedSigner(Configuration.TrustedSignerItem trustedSigner);
+        System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> GetTrustedSigners();
+        void Remove(System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> trustedSigners);
+    }
+
+    public partial interface IX509CertificateChain : System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.IDisposable
+    {
+    }
+
+    public partial class KeyPairFileReader : System.IDisposable
+    {
+        public KeyPairFileReader(System.IO.Stream stream, System.Text.Encoding encoding) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public System.Collections.Generic.Dictionary<string, string> ReadSection() { throw null; }
+    }
+
+    public static partial class KeyPairFileUtility
+    {
+        public static string GetValueOrThrow(System.Collections.Generic.Dictionary<string, string> values, string key) { throw null; }
+    }
+
+    public partial class KeyPairFileWriter : System.IDisposable
+    {
+        public KeyPairFileWriter(System.IO.Stream stream, System.Text.Encoding encoding, bool leaveOpen) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public void WritePair(string key, string value) { }
+
+        public void WriteSectionBreak() { }
+    }
+
+    public sealed partial class MessageImprint
+    {
+        public AlgorithmIdentifier HashAlgorithm { get { throw null; } }
+
+        public byte[] HashedMessage { get { throw null; } }
+
+        public static MessageImprint Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class NuGetPackageOwners
+    {
+        public NuGetPackageOwners(System.Collections.Generic.IReadOnlyList<string> packageOwners) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public static NuGetPackageOwners Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class NuGetV3ServiceIndexUrl
+    {
+        public NuGetV3ServiceIndexUrl(System.Uri v3ServiceIndexUrl) { }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public static NuGetV3ServiceIndexUrl Read(byte[] bytes) { throw null; }
+    }
+
+    public static partial class Oids
+    {
+        public const string AnyPolicy = "2.5.29.32.0";
+        public const string AuthorityKeyIdentifier = "2.5.29.35";
+        public const string BaselineTimestampPolicy = "0.4.0.2023.1.1";
+        public const string CodeSigningEku = "1.3.6.1.5.5.7.3.3";
+        public const string CommitmentTypeIdentifierProofOfOrigin = "1.2.840.113549.1.9.16.6.1";
+        public const string CommitmentTypeIdentifierProofOfReceipt = "1.2.840.113549.1.9.16.6.2";
+        public const string CommitmentTypeIndication = "1.2.840.113549.1.9.16.2.16";
+        public const string Countersignature = "1.2.840.113549.1.9.6";
+        public const string EnhancedKeyUsage = "2.5.29.37";
+        public const string IdQtCps = "1.3.6.1.5.5.7.2.1";
+        public const string IdQtUnotice = "1.3.6.1.5.5.7.2.2";
+        public const string LifetimeSigningEku = "1.3.6.1.4.1.311.10.3.13";
+        public const string NuGetPackageOwners = "1.3.6.1.4.1.311.84.2.1.1.2";
+        public const string NuGetV3ServiceIndexUrl = "1.3.6.1.4.1.311.84.2.1.1.1";
+        public const string Pkcs7Data = "1.2.840.113549.1.7.1";
+        public const string Sha1 = "1.3.14.3.2.26";
+        public const string Sha256 = "2.16.840.1.101.3.4.2.1";
+        public const string Sha256WithRSAEncryption = "1.2.840.113549.1.1.11";
+        public const string Sha384 = "2.16.840.1.101.3.4.2.2";
+        public const string Sha384WithRSAEncryption = "1.2.840.113549.1.1.12";
+        public const string Sha512 = "2.16.840.1.101.3.4.2.3";
+        public const string Sha512WithRSAEncryption = "1.2.840.113549.1.1.13";
+        public const string SignatureTimeStampTokenAttribute = "1.2.840.113549.1.9.16.2.14";
+        public const string SigningCertificate = "1.2.840.113549.1.9.16.2.12";
+        public const string SigningCertificateV2 = "1.2.840.113549.1.9.16.2.47";
+        public const string SigningTime = "1.2.840.113549.1.9.5";
+        public const string SubjectKeyIdentifier = "2.5.29.14";
+        public const string TimeStampingEku = "1.3.6.1.5.5.7.3.8";
+        public const string TSTInfoContentType = "1.2.840.113549.1.9.16.1.4";
+    }
+
+    public partial class PackageSignatureVerifier : IPackageSignatureVerifier
+    {
+        public PackageSignatureVerifier(System.Collections.Generic.IEnumerable<ISignatureVerificationProvider> verificationProviders) { }
+
+        public System.Threading.Tasks.Task<VerifySignaturesResult> VerifySignaturesAsync(ISignedPackageReader package, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+    }
+
+    public abstract partial class PackageVerificationResult
+    {
+        public PackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public virtual System.Collections.Generic.IEnumerable<SignatureLog> Issues { get { throw null; } }
+
+        public virtual SignatureVerificationStatus Trust { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> GetErrorIssues() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> GetWarningIssues() { throw null; }
+    }
+
+    public sealed partial class PolicyInformation
+    {
+        public System.Security.Cryptography.Oid PolicyIdentifier { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyQualifierInfo> PolicyQualifiers { get { throw null; } }
+
+        public static PolicyInformation Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class PolicyQualifierInfo
+    {
+        public System.Security.Cryptography.Oid PolicyQualifierId { get { throw null; } }
+
+        public byte[] Qualifier { get { throw null; } }
+
+        public static PolicyQualifierInfo Read(byte[] bytes) { throw null; }
+    }
+
+    public abstract partial class PrimarySignature : Signature
+    {
+        protected PrimarySignature(System.Security.Cryptography.Pkcs.SignedCms signedCms, SignatureType signatureType) : base(default!, default) { }
+
+        public override string FriendlyName { get { throw null; } }
+
+        public SignatureContent SignatureContent { get { throw null; } }
+
+        public System.Security.Cryptography.Pkcs.SignedCms SignedCms { get { throw null; } }
+
+        public byte[] GetBytes() { throw null; }
+
+        public override byte[] GetSignatureValue() { throw null; }
+
+        public static PrimarySignature Load(byte[] data) { throw null; }
+
+        public static PrimarySignature Load(System.IO.Stream stream) { throw null; }
+
+        public static PrimarySignature Load(System.Security.Cryptography.Pkcs.SignedCms cms) { throw null; }
+
+        public void Save(System.IO.Stream stream) { }
+
+        protected static void ThrowForInvalidPrimarySignature() { }
+
+        protected override void ThrowForInvalidSignature() { }
+    }
+
+    public static partial class PrimarySignatureFactory
+    {
+        public static PrimarySignature CreateSignature(System.Security.Cryptography.Pkcs.SignedCms signedCms) { throw null; }
+    }
+
+    public sealed partial class ReadOnlyBufferedStream : System.IO.Stream
+    {
+        public ReadOnlyBufferedStream(System.IO.Stream stream, bool leaveOpen, int bufferSize) { }
+
+        public ReadOnlyBufferedStream(System.IO.Stream stream, bool leaveOpen) { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanSeek { get { throw null; } }
+
+        public override bool CanTimeout { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override long Length { get { throw null; } }
+
+        public override long Position { get { throw null; } set { } }
+
+        public override int ReadTimeout { get { throw null; } set { } }
+
+        public override int WriteTimeout { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void Flush() { }
+
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override int Read(byte[] buffer, int offset, int count) { throw null; }
+
+        public override int ReadByte() { throw null; }
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+
+        public override void SetLength(long value) { }
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override void WriteByte(byte value) { }
+    }
+
+    public sealed partial class RepositoryCountersignature : Signature, IRepositorySignature, ISignature
+    {
+        internal RepositoryCountersignature() : base(default!, default) { }
+
+        public override string FriendlyName { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+
+        public static RepositoryCountersignature GetRepositoryCountersignature(PrimarySignature primarySignature) { throw null; }
+
+        public override byte[] GetSignatureValue() { throw null; }
+
+        protected override void ThrowForInvalidSignature() { }
+
+        public override SignatureVerificationSummary Verify(Timestamp timestamp, SignatureVerifySettings settings, Common.HashAlgorithmName fingerprintAlgorithm, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificateExtraStore) { throw null; }
+    }
+
+    public sealed partial class RepositoryPrimarySignature : PrimarySignature, IRepositorySignature, ISignature
+    {
+        public RepositoryPrimarySignature(System.Security.Cryptography.Pkcs.SignedCms signedCms) : base(default!, default) { }
+
+        public override string FriendlyName { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+
+        public override SignatureVerificationSummary Verify(Timestamp timestamp, SignatureVerifySettings settings, Common.HashAlgorithmName fingerprintAlgorithm, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificateExtraStore) { throw null; }
+    }
+
+    public static partial class RepositorySignatureInfoUtility
+    {
+        public static System.Collections.Generic.IReadOnlyCollection<CertificateHashAllowListEntry> GetRepositoryAllowList(System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> repositoryCertificateInfos) { throw null; }
+
+        public static SignedPackageVerifierSettings GetSignedPackageVerifierSettings(RepositorySignatureInfo repoSignatureInfo, SignedPackageVerifierSettings fallbackSettings) { throw null; }
+    }
+
+    public sealed partial class RepositorySignPackageRequest : SignPackageRequest
+    {
+        public RepositorySignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm, System.Uri v3ServiceIndexUrl, System.Collections.Generic.IReadOnlyList<string> packageOwners) : base(default!, default, default) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public override SignatureType SignatureType { get { throw null; } }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+    }
+
+    public partial class Rfc3161TimestampProvider : ITimestampProvider
+    {
+        public Rfc3161TimestampProvider(System.Uri timeStampServerUrl) { }
+
+        public System.Threading.Tasks.Task<PrimarySignature> TimestampSignatureAsync(PrimarySignature primarySignature, TimestampRequest request, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo : System.Security.Cryptography.AsnEncodedData
+    {
+        public Rfc3161TimestampTokenInfo() { }
+    }
+
+    public abstract partial class Signature : ISignature
+    {
+        protected Signature(System.Security.Cryptography.Pkcs.SignerInfo signerInfo, SignatureType type) { }
+
+        public virtual string FriendlyName { get { throw null; } }
+
+        public System.Security.Cryptography.Pkcs.SignerInfo SignerInfo { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Timestamp> Timestamps { get { throw null; } }
+
+        public SignatureType Type { get { throw null; } }
+
+        public abstract byte[] GetSignatureValue();
+        public string GetSigningCertificateFingerprint(Common.HashAlgorithmName algorithm) { throw null; }
+
+        protected abstract void ThrowForInvalidSignature();
+        public virtual SignatureVerificationSummary Verify(Timestamp timestamp, SignatureVerifySettings settings, Common.HashAlgorithmName fingerprintAlgorithm, System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificateExtraStore) { throw null; }
+    }
+
+    public sealed partial class SignatureContent
+    {
+        public SignatureContent(SigningSpecifications signingSpecifications, Common.HashAlgorithmName hashAlgorithm, string hashValue) { }
+
+        public Common.HashAlgorithmName HashAlgorithm { get { throw null; } }
+
+        public string HashValue { get { throw null; } }
+
+        public byte[] GetBytes() { throw null; }
+
+        public static SignatureContent Load(byte[] bytes, SigningSpecifications signingSpecifications) { throw null; }
+    }
+
+    public partial class SignatureException : Core.PackagingException
+    {
+        public SignatureException(Common.NuGetLogCode code, string message, Core.PackageIdentity package) : base(default!) { }
+
+        public SignatureException(Common.NuGetLogCode code, string message, System.Exception innerException) : base(default!) { }
+
+        public SignatureException(Common.NuGetLogCode code, string message) : base(default!) { }
+
+        public SignatureException(System.Collections.Generic.IReadOnlyList<PackageVerificationResult> results, Core.PackageIdentity package) : base(default!) { }
+
+        public SignatureException(string message) : base(default!) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PackageVerificationResult> Results { get { throw null; } }
+
+        public System.TimeSpan VerifyDuration { get { throw null; } set { } }
+    }
+
+    public partial class SignatureLog : Common.ILogMessage, System.IEquatable<SignatureLog>
+    {
+        public Common.NuGetLogCode Code { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } set { } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public System.DateTimeOffset Time { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public Common.RestoreLogMessage AsRestoreLogMessage() { throw null; }
+
+        public static SignatureLog DebugLog(string message) { throw null; }
+
+        public static SignatureLog DetailedLog(string message) { throw null; }
+
+        public bool Equals(SignatureLog other) { throw null; }
+
+        public static SignatureLog Error(Common.NuGetLogCode code, string message) { throw null; }
+
+        public static SignatureLog InformationLog(string message) { throw null; }
+
+        public static SignatureLog Issue(bool fatal, Common.NuGetLogCode code, string message) { throw null; }
+
+        public static SignatureLog MinimalLog(string message) { throw null; }
+    }
+
+    [System.Flags]
+    public enum SignaturePlacement
+    {
+        PrimarySignature = 1,
+        Countersignature = 2,
+        Any = 3
+    }
+
+    public sealed partial class SignatureTrustAndValidityVerificationProvider : ISignatureVerificationProvider
+    {
+        public SignatureTrustAndValidityVerificationProvider(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Common.HashAlgorithmName>> allowUntrustedRootList = null) { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public enum SignatureType
+    {
+        Unknown = 0,
+        Author = 1,
+        Repository = 2
+    }
+
+    public static partial class SignatureUtility
+    {
+        public static IX509CertificateChain GetCertificateChain(PrimarySignature primarySignature, RepositoryCountersignature repositoryCountersignature) { throw null; }
+
+        public static IX509CertificateChain GetCertificateChain(PrimarySignature primarySignature) { throw null; }
+
+        public static IX509CertificateChain GetTimestampCertificateChain(PrimarySignature primarySignature, RepositoryCountersignature repositoryCountersignature) { throw null; }
+
+        public static IX509CertificateChain GetTimestampCertificateChain(PrimarySignature primarySignature) { throw null; }
+
+        public static bool HasRepositoryCountersignature(PrimarySignature primarySignature) { throw null; }
+    }
+
+    public enum SignatureVerificationBehavior
+    {
+        Never = 0,
+        IfExists = 1,
+        IfExistsAndIsNecessary = 2,
+        Always = 3
+    }
+
+    public enum SignatureVerificationStatus
+    {
+        Unknown = 0,
+        Suspect = 1,
+        Disallowed = 2,
+        Valid = 3
+    }
+
+    [System.Flags]
+    public enum SignatureVerificationStatusFlags
+    {
+        NoErrors = 0,
+        NoSignature = 1,
+        NoCertificate = 2,
+        MultipleSignatures = 4,
+        SignatureCheckFailed = 8,
+        SignatureAlgorithmUnsupported = 16,
+        CertificatePublicKeyInvalid = 32,
+        HasLifetimeSigningEku = 64,
+        CertificateValidityInTheFuture = 128,
+        CertificateExpired = 256,
+        HashAlgorithmUnsupported = 512,
+        MessageImprintUnsupportedAlgorithm = 1024,
+        Illegal = 1790,
+        IntegrityCheckFailed = 2048,
+        ChainBuildingFailure = 4096,
+        UnknownRevocation = 8192,
+        CertificateRevoked = 16384,
+        Suspect = 18432,
+        UntrustedRoot = 32768,
+        GeneralizedTimeOutsideValidity = 65536,
+        Untrusted = 110849,
+        NoValidTimestamp = 131072,
+        MultipleTimestamps = 262144
+    }
+
+    public sealed partial class SignatureVerificationSummary
+    {
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, Timestamp timestamp, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, Timestamp timestamp, System.DateTimeOffset? expirationTime, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public System.DateTimeOffset? ExpirationTime { get { throw null; } }
+
+        public SignatureVerificationStatusFlags Flags { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<SignatureLog> Issues { get { throw null; } set { } }
+
+        public SignatureType SignatureType { get { throw null; } }
+
+        public SignatureVerificationStatus Status { get { throw null; } }
+
+        public Timestamp Timestamp { get { throw null; } }
+    }
+
+    public sealed partial class SignatureVerifySettings
+    {
+        public SignatureVerifySettings(bool allowIllegal, bool allowUntrusted, bool allowUnknownRevocation, bool reportUnknownRevocation, bool reportUntrustedRoot, Common.RevocationMode revocationMode) { }
+
+        public bool AllowIllegal { get { throw null; } }
+
+        public bool AllowUnknownRevocation { get { throw null; } }
+
+        public bool AllowUntrusted { get { throw null; } }
+
+        public static SignatureVerifySettings Default { get { throw null; } }
+
+        public bool ReportUnknownRevocation { get { throw null; } }
+
+        public bool ReportUntrustedRoot { get { throw null; } }
+
+        public Common.RevocationMode RevocationMode { get { throw null; } }
+    }
+
+    public partial class SignedPackageArchive : PackageArchiveReader, ISignedPackage, ISignedPackageReader, System.IDisposable, ISignedPackageWriter
+    {
+        public SignedPackageArchive(System.IO.Stream packageReadStream, System.IO.Stream packageWriteStream) : base(packageReadStream) { }
+
+        public System.Threading.Tasks.Task AddSignatureAsync(System.IO.Stream signatureStream, System.Threading.CancellationToken token) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public System.Threading.Tasks.Task<bool> IsZip64Async(System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task RemoveSignatureAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class SignedPackageArchiveIOUtility
+    {
+        public static void HashBytes(System.Security.Cryptography.HashAlgorithm hashAlgorithm, byte[] bytes) { }
+
+        public static void ReadAndHashUntilPosition(System.IO.BinaryReader reader, System.Security.Cryptography.HashAlgorithm hashAlgorithm, long position) { }
+
+        public static void ReadAndWriteUntilPosition(System.IO.BinaryReader reader, System.IO.BinaryWriter writer, long position) { }
+
+        public static SignedPackageArchiveMetadata ReadSignedArchiveMetadata(System.IO.BinaryReader reader, bool validateSignatureEntry = true) { throw null; }
+    }
+
+    public sealed partial class SignedPackageArchiveMetadata
+    {
+        public SignedPackageArchiveMetadata() { }
+
+        public System.Collections.Generic.List<CentralDirectoryHeaderMetadata> CentralDirectoryHeaders { get { throw null; } set { } }
+
+        public long EndOfCentralDirectory { get { throw null; } set { } }
+
+        public int SignatureCentralDirectoryHeaderIndex { get { throw null; } set { } }
+
+        public long StartOfLocalFileHeaders { get { throw null; } set { } }
+
+        public CentralDirectoryHeaderMetadata GetPackageSignatureFileCentralDirectoryHeaderMetadata() { throw null; }
+    }
+
+    public static partial class SignedPackageArchiveUtility
+    {
+        public static bool IsSigned(System.IO.BinaryReader reader) { throw null; }
+
+        public static bool IsZip64(System.IO.BinaryReader reader) { throw null; }
+
+        public static System.IO.Stream OpenPackageSignatureFileStream(System.IO.BinaryReader reader) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> RemoveRepositorySignaturesAsync(System.IO.Stream input, System.IO.Stream output, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class SignedPackageVerificationResult : PackageVerificationResult
+    {
+        public SignedPackageVerificationResult(SignatureVerificationStatus trust, PrimarySignature signature, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+
+        public PrimarySignature Signature { get { throw null; } }
+    }
+
+    public sealed partial class SignedPackageVerifierSettings
+    {
+        public SignedPackageVerifierSettings(bool allowUnsigned, bool allowIllegal, bool allowUntrusted, bool allowIgnoreTimestamp, bool allowMultipleTimestamps, bool allowNoTimestamp, bool allowUnknownRevocation, bool reportUnknownRevocation, VerificationTarget verificationTarget, SignaturePlacement signaturePlacement, SignatureVerificationBehavior repositoryCountersignatureVerificationBehavior, Common.RevocationMode revocationMode) { }
+
+        public bool AllowIgnoreTimestamp { get { throw null; } }
+
+        public bool AllowIllegal { get { throw null; } }
+
+        public bool AllowMultipleTimestamps { get { throw null; } }
+
+        public bool AllowNoTimestamp { get { throw null; } }
+
+        public bool AllowUnknownRevocation { get { throw null; } }
+
+        public bool AllowUnsigned { get { throw null; } }
+
+        public bool AllowUntrusted { get { throw null; } }
+
+        public bool ReportUnknownRevocation { get { throw null; } }
+
+        public SignatureVerificationBehavior RepositoryCountersignatureVerificationBehavior { get { throw null; } }
+
+        public Common.RevocationMode RevocationMode { get { throw null; } }
+
+        public SignaturePlacement SignaturePlacement { get { throw null; } }
+
+        public VerificationTarget VerificationTarget { get { throw null; } }
+
+        public static SignedPackageVerifierSettings GetAcceptModeDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetDefault(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetRequireModeDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetVerifyCommandDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+    }
+
+    public sealed partial class SigningCertificate
+    {
+        public System.Collections.Generic.IReadOnlyList<EssCertId> Certificates { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyInformation> Policies { get { throw null; } }
+
+        public static SigningCertificate Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class SigningCertificateV2
+    {
+        public System.Collections.Generic.IReadOnlyList<EssCertIdV2> Certificates { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyInformation> Policies { get { throw null; } }
+
+        public static SigningCertificateV2 Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public static SigningCertificateV2 Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class SigningOptions : System.IDisposable
+    {
+        public SigningOptions(System.Lazy<System.IO.Stream> inputPackageStream, System.Lazy<System.IO.Stream> outputPackageStream, bool overwrite, ISignatureProvider signatureProvider, Common.ILogger logger) { }
+
+        public System.IO.Stream InputPackageStream { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public System.IO.Stream OutputPackageStream { get { throw null; } }
+
+        public bool Overwrite { get { throw null; } }
+
+        public ISignatureProvider SignatureProvider { get { throw null; } }
+
+        public static SigningOptions CreateFromFilePaths(string inputPackageFilePath, string outputPackageFilePath, bool overwrite, ISignatureProvider signatureProvider, Common.ILogger logger) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public abstract partial class SigningSpecifications
+    {
+        public static readonly SigningSpecificationsV1 V1;
+        protected SigningSpecifications() { }
+
+        public abstract string[] AllowedHashAlgorithmOids { get; }
+        public abstract Common.HashAlgorithmName[] AllowedHashAlgorithms { get; }
+        public abstract string[] AllowedSignatureAlgorithmOids { get; }
+        public abstract Common.SignatureAlgorithmName[] AllowedSignatureAlgorithms { get; }
+        public abstract System.Text.Encoding Encoding { get; }
+        public abstract int RSAPublicKeyMinLength { get; }
+        public abstract string SignaturePath { get; }
+        public abstract string Version { get; }
+    }
+
+    public sealed partial class SigningSpecificationsV1 : SigningSpecifications
+    {
+        public SigningSpecificationsV1() { }
+
+        public override string[] AllowedHashAlgorithmOids { get { throw null; } }
+
+        public override Common.HashAlgorithmName[] AllowedHashAlgorithms { get { throw null; } }
+
+        public override string[] AllowedSignatureAlgorithmOids { get { throw null; } }
+
+        public override Common.SignatureAlgorithmName[] AllowedSignatureAlgorithms { get { throw null; } }
+
+        public override System.Text.Encoding Encoding { get { throw null; } }
+
+        public override int RSAPublicKeyMinLength { get { throw null; } }
+
+        public override string SignaturePath { get { throw null; } }
+
+        public override string Version { get { throw null; } }
+    }
+
+    public static partial class SigningUtility
+    {
+        public static System.Security.Cryptography.Pkcs.CmsSigner CreateCmsSigner(SignPackageRequest request, Common.ILogger logger) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObjectCollection CreateSignedAttributes(RepositorySignPackageRequest request, System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2> chainList) { throw null; }
+
+        public static System.Security.Cryptography.CryptographicAttributeObjectCollection CreateSignedAttributes(SignPackageRequest request, System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2> chainList) { throw null; }
+
+        public static System.Threading.Tasks.Task SignAsync(SigningOptions options, SignPackageRequest signRequest, System.Threading.CancellationToken token) { throw null; }
+
+        public static void Verify(SignPackageRequest request, Common.ILogger logger) { }
+    }
+
+    public abstract partial class SignPackageRequest : System.IDisposable
+    {
+        protected SignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm) { }
+
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection AdditionalCertificates { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public System.Security.Cryptography.CngKey PrivateKey { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName SignatureHashAlgorithm { get { throw null; } }
+
+        public abstract SignatureType SignatureType { get; }
+
+        public Common.HashAlgorithmName TimestampHashAlgorithm { get { throw null; } }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class Timestamp
+    {
+        public Timestamp() { }
+
+        public Timestamp(System.Security.Cryptography.Pkcs.SignedCms timestampCms) { }
+
+        public System.DateTimeOffset GeneralizedTime { get { throw null; } }
+
+        public System.DateTimeOffset LowerLimit { get { throw null; } }
+
+        public System.Security.Cryptography.Pkcs.SignedCms SignedCms { get { throw null; } }
+
+        public System.Security.Cryptography.Pkcs.SignerInfo SignerInfo { get { throw null; } }
+
+        public System.DateTimeOffset UpperLimit { get { throw null; } }
+    }
+
+    public partial class TimestampException : SignatureException
+    {
+        public TimestampException() : base(default!) { }
+
+        public TimestampException(Common.NuGetLogCode code, string message, System.Exception innerException) : base(default!) { }
+
+        public TimestampException(Common.NuGetLogCode code, string message) : base(default!) { }
+
+        public TimestampException(string message) : base(default!) { }
+    }
+
+    public partial class TimestampRequest
+    {
+        public TimestampRequest(SigningSpecifications signingSpecifications, byte[] hashedMessage, Common.HashAlgorithmName hashAlgorithm, SignaturePlacement target) { }
+
+        public Common.HashAlgorithmName HashAlgorithm { get { throw null; } }
+
+        public byte[] HashedMessage { get { throw null; } }
+
+        public SigningSpecifications SigningSpecifications { get { throw null; } }
+
+        public SignaturePlacement Target { get { throw null; } }
+    }
+
+    public sealed partial class TrustedSignerAllowListEntry : CertificateHashAllowListEntry
+    {
+        public TrustedSignerAllowListEntry(VerificationTarget target, SignaturePlacement placement, string fingerprint, Common.HashAlgorithmName algorithm, bool allowUntrustedRoot = false, System.Collections.Generic.IReadOnlyList<string> owners = null) : base(default, default, default!, default) { }
+
+        public bool AllowUntrustedRoot { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Owners { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class TrustedSignersProvider : ITrustedSignersProvider
+    {
+        public TrustedSignersProvider(Configuration.ISettings settings) { }
+
+        public void AddOrUpdateTrustedSigner(Configuration.TrustedSignerItem trustedSigner) { }
+
+        public static System.Collections.Generic.IReadOnlyList<TrustedSignerAllowListEntry> GetAllowListEntries(Configuration.ISettings settings, Common.ILogger logger) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> GetTrustedSigners() { throw null; }
+
+        public void Remove(System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> trustedSigners) { }
+    }
+
+    public sealed partial class TstInfo
+    {
+        public Accuracy Accuracy { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection Extensions { get { throw null; } }
+
+        public System.DateTimeOffset GenTime { get { throw null; } }
+
+        public MessageImprint MessageImprint { get { throw null; } }
+
+        public byte[] Nonce { get { throw null; } }
+
+        public bool Ordering { get { throw null; } }
+
+        public System.Security.Cryptography.Oid Policy { get { throw null; } }
+
+        public byte[] SerialNumber { get { throw null; } }
+
+        public byte[] Tsa { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static TstInfo Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class UnknownPrimarySignature : PrimarySignature
+    {
+        public UnknownPrimarySignature(System.Security.Cryptography.Pkcs.SignedCms signedCms) : base(default!, default) { }
+    }
+
+    public partial class UnsignedPackageVerificationResult : PackageVerificationResult
+    {
+        public UnsignedPackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+    }
+
+    public abstract partial class VerificationAllowListEntry
+    {
+        public VerificationAllowListEntry(VerificationTarget target, SignaturePlacement placement) { }
+
+        public SignaturePlacement Placement { get { throw null; } }
+
+        public VerificationTarget Target { get { throw null; } }
+    }
+
+    [System.Flags]
+    public enum VerificationTarget
+    {
+        None = 0,
+        Unknown = 2,
+        Author = 4,
+        Repository = 8,
+        All = 14
+    }
+
+    public static partial class VerificationUtility
+    {
+        public static SignatureVerificationStatus GetSignatureVerificationStatus(SignatureVerificationStatusFlags flags) { throw null; }
+
+        public static bool IsVerificationTarget(SignatureType signatureType, VerificationTarget target) { throw null; }
+    }
+
+    public sealed partial class VerifySignaturesResult
+    {
+        public VerifySignaturesResult(bool isValid, bool isSigned, System.Collections.Generic.IEnumerable<PackageVerificationResult> results) { }
+
+        public VerifySignaturesResult(bool isValid, bool isSigned) { }
+
+        public bool IsSigned { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PackageVerificationResult> Results { get { throw null; } }
+    }
+
+    public sealed partial class X509CertificateChain : System.Collections.Generic.List<System.Security.Cryptography.X509Certificates.X509Certificate2>, IX509CertificateChain, System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.IDisposable
+    {
+        public X509CertificateChain() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class X509ChainHolder : System.IDisposable
+    {
+        public X509ChainHolder() { }
+
+        public System.Security.Cryptography.X509Certificates.X509Chain Chain { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public partial class X509SignatureProvider : ISignatureProvider
+    {
+        public X509SignatureProvider(ITimestampProvider timestampProvider) { }
+
+        public System.Threading.Tasks.Task<PrimarySignature> CreatePrimarySignatureAsync(SignPackageRequest request, SignatureContent signatureContent, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<PrimarySignature> CreateRepositoryCountersignatureAsync(RepositorySignPackageRequest request, PrimarySignature primarySignature, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Signing.DerEncoding
+{
+    public sealed partial class DerGeneralizedTime
+    {
+        public System.DateTime DateTime { get { throw null; } }
+
+        public static DerGeneralizedTime Read(string decodedTime) { throw null; }
+    }
+}
+
+namespace NuGet.RuntimeModel
+{
+    public partial class CompatibilityProfile : System.IEquatable<CompatibilityProfile>
+    {
+        public CompatibilityProfile(string name, System.Collections.Generic.IEnumerable<Frameworks.FrameworkRuntimePair> restoreContexts) { }
+
+        public CompatibilityProfile(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.FrameworkRuntimePair> RestoreContexts { get { throw null; } }
+
+        public CompatibilityProfile Clone() { throw null; }
+
+        public bool Equals(CompatibilityProfile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial interface IObjectWriter
+    {
+        void WriteArrayEnd();
+        void WriteArrayStart(string name);
+        void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values);
+        void WriteNameValue(string name, bool value);
+        void WriteNameValue(string name, int value);
+        void WriteNameValue(string name, string value);
+        void WriteObjectEnd();
+        void WriteObjectStart();
+        void WriteObjectStart(string name);
+    }
+
+    public sealed partial class JsonObjectWriter : IObjectWriter, System.IDisposable
+    {
+        public JsonObjectWriter(Newtonsoft.Json.JsonWriter writer) { }
+
+        public void Dispose() { }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public static partial class JsonRuntimeFormat
+    {
+        public static RuntimeGraph ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken json) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(System.IO.Stream stream) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(System.IO.TextReader textReader) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(string filePath) { throw null; }
+
+        public static void WriteRuntimeGraph(IObjectWriter writer, RuntimeGraph runtimeGraph) { }
+
+        public static void WriteRuntimeGraph(string filePath, RuntimeGraph runtimeGraph) { }
+    }
+
+    public partial class RuntimeDependencySet : System.IEquatable<RuntimeDependencySet>
+    {
+        public RuntimeDependencySet(string id, System.Collections.Generic.IEnumerable<RuntimePackageDependency> dependencies) { }
+
+        public RuntimeDependencySet(string id) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimePackageDependency> Dependencies { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public RuntimeDependencySet Clone() { throw null; }
+
+        public bool Equals(RuntimeDependencySet other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RuntimeDescription : System.IEquatable<RuntimeDescription>
+    {
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<RuntimeDependencySet> runtimeDependencySets) { }
+
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<string> inheritedRuntimes, System.Collections.Generic.IEnumerable<RuntimeDependencySet> runtimeDependencySets) { }
+
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<string> inheritedRuntimes) { }
+
+        public RuntimeDescription(string runtimeIdentifier) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InheritedRuntimes { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimeDependencySet> RuntimeDependencySets { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public RuntimeDescription Clone() { throw null; }
+
+        public bool Equals(RuntimeDescription other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static RuntimeDescription Merge(RuntimeDescription left, RuntimeDescription right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RuntimeGraph : System.IEquatable<RuntimeGraph>
+    {
+        public static readonly RuntimeGraph Empty;
+        public static readonly string RuntimeGraphFileName;
+        public RuntimeGraph() { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<CompatibilityProfile> supports) { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<RuntimeDescription> runtimes, System.Collections.Generic.IEnumerable<CompatibilityProfile> supports) { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<RuntimeDescription> runtimes) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimeDescription> Runtimes { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, CompatibilityProfile> Supports { get { throw null; } set { } }
+
+        public bool AreCompatible(string criteria, string provided) { throw null; }
+
+        public RuntimeGraph Clone() { throw null; }
+
+        public bool Equals(RuntimeGraph other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<string> ExpandRuntime(string runtime) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<RuntimePackageDependency> FindRuntimeDependencies(string runtimeName, string packageId) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static RuntimeGraph Merge(RuntimeGraph left, RuntimeGraph right) { throw null; }
+    }
+
+    public partial class RuntimePackageDependency : System.IEquatable<RuntimePackageDependency>
+    {
+        public RuntimePackageDependency(string id, Versioning.VersionRange versionRange) { }
+
+        public string Id { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public RuntimePackageDependency Clone() { throw null; }
+
+        public bool Equals(RuntimePackageDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.packaging/6.2.2/lib/netstandard2.0/NuGet.Packaging.cs
+++ b/src/referencePackages/src/nuget.packaging/6.2.2/lib/netstandard2.0/NuGet.Packaging.cs
@@ -1,0 +1,3564 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Packaging.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Packaging.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's understanding of packages. Reading nuspec, nupkgs and package signing.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Packaging")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Client
+{
+    public partial class ManagedCodeConventions
+    {
+        public ManagedCodeConventions(RuntimeModel.RuntimeGraph runtimeGraph) { }
+
+        public ManagedCodeCriteria Criteria { get { throw null; } }
+
+        public ManagedCodePatterns Patterns { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentModel.ContentPropertyDefinition> Properties { get { throw null; } }
+
+        public partial class ManagedCodeCriteria
+        {
+            public ContentModel.SelectionCriteria ForFramework(Frameworks.NuGetFramework framework) { throw null; }
+
+            public ContentModel.SelectionCriteria ForFrameworkAndRuntime(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+            public ContentModel.SelectionCriteria ForRuntime(string runtimeIdentifier) { throw null; }
+        }
+
+        public partial class ManagedCodePatterns
+        {
+            public ContentModel.PatternSet AnyTargettedFile { get { throw null; } }
+
+            public ContentModel.PatternSet CompileLibAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet CompileRefAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet ContentFiles { get { throw null; } }
+
+            public ContentModel.PatternSet EmbedAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildFiles { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildMultiTargetingFiles { get { throw null; } }
+
+            public ContentModel.PatternSet MSBuildTransitiveFiles { get { throw null; } }
+
+            public ContentModel.PatternSet NativeLibraries { get { throw null; } }
+
+            public ContentModel.PatternSet ResourceAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet RuntimeAssemblies { get { throw null; } }
+
+            public ContentModel.PatternSet ToolsAssemblies { get { throw null; } }
+        }
+
+        public static partial class PropertyNames
+        {
+            public static readonly string AnyValue;
+            public static readonly string CodeLanguage;
+            public static readonly string Locale;
+            public static readonly string ManagedAssembly;
+            public static readonly string MSBuild;
+            public static readonly string RuntimeIdentifier;
+            public static readonly string SatelliteAssembly;
+            public static readonly string TargetFrameworkMoniker;
+        }
+    }
+}
+
+namespace NuGet.ContentModel
+{
+    public partial class Asset
+    {
+        public Asset() { }
+
+        public string Link { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ContentItem
+    {
+        public ContentItem() { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, object> Properties { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ContentItemCollection
+    {
+        public ContentItemCollection() { }
+
+        public bool HasContract { get { throw null; } }
+
+        public ContentItemGroup FindBestItemGroup(SelectionCriteria criteria, params PatternSet[] definitions) { throw null; }
+
+        [System.Obsolete("This method causes excessive memory allocation with yield return. Use ContentItemCollection.PopulateItemGroups instead.")]
+        public System.Collections.Generic.IEnumerable<ContentItemGroup> FindItemGroups(PatternSet definition) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<ContentItem> FindItems(PatternSet definition) { throw null; }
+
+        public bool HasItemGroup(SelectionCriteria criteria, params PatternSet[] definitions) { throw null; }
+
+        public void Load(System.Collections.Generic.IEnumerable<string> paths) { }
+
+        public void PopulateItemGroups(PatternSet definition, System.Collections.Generic.IList<ContentItemGroup> contentItemGroupList) { }
+    }
+
+    public partial class ContentItemGroup
+    {
+        public ContentItemGroup() { }
+
+        public System.Collections.Generic.IList<ContentItem> Items { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
+    }
+
+    public partial class ContentPropertyDefinition
+    {
+        public ContentPropertyDefinition(string name, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Collections.Generic.IEnumerable<string> fileExtensions) { }
+
+        public ContentPropertyDefinition(string name, System.Func<object, object, bool> compatibilityTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Collections.Generic.IEnumerable<string> fileExtensions) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest, System.Func<object, object, object, int> compareTest, System.Collections.Generic.IEnumerable<string> fileExtensions, bool allowSubfolders) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest, System.Func<object, object, object, int> compareTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser, System.Func<object, object, bool> compatibilityTest) { }
+
+        public ContentPropertyDefinition(string name, System.Func<string, PatternTable, object> parser) { }
+
+        public ContentPropertyDefinition(string name) { }
+
+        public System.Func<object, object, object, int> CompareTest { get { throw null; } }
+
+        public System.Func<object, object, bool> CompatibilityTest { get { throw null; } }
+
+        public bool FileExtensionAllowSubFolders { get { throw null; } }
+
+        public System.Collections.Generic.List<string> FileExtensions { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Func<string, PatternTable, object> Parser { get { throw null; } }
+
+        public virtual int Compare(object criteriaValue, object candidateValue1, object candidateValue2) { throw null; }
+
+        public virtual bool IsCriteriaSatisfied(object critieriaValue, object candidateValue) { throw null; }
+
+        public virtual bool TryLookup(string name, PatternTable table, out object value) { throw null; }
+    }
+
+    public partial class PatternDefinition
+    {
+        public PatternDefinition(string pattern, PatternTable table, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> defaults) { }
+
+        public PatternDefinition(string pattern, PatternTable table) { }
+
+        public PatternDefinition(string pattern) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, object> Defaults { get { throw null; } }
+
+        public string Pattern { get { throw null; } }
+
+        public PatternTable Table { get { throw null; } }
+
+        public static implicit operator PatternDefinition(string pattern) { throw null; }
+    }
+
+    public partial class PatternSet
+    {
+        public PatternSet(System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> properties, System.Collections.Generic.IEnumerable<PatternDefinition> groupPatterns, System.Collections.Generic.IEnumerable<PatternDefinition> pathPatterns) { }
+
+        public System.Collections.Generic.IEnumerable<PatternDefinition> GroupPatterns { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PatternDefinition> PathPatterns { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> PropertyDefinitions { get { throw null; } set { } }
+    }
+
+    public partial class PatternTable
+    {
+        public PatternTable() { }
+
+        public PatternTable(System.Collections.Generic.IEnumerable<PatternTableEntry> entries) { }
+
+        public bool TryLookup(string propertyName, string name, out object value) { throw null; }
+    }
+
+    public partial class PatternTableEntry
+    {
+        public PatternTableEntry(string propertyName, string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public string PropertyName { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public partial class SelectionCriteria
+    {
+        public SelectionCriteria() { }
+
+        public System.Collections.Generic.IList<SelectionCriteriaEntry> Entries { get { throw null; } set { } }
+    }
+
+    public partial class SelectionCriteriaBuilder
+    {
+        public SelectionCriteriaBuilder(System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> properties) { }
+
+        public virtual SelectionCriteriaEntryBuilder Add { get { throw null; } }
+
+        public virtual SelectionCriteria Criteria { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> Properties { get { throw null; } }
+    }
+
+    public partial class SelectionCriteriaEntry
+    {
+        public SelectionCriteriaEntry() { }
+
+        public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } set { } }
+    }
+
+    public partial class SelectionCriteriaEntryBuilder : SelectionCriteriaBuilder
+    {
+        internal SelectionCriteriaEntryBuilder() : base(default!) { }
+
+        public override SelectionCriteriaEntryBuilder Add { get { throw null; } }
+
+        public SelectionCriteriaBuilder Builder { get { throw null; } }
+
+        public override SelectionCriteria Criteria { get { throw null; } }
+
+        public SelectionCriteriaEntry Entry { get { throw null; } }
+
+        public SelectionCriteriaEntryBuilder this[string key, object value] { get { throw null; } }
+
+        public SelectionCriteriaEntryBuilder this[string key, string value] { get { throw null; } }
+    }
+}
+
+namespace NuGet.ContentModel.Infrastructure
+{
+    public partial class PatternExpression
+    {
+        public PatternExpression(PatternDefinition pattern) { }
+
+        public ContentItem Match(string path, System.Collections.Generic.IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging
+{
+    public static partial class CollectionExtensions
+    {
+        public static void AddRange<T>(this System.Collections.Generic.ICollection<T> collection, System.Collections.Generic.IEnumerable<T> items) { }
+    }
+
+    public enum ExtractionSource
+    {
+        RestoreCommand = 0,
+        DownloadResource = 1,
+        NuGetFolderProject = 2
+    }
+
+    public partial class FallbackPackagePathInfo
+    {
+        public FallbackPackagePathInfo(string id, Versioning.NuGetVersion version, VersionFolderPathResolver resolver) { }
+
+        public string Id { get { throw null; } }
+
+        public VersionFolderPathResolver PathResolver { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+    }
+
+    public partial class FallbackPackagePathResolver
+    {
+        public FallbackPackagePathResolver(Common.INuGetPathContext pathContext) { }
+
+        public FallbackPackagePathResolver(string userPackageFolder, System.Collections.Generic.IEnumerable<string> fallbackPackageFolders) { }
+
+        public string GetPackageDirectory(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageDirectory(string packageId, string version) { throw null; }
+
+        public FallbackPackagePathInfo GetPackageInfo(string packageId, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class FrameworkAssemblyReference
+    {
+        public FrameworkAssemblyReference(string assemblyName, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> supportedFrameworks) { }
+
+        public string AssemblyName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> SupportedFrameworks { get { throw null; } }
+    }
+
+    public static partial class FrameworkNameUtility
+    {
+        public static System.Runtime.Versioning.FrameworkName ParseFrameworkFolderName(string path, bool strictParsing, out string effectivePath) { throw null; }
+
+        public static System.Runtime.Versioning.FrameworkName ParseFrameworkNameFromFilePath(string filePath, out string effectivePath) { throw null; }
+
+        public static Frameworks.NuGetFramework ParseNuGetFrameworkFolderName(string path, bool strictParsing, out string effectivePath) { throw null; }
+
+        public static Frameworks.NuGetFramework ParseNuGetFrameworkFromFilePath(string filePath, out string effectivePath) { throw null; }
+    }
+
+    public sealed partial class FrameworkReference : System.IEquatable<FrameworkReference>, System.Collections.Generic.IComparer<FrameworkReference>, System.IComparable<FrameworkReference>
+    {
+        public FrameworkReference(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public int Compare(FrameworkReference x, FrameworkReference y) { throw null; }
+
+        public int CompareTo(FrameworkReference other) { throw null; }
+
+        public bool Equals(FrameworkReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class FrameworkReferenceGroup : System.IEquatable<FrameworkReferenceGroup>, Frameworks.IFrameworkSpecific
+    {
+        public FrameworkReferenceGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<FrameworkReference> frameworkReferences) { }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReference> FrameworkReferences { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(FrameworkReferenceGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class FrameworksExtensions
+    {
+        public static string GetFrameworkString(this Frameworks.NuGetFramework self) { throw null; }
+    }
+
+    public partial class FrameworkSpecificGroup : System.IEquatable<FrameworkSpecificGroup>, Frameworks.IFrameworkSpecific
+    {
+        public FrameworkSpecificGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<string> items) { }
+
+        public bool HasEmptyFolder { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Items { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(FrameworkSpecificGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial interface IAsyncPackageContentReader
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IHashFunction : System.IDisposable
+    {
+        string GetHash();
+        void Update(byte[] data, int offset, int count);
+    }
+
+    public partial interface INuspecReader : Core.INuspecCoreReader
+    {
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkReferenceGroups();
+        string GetLanguage();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceGroups();
+    }
+
+    public partial interface IPackageContentReader
+    {
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetBuildItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetContentItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetLibItems();
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetPackageDependencies();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceItems();
+        System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetToolItems();
+    }
+
+    public partial interface IPackageDownloader : System.IDisposable
+    {
+        IAsyncPackageContentReader ContentReader { get; }
+
+        Core.IAsyncPackageCoreReader CoreReader { get; }
+
+        Signing.ISignedPackageReader SignedPackageReader { get; }
+
+        string Source { get; }
+
+        System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken);
+        void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync);
+        void SetThrottle(System.Threading.SemaphoreSlim throttle);
+    }
+
+    public partial interface IPackageFile
+    {
+        string EffectivePath { get; }
+
+        System.DateTimeOffset LastWriteTime { get; }
+
+        Frameworks.NuGetFramework NuGetFramework { get; }
+
+        string Path { get; }
+
+        [System.Obsolete("Use NuGetFramework instead. This property will be null for any frameworks net5.0 or above.")]
+        System.Runtime.Versioning.FrameworkName TargetFramework { get; }
+
+        System.IO.Stream GetStream();
+    }
+
+    public partial interface IPackageMetadata
+    {
+        System.Collections.Generic.IEnumerable<string> Authors { get; }
+
+        System.Collections.Generic.IEnumerable<ManifestContentFiles> ContentFiles { get; }
+
+        string Copyright { get; }
+
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> DependencyGroups { get; }
+
+        string Description { get; }
+
+        bool DevelopmentDependency { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get; }
+
+        System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get; }
+
+        string Icon { get; }
+
+        System.Uri IconUrl { get; }
+
+        string Id { get; }
+
+        string Language { get; }
+
+        LicenseMetadata LicenseMetadata { get; }
+
+        System.Uri LicenseUrl { get; }
+
+        System.Version MinClientVersion { get; }
+
+        System.Collections.Generic.IEnumerable<string> Owners { get; }
+
+        System.Collections.Generic.IEnumerable<PackageReferenceSet> PackageAssemblyReferences { get; }
+
+        System.Collections.Generic.IEnumerable<Core.PackageType> PackageTypes { get; }
+
+        System.Uri ProjectUrl { get; }
+
+        string Readme { get; }
+
+        string ReleaseNotes { get; }
+
+        Core.RepositoryMetadata Repository { get; }
+
+        bool RequireLicenseAcceptance { get; }
+
+        bool Serviceable { get; }
+
+        string Summary { get; }
+
+        string Tags { get; }
+
+        string Title { get; }
+
+        Versioning.NuGetVersion Version { get; }
+    }
+
+    public partial interface IPackageResolver
+    {
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<Core.PackageIdentity> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Collections.Generic.IEnumerable<PackageReference> installedPackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<Core.PackageIdentity> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<string> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Collections.Generic.IEnumerable<PackageReference> installedPackages, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<Core.PackageIdentity> Resolve(System.Collections.Generic.IEnumerable<string> targets, System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> availablePackages, System.Threading.CancellationToken token);
+    }
+
+    public partial class LicenseMetadata : System.IEquatable<LicenseMetadata>
+    {
+        public static readonly System.Version CurrentVersion;
+        public static readonly System.Version EmptyVersion;
+        public static readonly System.Uri LicenseFileDeprecationUrl;
+        public static readonly string LicenseServiceLinkTemplate;
+        public LicenseMetadata(LicenseType type, string license, Licenses.NuGetLicenseExpression expression, System.Collections.Generic.IReadOnlyList<string> warningsAndErrors, System.Version version) { }
+
+        public string License { get { throw null; } }
+
+        public Licenses.NuGetLicenseExpression LicenseExpression { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public LicenseType Type { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> WarningsAndErrors { get { throw null; } }
+
+        public bool Equals(LicenseMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum LicenseType
+    {
+        File = 0,
+        Expression = 1
+    }
+
+    [System.Obsolete("Use NuGet.Protocol.LocalPackageArchiveDownloader")]
+    public sealed partial class LocalPackageArchiveDownloader : IPackageDownloader, System.IDisposable
+    {
+        public LocalPackageArchiveDownloader(string source, string packageFilePath, Core.PackageIdentity packageIdentity, Common.ILogger logger) { }
+
+        public IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class Manifest
+    {
+        public Manifest(ManifestMetadata metadata, System.Collections.Generic.ICollection<ManifestFile> files) { }
+
+        public Manifest(ManifestMetadata metadata) { }
+
+        public System.Collections.Generic.ICollection<ManifestFile> Files { get { throw null; } }
+
+        public bool HasFilesNode { get { throw null; } }
+
+        public ManifestMetadata Metadata { get { throw null; } }
+
+        public static Manifest Create(IPackageMetadata metadata) { throw null; }
+
+        public static Manifest ReadFrom(System.IO.Stream stream, bool validateSchema) { throw null; }
+
+        public static Manifest ReadFrom(System.IO.Stream stream, System.Func<string, string> propertyProvider, bool validateSchema) { throw null; }
+
+        public void Save(System.IO.Stream stream, bool generateBackwardsCompatible) { }
+
+        public void Save(System.IO.Stream stream, int minimumManifestVersion, bool generateBackwardsCompatible) { }
+
+        public void Save(System.IO.Stream stream, int minimumManifestVersion) { }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public static void Validate(Manifest manifest) { }
+    }
+
+    public partial class ManifestContentFiles
+    {
+        public ManifestContentFiles() { }
+
+        public string BuildAction { get { throw null; } set { } }
+
+        public string CopyToOutput { get { throw null; } set { } }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Flatten { get { throw null; } set { } }
+
+        public string Include { get { throw null; } set { } }
+    }
+
+    public partial class ManifestFile
+    {
+        public ManifestFile() { }
+
+        public string Exclude { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public string Target { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    public partial class ManifestMetadata : IPackageMetadata
+    {
+        public ManifestMetadata() { }
+
+        public ManifestMetadata(IPackageMetadata copy) { }
+
+        public System.Collections.Generic.IEnumerable<string> Authors { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<ManifestContentFiles> ContentFiles { get { throw null; } set { } }
+
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> DependencyGroups { get { throw null; } set { } }
+
+        public string Description { get { throw null; } set { } }
+
+        public bool DevelopmentDependency { get { throw null; } set { } }
+
+        public bool EmitRequireLicenseAcceptance { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> FrameworkReferenceGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> FrameworkReferences { get { throw null; } set { } }
+
+        public string Icon { get { throw null; } set { } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public string Id { get { throw null; } set { } }
+
+        public string Language { get { throw null; } set { } }
+
+        public LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public System.Version MinClientVersion { get { throw null; } }
+
+        public string MinClientVersionString { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<PackageReferenceSet> PackageAssemblyReferences { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Core.PackageType> PackageTypes { get { throw null; } set { } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public string Readme { get { throw null; } set { } }
+
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        public Core.RepositoryMetadata Repository { get { throw null; } set { } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string Summary { get { throw null; } set { } }
+
+        public string Tags { get { throw null; } set { } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public void SetIconUrl(string iconUrl) { }
+
+        public void SetLicenseUrl(string licenseUrl) { }
+
+        public void SetProjectUrl(string projectUrl) { }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    public static partial class ManifestSchemaUtility
+    {
+        public static string GetSchemaNamespace(int version) { throw null; }
+
+        public static int GetVersionFromNamespace(string @namespace) { throw null; }
+
+        public static bool IsKnownSchema(string schemaNamespace) { throw null; }
+    }
+
+    public static partial class ManifestVersionUtility
+    {
+        public const int DefaultVersion = 1;
+        public const int SemverVersion = 3;
+        public const int TargetFrameworkSupportForDependencyContentsAndToolsVersion = 4;
+        public const int TargetFrameworkSupportForReferencesVersion = 5;
+        public const int XdtTransformationVersion = 6;
+        public static int GetManifestVersion(ManifestMetadata metadata) { throw null; }
+    }
+
+    public partial class MinClientVersionException : Core.PackagingException, Common.ILogMessageException
+    {
+        public MinClientVersionException(string message) : base(default!) { }
+
+        public override Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public static partial class MinClientVersionUtility
+    {
+        public static Versioning.NuGetVersion GetNuGetClientVersion() { throw null; }
+
+        public static bool IsMinClientVersionCompatible(Core.NuspecCoreReaderBase nuspecReader) { throw null; }
+
+        public static bool IsMinClientVersionCompatible(Versioning.NuGetVersion packageMinClientVersion) { throw null; }
+
+        public static void VerifyMinClientVersion(Core.NuspecCoreReaderBase nuspecReader) { }
+    }
+
+    public partial class NupkgMetadataFile : System.IEquatable<NupkgMetadataFile>
+    {
+        public NupkgMetadataFile() { }
+
+        public string ContentHash { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(NupkgMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class NupkgMetadataFileFormat
+    {
+        public static readonly int Version;
+        public static NupkgMetadataFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static NupkgMetadataFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static NupkgMetadataFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static NupkgMetadataFile Read(string filePath) { throw null; }
+
+        public static void Write(System.IO.Stream stream, NupkgMetadataFile hashFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, NupkgMetadataFile hashFile) { }
+
+        public static void Write(string filePath, NupkgMetadataFile hashFile) { }
+    }
+
+    public partial class NuspecReader : Core.NuspecCoreReaderBase
+    {
+        public NuspecReader(System.IO.Stream stream, Frameworks.IFrameworkNameProvider frameworkProvider, bool leaveStreamOpen) : base(stream) { }
+
+        public NuspecReader(System.IO.Stream stream) : base(stream) { }
+
+        public NuspecReader(string path, Frameworks.IFrameworkNameProvider frameworkProvider) : base(path) { }
+
+        public NuspecReader(string path) : base(path) { }
+
+        public NuspecReader(System.Xml.Linq.XDocument xml, Frameworks.IFrameworkNameProvider frameworkProvider) : base(xml) { }
+
+        public NuspecReader(System.Xml.Linq.XDocument xml) : base(xml) { }
+
+        public string GetAuthors() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Core.ContentFilesEntry> GetContentFiles() { throw null; }
+
+        public string GetCopyright() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetDependencyGroups(bool useStrictVersionCheck) { throw null; }
+
+        public string GetDescription() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkAssemblyGroups() { throw null; }
+
+        [System.Obsolete("GetFrameworkReferenceGroups() is deprecated. Please use GetFrameworkAssemblyGroups() instead.")]
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkReferenceGroups() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> GetFrameworkRefGroups() { throw null; }
+
+        public string GetIcon() { throw null; }
+
+        public string GetIconUrl() { throw null; }
+
+        public string GetLanguage() { throw null; }
+
+        public LicenseMetadata GetLicenseMetadata() { throw null; }
+
+        public string GetLicenseUrl() { throw null; }
+
+        public string GetOwners() { throw null; }
+
+        public string GetProjectUrl() { throw null; }
+
+        public string GetReadme() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceGroups() { throw null; }
+
+        public string GetReleaseNotes() { throw null; }
+
+        public Core.RepositoryMetadata GetRepositoryMetadata() { throw null; }
+
+        public bool GetRequireLicenseAcceptance() { throw null; }
+
+        public string GetSummary() { throw null; }
+
+        public string GetTags() { throw null; }
+
+        public string GetTitle() { throw null; }
+    }
+
+    public partial class PackageArchiveReader : PackageReaderBase
+    {
+        public PackageArchiveReader(System.IO.Compression.ZipArchive zipArchive, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Compression.ZipArchive zipArchive) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, bool leaveStreamOpen, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream, bool leaveStreamOpen) : base(default!) { }
+
+        public PackageArchiveReader(System.IO.Stream stream) : base(default!) { }
+
+        public PackageArchiveReader(string filePath, Frameworks.IFrameworkNameProvider frameworkProvider = null, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider = null) : base(default!) { }
+
+        protected Signing.SigningSpecifications SigningSpecifications { get { throw null; } }
+
+        protected System.IO.Stream ZipReadStream { get { throw null; } set { } }
+
+        public override bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public System.Collections.Generic.IEnumerable<ZipFilePair> EnumeratePackageEntries(System.Collections.Generic.IEnumerable<string> packageFiles, string packageDirectory) { throw null; }
+
+        public string ExtractFile(string packageFile, string targetFilePath, Common.ILogger logger) { throw null; }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithmName, System.Threading.CancellationToken token) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public System.IO.Compression.ZipArchiveEntry GetEntry(string packageFile) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        protected void ThrowIfZipReadStreamIsNull() { }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task ValidatePackageEntriesAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageBuilder : IPackageMetadata
+    {
+        public const int MaxIconFileSize = 1048576;
+        public PackageBuilder() { }
+
+        public PackageBuilder(bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(bool deterministic) { }
+
+        public PackageBuilder(System.IO.Stream stream, string basePath, System.Func<string, string> propertyProvider) { }
+
+        public PackageBuilder(System.IO.Stream stream, string basePath) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic) { }
+
+        public PackageBuilder(string path, System.Func<string, string> propertyProvider, bool includeEmptyDirectories) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic, Common.ILogger logger) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories, bool deterministic) { }
+
+        public PackageBuilder(string path, string basePath, System.Func<string, string> propertyProvider, bool includeEmptyDirectories) { }
+
+        public System.Collections.Generic.ISet<string> Authors { get { throw null; } }
+
+        public System.Collections.Generic.ICollection<ManifestContentFiles> ContentFiles { get { throw null; } }
+
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.ObjectModel.Collection<PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public string Description { get { throw null; } set { } }
+
+        public bool DevelopmentDependency { get { throw null; } set { } }
+
+        public bool EmitRequireLicenseAcceptance { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<IPackageFile> Files { get { throw null; } }
+
+        public System.Collections.ObjectModel.Collection<FrameworkReferenceGroup> FrameworkReferenceGroups { get { throw null; } }
+
+        public System.Collections.ObjectModel.Collection<FrameworkAssemblyReference> FrameworkReferences { get { throw null; } }
+
+        public bool HasSnapshotVersion { get { throw null; } set { } }
+
+        public string Icon { get { throw null; } set { } }
+
+        public System.Uri IconUrl { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public string Language { get { throw null; } set { } }
+
+        public LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+        public System.Uri LicenseUrl { get { throw null; } set { } }
+
+        public System.Version MinClientVersion { get { throw null; } set { } }
+
+        System.Collections.Generic.IEnumerable<string> IPackageMetadata.Authors { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<ManifestContentFiles> IPackageMetadata.ContentFiles { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<PackageDependencyGroup> IPackageMetadata.DependencyGroups { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<FrameworkReferenceGroup> IPackageMetadata.FrameworkReferenceGroups { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<FrameworkAssemblyReference> IPackageMetadata.FrameworkReferences { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<string> IPackageMetadata.Owners { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<PackageReferenceSet> IPackageMetadata.PackageAssemblyReferences { get { throw null; } }
+
+        System.Collections.Generic.IEnumerable<Core.PackageType> IPackageMetadata.PackageTypes { get { throw null; } }
+
+        string IPackageMetadata.Tags { get { throw null; } }
+
+        public string OutputName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> Owners { get { throw null; } }
+
+        public System.Collections.Generic.ICollection<PackageReferenceSet> PackageAssemblyReferences { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<Core.PackageType> PackageTypes { get { throw null; } set { } }
+
+        public System.Uri ProjectUrl { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> Properties { get { throw null; } }
+
+        public string Readme { get { throw null; } set { } }
+
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        public Core.RepositoryMetadata Repository { get { throw null; } set { } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string Summary { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> Tags { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> TargetFrameworks { get { throw null; } set { } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public void AddFiles(string basePath, string source, string destination, string exclude = null) { }
+
+        public void Populate(ManifestMetadata manifestMetadata) { }
+
+        public void PopulateFiles(string basePath, System.Collections.Generic.IEnumerable<ManifestFile> files) { }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public static void ValidateReferenceAssemblies(System.Collections.Generic.IEnumerable<IPackageFile> files, System.Collections.Generic.IEnumerable<PackageReferenceSet> packageAssemblyReferences) { }
+    }
+
+    public partial class PackageDependencyGroup : System.IEquatable<PackageDependencyGroup>, Frameworks.IFrameworkSpecific
+    {
+        public PackageDependencyGroup(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<Core.PackageDependency> packages) { }
+
+        public System.Collections.Generic.IEnumerable<Core.PackageDependency> Packages { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(PackageDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageExtractionContext
+    {
+        public PackageExtractionContext(PackageSaveMode packageSaveMode, XmlDocFileSaveMode xmlDocFileSaveMode, Signing.ClientPolicyContext clientPolicyContext, Common.ILogger logger) { }
+
+        public Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } }
+
+        public bool CopySatelliteFiles { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public Signing.IPackageSignatureVerifier SignedPackageVerifier { get { throw null; } set { } }
+
+        public XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+
+    public partial class PackageExtractionResult
+    {
+        public PackageExtractionResult(bool cached, System.TimeSpan signVerifyDelay, PackageSignType packageType, bool success, System.DateTimeOffset signVerifyStartTime, System.DateTimeOffset signVerifyEndTime) { }
+
+        public PackageExtractionResult(bool cached, System.TimeSpan signVerifyDelay, PackageSignType packageType, bool success, System.TimeSpan duration) { }
+
+        public bool Cached { get { throw null; } }
+
+        public System.TimeSpan Duration { get { throw null; } set { } }
+
+        public PackageSignType PackageType { get { throw null; } }
+
+        public System.TimeSpan SignVerifyDelay { get { throw null; } }
+
+        public System.DateTimeOffset SignVerifyEndTime { get { throw null; } }
+
+        public System.DateTimeOffset SignVerifyStartTime { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+    }
+
+    public partial class PackageExtractionTelemetryEvent : Common.TelemetryEvent
+    {
+        public const string EventName = "PackageExtractionInformation";
+        public PackageExtractionTelemetryEvent(PackageSaveMode packageSaveMode, Common.NuGetOperationStatus status, ExtractionSource extractionSource, Core.PackageIdentity packageId = null) : base(default!) { }
+
+        public ExtractionSource ExtractionSource { get { throw null; } }
+
+        public string PackageId { get { throw null; } }
+
+        public PackageSaveMode PackageSaveMode { get { throw null; } }
+
+        public string PackageVersion { get { throw null; } }
+
+        public Common.NuGetOperationStatus Status { get { throw null; } }
+
+        public void LogPackageIdentity(Core.PackageIdentity packageId) { }
+
+        public void SetResult(Common.NuGetOperationStatus status) { }
+    }
+
+    public static partial class PackageExtractor
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopySatelliteFilesAsync(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, PackageReaderBase packageReader, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, PackageReaderBase packageReader, System.IO.Stream packageStream, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> ExtractPackageAsync(string source, System.IO.Stream packageStream, PackagePathResolver packagePathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> InstallFromSourceAsync(Core.PackageIdentity packageIdentity, IPackageDownloader packageDownloader, VersionFolderPathResolver versionFolderPathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> InstallFromSourceAsync(string source, Core.PackageIdentity packageIdentity, System.Func<System.IO.Stream, System.Threading.Tasks.Task> copyToAsync, VersionFolderPathResolver versionFolderPathResolver, PackageExtractionContext packageExtractionContext, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+    }
+
+    public partial class PackageFileExtractor
+    {
+        public PackageFileExtractor(System.Collections.Generic.IEnumerable<string> packageFiles, XmlDocFileSaveMode xmlDocFileSaveMode) { }
+
+        public string ExtractPackageFile(string source, string target, System.IO.Stream stream) { throw null; }
+    }
+
+    public partial class PackageFolderReader : PackageReaderBase
+    {
+        public PackageFolderReader(System.IO.DirectoryInfo folder, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageFolderReader(System.IO.DirectoryInfo folder) : base(default!) { }
+
+        public PackageFolderReader(string folderPath, Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) : base(default!) { }
+
+        public PackageFolderReader(string folderPath) : base(default!) { }
+
+        public override bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override string GetNuspecFile() { throw null; }
+
+        public override System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class PackageHelper
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<ZipFilePair>> GetInstalledPackageFilesAsync(PackageArchiveReader packageReader, Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<string, System.Collections.Generic.IEnumerable<ZipFilePair>>> GetInstalledSatelliteFilesAsync(PackageArchiveReader packageReader, PackagePathResolver packagePathResolver, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<string, System.Collections.Generic.IEnumerable<string>>> GetSatelliteFilesAsync(PackageReaderBase packageReader, PackagePathResolver packagePathResolver, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static bool IsAssembly(string path) { throw null; }
+
+        public static bool IsManifest(string path) { throw null; }
+
+        public static bool IsNuspec(string path) { throw null; }
+
+        public static bool IsPackageFile(string packageFileName, PackageSaveMode packageSaveMode) { throw null; }
+
+        public static bool IsRoot(string path) { throw null; }
+    }
+
+    public static partial class PackageIdValidator
+    {
+        public const int MaxPackageIdLength = 100;
+        public static bool IsValidPackageId(string packageId) { throw null; }
+
+        public static void ValidatePackageId(string packageId) { }
+    }
+
+    public static partial class PackagePathHelper
+    {
+        public static string GetInstalledPackageFilePath(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetPackageLookupPaths(Core.PackageIdentity packageIdentity, PackagePathResolver packagePathResolver) { throw null; }
+    }
+
+    public partial class PackagePathResolver
+    {
+        public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true) { }
+
+        protected internal string Root { get { throw null; } }
+
+        public bool UseSideBySidePaths { get { throw null; } }
+
+        public virtual string GetInstalledPackageFilePath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetInstalledPath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetInstallPath(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public string GetManifestFileName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetPackageDirectoryName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public string GetPackageDownloadMarkerFileName(Core.PackageIdentity packageIdentity) { throw null; }
+
+        public virtual string GetPackageFileName(Core.PackageIdentity packageIdentity) { throw null; }
+    }
+
+    public abstract partial class PackageReaderBase : Core.IPackageCoreReader, System.IDisposable, IPackageContentReader, Core.IAsyncPackageCoreReader, IAsyncPackageContentReader, Signing.ISignedPackageReader
+    {
+        public PackageReaderBase(Frameworks.IFrameworkNameProvider frameworkProvider, Frameworks.IFrameworkCompatibilityProvider compatibilityProvider) { }
+
+        public PackageReaderBase(Frameworks.IFrameworkNameProvider frameworkProvider) { }
+
+        protected Frameworks.IFrameworkCompatibilityProvider CompatibilityProvider { get { throw null; } set { } }
+
+        protected Frameworks.IFrameworkNameProvider FrameworkProvider { get { throw null; } set { } }
+
+        public virtual NuspecReader NuspecReader { get { throw null; } }
+
+        public abstract bool CanVerifySignedPackages(Signing.SignedPackageVerifierSettings verifierSettings);
+        public abstract System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetBuildItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetContentItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual bool GetDevelopmentDependency() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFileGroups(string folder) { throw null; }
+
+        public abstract System.Collections.Generic.IEnumerable<string> GetFiles();
+        public abstract System.Collections.Generic.IEnumerable<string> GetFiles(string folder);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected Frameworks.NuGetFramework GetFrameworkFromPath(string path, bool allowSubFolders = false) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetFrameworkItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual Core.PackageIdentity GetIdentity() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Core.PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetItems(string folderName) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetLibItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.IO.Stream GetNuspec() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual string GetNuspecFile() { throw null; }
+
+        protected static string GetNuspecFile(System.Collections.Generic.IEnumerable<string> files) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<NuspecReader> GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<PackageDependencyGroup> GetPackageDependencies() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<Core.PackageType> GetPackageTypes() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Core.PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token);
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetReferenceItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.IO.Stream GetStream(string path);
+        public virtual System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetSupportedFrameworks() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework>> GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<FrameworkSpecificGroup> GetToolItems() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected static bool IsAllowedBuildFile(string packageId, string path) { throw null; }
+
+        protected static bool IsReferenceAssembly(string path) { throw null; }
+
+        public virtual bool IsServiceable() { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> IsServiceableAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token);
+        protected string NormalizeDirectoryPath(string path) { throw null; }
+
+        public abstract System.Threading.Tasks.Task ValidateIntegrityAsync(Signing.SignatureContent signatureContent, System.Threading.CancellationToken token);
+        protected static void ValidatePackageEntries(string normalizedDestination, System.Collections.Generic.IEnumerable<string> packageFiles, Core.PackageIdentity packageIdentity) { }
+
+        protected static void ValidatePackageEntry(string normalizedDestination, string normalizedFilePath, Core.PackageIdentity packageIdentity) { }
+    }
+
+    public static partial class PackageReaderExtensions
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetPackageFilesAsync(this Core.IAsyncPackageCoreReader packageReader, PackageSaveMode packageSaveMode, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetSatelliteFilesAsync(this IAsyncPackageContentReader packageReader, string packageLanguage, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageReference
+    {
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled, bool developmentDependency, bool requireReinstallation, Versioning.VersionRange allowedVersions) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled, bool developmentDependency, bool requireReinstallation) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework, bool userInstalled) { }
+
+        public PackageReference(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public Versioning.VersionRange AllowedVersions { get { throw null; } }
+
+        public bool HasAllowedVersions { get { throw null; } }
+
+        public bool IsDevelopmentDependency { get { throw null; } }
+
+        public bool IsUserInstalled { get { throw null; } }
+
+        public Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public bool RequireReinstallation { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageReferenceSet
+    {
+        public PackageReferenceSet(Frameworks.NuGetFramework targetFramework, System.Collections.Generic.IEnumerable<string> references) { }
+
+        public PackageReferenceSet(System.Collections.Generic.IEnumerable<string> references) { }
+
+        public PackageReferenceSet(string targetFramework, System.Collections.Generic.IEnumerable<string> references) { }
+
+        public System.Collections.Generic.IReadOnlyCollection<string> References { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Validate() { throw null; }
+    }
+
+    [System.Flags]
+    public enum PackageSaveMode
+    {
+        None = 0,
+        Nuspec = 1,
+        Nupkg = 2,
+        Files = 4,
+        Defaultv2 = 6,
+        Defaultv3 = 7
+    }
+
+    public static partial class PackagesConfig
+    {
+        public static readonly string allowedVersionsAttributeName;
+        public static readonly string developmentDependencyAttributeName;
+        public static readonly string IdAttributeName;
+        public static readonly string MinClientAttributeName;
+        public static readonly string PackageNodeName;
+        public static readonly string PackagesNodeName;
+        public static readonly string RequireInstallAttributeName;
+        public static readonly string TargetFrameworkAttributeName;
+        public static readonly string UserInstalledAttributeName;
+        public static readonly string VersionAttributeName;
+        public static bool BoolAttribute(System.Xml.Linq.XElement node, string name, bool defaultValue = false) { throw null; }
+
+        public static bool HasAttributeValue(System.Xml.Linq.XElement node, string attributeName, string targetValue, out System.Xml.Linq.XElement element) { throw null; }
+
+        public static bool TryGetAttribute(System.Xml.Linq.XElement node, string name, out string value) { throw null; }
+    }
+
+    public partial class PackagesConfigReader
+    {
+        public PackagesConfigReader(Frameworks.IFrameworkNameProvider frameworkMappings, System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public PackagesConfigReader(Frameworks.IFrameworkNameProvider frameworkMappings, System.Xml.Linq.XDocument xml) { }
+
+        public PackagesConfigReader(System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public PackagesConfigReader(System.IO.Stream stream) { }
+
+        public PackagesConfigReader(System.Xml.Linq.XDocument xml) { }
+
+        public Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageReference> GetPackages() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<PackageReference> GetPackages(bool allowDuplicatePackageIds) { throw null; }
+    }
+
+    public partial class PackagesConfigReaderException : Core.PackagingException
+    {
+        public PackagesConfigReaderException(string message, System.Exception innerException) : base(default!) { }
+
+        public PackagesConfigReaderException(string message) : base(default!) { }
+    }
+
+    public partial class PackagesConfigWriter : System.IDisposable
+    {
+        public PackagesConfigWriter(System.IO.Stream stream, bool createNew, Frameworks.IFrameworkNameProvider frameworkMappings) { }
+
+        public PackagesConfigWriter(System.IO.Stream stream, bool createNew) { }
+
+        public PackagesConfigWriter(string fullPath, bool createNew, Frameworks.IFrameworkNameProvider frameworkMappings) { }
+
+        public PackagesConfigWriter(string fullPath, bool createNew) { }
+
+        public void AddPackageEntry(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public void AddPackageEntry(PackageReference entry) { }
+
+        public void AddPackageEntry(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework targetFramework) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public void RemovePackageEntry(Core.PackageIdentity identity, Frameworks.NuGetFramework targetFramework) { }
+
+        public void RemovePackageEntry(PackageReference entry) { }
+
+        public void RemovePackageEntry(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework targetFramework) { }
+
+        public void UpdateOrAddPackageEntry(System.Xml.Linq.XDocument originalConfig, PackageReference newEntry) { }
+
+        public void UpdatePackageEntry(PackageReference oldEntry, PackageReference newEntry) { }
+
+        public void WriteFile(string fullPath) { }
+
+        public void WriteMinClientVersion(Versioning.NuGetVersion version) { }
+    }
+
+    public partial class PackagesConfigWriterException : Core.PackagingException
+    {
+        public PackagesConfigWriterException(string message, System.Exception innerException) : base(default!) { }
+
+        public PackagesConfigWriterException(string message) : base(default!) { }
+    }
+
+    public partial class PackageSigningTelemetryEvent : Common.TelemetryEvent
+    {
+        public const string EventName = "SigningInformation";
+        public PackageSigningTelemetryEvent() : base(default!) { }
+
+        public string ExtractionId { get { throw null; } }
+
+        public PackageSignType PackageSignType { get { throw null; } }
+
+        public Common.NuGetOperationStatus Status { get { throw null; } }
+
+        public void SetResult(PackageSignType packageSignType, Common.NuGetOperationStatus status) { }
+    }
+
+    public enum PackageSignType
+    {
+        Signed = 0,
+        Unsigned = 1
+    }
+
+    public static partial class PackagingConstants
+    {
+        public static readonly string AgnosticFramework;
+        public static readonly string AnyCodeLanguage;
+        public static readonly string AnyFramework;
+        public static readonly string ContentFilesDefaultBuildAction;
+        public static readonly string ManifestExtension;
+        public static readonly string PackageVerifyDurationName;
+        public static readonly string SnupkgFormat;
+        public static readonly string SymbolsNupkgFormat;
+        public static readonly string TargetFrameworkPropertyKey;
+        public static partial class Folders
+        {
+            public static readonly string Analyzers;
+            public static readonly string Build;
+            public static readonly string BuildCrossTargeting;
+            public static readonly string BuildTransitive;
+            public static readonly string Content;
+            public static readonly string ContentFiles;
+            public static readonly string Lib;
+            public static readonly string Native;
+            public static readonly string Ref;
+            public static readonly string Runtimes;
+            public static readonly string Source;
+            public static readonly string Tools;
+            public static string[] Known { get { throw null; } }
+        }
+    }
+
+    public partial class PhysicalPackageFile : IPackageFile
+    {
+        public PhysicalPackageFile() { }
+
+        public PhysicalPackageFile(System.IO.MemoryStream stream) { }
+
+        public string EffectivePath { get { throw null; } }
+
+        public System.DateTimeOffset LastWriteTime { get { throw null; } }
+
+        public Frameworks.NuGetFramework NuGetFramework { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public string SourcePath { get { throw null; } set { } }
+
+        public System.Runtime.Versioning.FrameworkName TargetFramework { get { throw null; } }
+
+        public string TargetPath { get { throw null; } set { } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public System.IO.Stream GetStream() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RepositorySignatureInfo
+    {
+        public RepositorySignatureInfo(bool allRepositorySigned, System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> repositoryCertificateInfos) { }
+
+        public bool AllRepositorySigned { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> RepositoryCertificateInfos { get { throw null; } }
+    }
+
+    public partial class RepositorySignatureInfoProvider
+    {
+        public RepositorySignatureInfoProvider() { }
+
+        public static RepositorySignatureInfoProvider Instance { get { throw null; } }
+
+        public void AddOrUpdateRepositorySignatureInfo(string source, RepositorySignatureInfo repositorySignatureInfo) { }
+
+        public bool TryGetRepositorySignatureInfo(string source, out RepositorySignatureInfo repositorySignatureInfo) { throw null; }
+    }
+
+    public sealed partial class Sha512HashFunction : IHashFunction, System.IDisposable
+    {
+        public Sha512HashFunction() { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public byte[] GetHashBytes() { throw null; }
+
+        public void Update(byte[] data, int offset, int count) { }
+    }
+
+    public static partial class StreamExtensions
+    {
+        public static string CopyToFile(this System.IO.Stream inputStream, string fileFullPath) { throw null; }
+    }
+
+    public static partial class TopologicalSortUtility
+    {
+        public static System.Collections.Generic.IReadOnlyList<Core.PackageDependencyInfo> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<Core.PackageDependencyInfo> packages) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<T> SortPackagesByDependencyOrder<T>(System.Collections.Generic.IEnumerable<T> items, System.StringComparer comparer, System.Func<T, string> getId, System.Func<T, string[]> getDependencies)
+            where T : class { throw null; }
+    }
+
+    public partial class UnsafePackageEntryException : Core.PackagingException, Common.ILogMessageException
+    {
+        public UnsafePackageEntryException(string message) : base(default!) { }
+
+        public override Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class VersionFolderPathResolver
+    {
+        public VersionFolderPathResolver(string rootPath, bool isLowercase) { }
+
+        public VersionFolderPathResolver(string rootPath) { }
+
+        public bool IsLowerCase { get { throw null; } }
+
+        public string RootPath { get { throw null; } }
+
+        public string GetHashFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetHashPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetInstallPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetManifestFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetManifestFilePath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetNupkgMetadataPath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetPackageDirectory(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageDownloadMarkerFileName(string packageId) { throw null; }
+
+        public virtual string GetPackageFileName(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public string GetPackageFilePath(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual string GetVersionListDirectory(string packageId) { throw null; }
+
+        public string GetVersionListPath(string packageId) { throw null; }
+    }
+
+    public static partial class XElementExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> ElementsNoNamespace(this System.Xml.Linq.XContainer container, string localName) { throw null; }
+
+        public static System.Xml.Linq.XElement Except(this System.Xml.Linq.XElement source, System.Xml.Linq.XElement target) { throw null; }
+
+        public static string GetOptionalAttributeValue(this System.Xml.Linq.XElement element, string localName, string namespaceName = null) { throw null; }
+    }
+
+    public enum XmlDocFileSaveMode
+    {
+        None = 0,
+        Skip = 1,
+        Compress = 2
+    }
+
+    [System.Obsolete("This class is obsolete and will be removed in a future release.")]
+    public static partial class XmlUtility
+    {
+        public static System.Xml.Linq.XDocument LoadSafe(System.IO.Stream input, bool ignoreWhiteSpace) { throw null; }
+
+        public static System.Xml.Linq.XDocument LoadSafe(System.IO.Stream input) { throw null; }
+    }
+
+    public static partial class ZipArchiveExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<string> GetFiles(this System.IO.Compression.ZipArchive zipArchive) { throw null; }
+
+        public static System.IO.Compression.ZipArchiveEntry LookupEntry(this System.IO.Compression.ZipArchive zipArchive, string path) { throw null; }
+
+        public static System.IO.Stream OpenFile(this System.IO.Compression.ZipArchive zipArchive, string path) { throw null; }
+
+        public static string SaveAsFile(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, Common.ILogger logger) { throw null; }
+
+        public static void UpdateFileTimeFromEntry(this System.IO.Compression.ZipArchiveEntry entry, string fileFullPath, Common.ILogger logger) { }
+    }
+
+    public partial class ZipFilePair
+    {
+        public ZipFilePair(string fileFullPath, System.IO.Compression.ZipArchiveEntry entry) { }
+
+        public string FileFullPath { get { throw null; } }
+
+        public System.IO.Compression.ZipArchiveEntry PackageEntry { get { throw null; } }
+
+        public bool IsInstalled() { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Core
+{
+    public partial class ContentFilesEntry
+    {
+        public ContentFilesEntry(string include, string exclude, string buildAction, bool? copyToOutput, bool? flatten) { }
+
+        public string BuildAction { get { throw null; } }
+
+        public bool? CopyToOutput { get { throw null; } }
+
+        public string Exclude { get { throw null; } }
+
+        public bool? Flatten { get { throw null; } }
+
+        public string Include { get { throw null; } }
+    }
+
+    public delegate string ExtractPackageFileDelegate(string sourceFile, string targetPath, System.IO.Stream fileStream);
+    public partial class Fingerprints
+    {
+        public Fingerprints(System.Collections.Generic.IDictionary<string, string> fingerPrints) { }
+
+        public string this[string key] { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator() { throw null; }
+    }
+
+    public partial interface IAsyncPackageCoreReader : System.IDisposable
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface INuspecCoreReader
+    {
+        string GetId();
+        PackageIdentity GetIdentity();
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetMetadata();
+        Versioning.NuGetVersion GetMinClientVersion();
+        System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes();
+        Versioning.NuGetVersion GetVersion();
+    }
+
+    public partial interface IPackageCoreReader : System.IDisposable
+    {
+        System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Collections.Generic.IEnumerable<string> GetFiles();
+        System.Collections.Generic.IEnumerable<string> GetFiles(string folder);
+        PackageIdentity GetIdentity();
+        Versioning.NuGetVersion GetMinClientVersion();
+        System.IO.Stream GetNuspec();
+        string GetNuspecFile();
+        System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes();
+        System.IO.Stream GetStream(string path);
+    }
+
+    public partial interface IPackageIdentityComparer : System.Collections.Generic.IEqualityComparer<PackageIdentity>, System.Collections.Generic.IComparer<PackageIdentity>
+    {
+    }
+
+    public partial interface IRepositoryCertificateInfo
+    {
+        string ContentUrl { get; }
+
+        Fingerprints Fingerprints { get; }
+
+        string Issuer { get; }
+
+        System.DateTimeOffset NotAfter { get; }
+
+        System.DateTimeOffset NotBefore { get; }
+
+        string Subject { get; }
+    }
+
+    public partial class NuspecCoreReader : NuspecCoreReaderBase
+    {
+        public NuspecCoreReader(System.IO.Stream stream) : base(stream) { }
+
+        public NuspecCoreReader(System.Xml.Linq.XDocument xml) : base(xml) { }
+
+        public virtual System.Collections.Generic.IEnumerable<PackageDependency> GetDependencies() { throw null; }
+    }
+
+    public abstract partial class NuspecCoreReaderBase : INuspecCoreReader
+    {
+        protected const string DevelopmentDependency = "developmentDependency";
+        protected const string Id = "id";
+        protected const string Metadata = "metadata";
+        protected const string MinClientVersion = "minClientVersion";
+        protected const string Version = "version";
+        public NuspecCoreReaderBase(System.IO.Stream stream, bool leaveStreamOpen) { }
+
+        public NuspecCoreReaderBase(System.IO.Stream stream) { }
+
+        public NuspecCoreReaderBase(string path) { }
+
+        public NuspecCoreReaderBase(System.Xml.Linq.XDocument xml) { }
+
+        protected System.Xml.Linq.XElement MetadataNode { get { throw null; } }
+
+        protected System.Collections.Generic.Dictionary<string, string> MetadataValues { get { throw null; } }
+
+        public System.Xml.Linq.XDocument Xml { get { throw null; } }
+
+        public virtual bool GetDevelopmentDependency() { throw null; }
+
+        public virtual string GetId() { throw null; }
+
+        public virtual PackageIdentity GetIdentity() { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetMetadata() { throw null; }
+
+        public virtual string GetMetadataValue(string name) { throw null; }
+
+        public virtual Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes() { throw null; }
+
+        public virtual Versioning.NuGetVersion GetVersion() { throw null; }
+
+        public virtual bool IsServiceable() { throw null; }
+    }
+
+    public static partial class NuspecUtility
+    {
+        public static readonly string FrameworkReference;
+        public static readonly string FrameworkReferences;
+        public static readonly string Group;
+        public static readonly string License;
+        public static readonly string Name;
+        public static readonly string PackageType;
+        public static readonly string PackageTypes;
+        public static readonly string Repository;
+        public static readonly string RepositoryBranch;
+        public static readonly string RepositoryCommit;
+        public static readonly string RepositoryUrl;
+        public static readonly string Serviceable;
+        public static readonly string TargetFramework;
+        public static readonly string Type;
+        public static readonly string Version;
+        public static System.Collections.Generic.IReadOnlyList<PackageType> GetPackageTypes(System.Xml.Linq.XElement metadataNode, bool useMetadataNamespace) { throw null; }
+
+        public static bool IsServiceable(System.Xml.Linq.XElement metadataNode) { throw null; }
+    }
+
+    public partial class PackageDependency : System.IEquatable<PackageDependency>
+    {
+        public PackageDependency(string id, Versioning.VersionRange versionRange, System.Collections.Generic.IReadOnlyList<string> include, System.Collections.Generic.IReadOnlyList<string> exclude) { }
+
+        public PackageDependency(string id, Versioning.VersionRange versionRange) { }
+
+        public PackageDependency(string id) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public bool Equals(PackageDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageDependencyComparer : System.Collections.Generic.IEqualityComparer<PackageDependency>
+    {
+        public static readonly PackageDependencyComparer Default;
+        public PackageDependencyComparer() { }
+
+        public PackageDependencyComparer(Versioning.IVersionRangeComparer versionRangeComparer) { }
+
+        public bool Equals(PackageDependency x, PackageDependency y) { throw null; }
+
+        public int GetHashCode(PackageDependency obj) { throw null; }
+    }
+
+    public partial class PackageDependencyInfo : PackageIdentity, System.IEquatable<PackageDependencyInfo>
+    {
+        public PackageDependencyInfo(PackageIdentity identity, System.Collections.Generic.IEnumerable<PackageDependency> dependencies) : base(default!, default!) { }
+
+        public PackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<PackageDependency> dependencies) : base(default!, default!) { }
+
+        public PackageDependencyInfo(string id, Versioning.NuGetVersion version) : base(default!, default!) { }
+
+        public System.Collections.Generic.IEnumerable<PackageDependency> Dependencies { get { throw null; } }
+
+        public bool Equals(PackageDependencyInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageDependencyInfoComparer : System.Collections.Generic.IEqualityComparer<PackageDependencyInfo>
+    {
+        public PackageDependencyInfoComparer() { }
+
+        public PackageDependencyInfoComparer(IPackageIdentityComparer identityComparer, PackageDependencyComparer dependencyComparer) { }
+
+        public static PackageDependencyInfoComparer Default { get { throw null; } }
+
+        public bool Equals(PackageDependencyInfo x, PackageDependencyInfo y) { throw null; }
+
+        public int GetHashCode(PackageDependencyInfo obj) { throw null; }
+    }
+
+    public partial class PackageIdentity : System.IEquatable<PackageIdentity>, System.IComparable<PackageIdentity>
+    {
+        public PackageIdentity(string id, Versioning.NuGetVersion version) { }
+
+        public static PackageIdentityComparer Comparer { get { throw null; } }
+
+        public bool HasVersion { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public int CompareTo(PackageIdentity other) { throw null; }
+
+        public virtual bool Equals(PackageIdentity other, Versioning.VersionComparison versionComparison) { throw null; }
+
+        public bool Equals(PackageIdentity other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class PackageIdentityComparer : IPackageIdentityComparer, System.Collections.Generic.IEqualityComparer<PackageIdentity>, System.Collections.Generic.IComparer<PackageIdentity>
+    {
+        public PackageIdentityComparer() { }
+
+        public PackageIdentityComparer(Versioning.IVersionComparer versionComparer) { }
+
+        public PackageIdentityComparer(Versioning.VersionComparison versionComparison) { }
+
+        public static PackageIdentityComparer Default { get { throw null; } }
+
+        public int Compare(PackageIdentity x, PackageIdentity y) { throw null; }
+
+        public bool Equals(PackageIdentity x, PackageIdentity y) { throw null; }
+
+        public int GetHashCode(PackageIdentity obj) { throw null; }
+    }
+
+    public partial class PackageType : System.IEquatable<PackageType>, System.IComparable<PackageType>
+    {
+        public static readonly PackageType Dependency;
+        public static readonly PackageType DotnetCliTool;
+        public static readonly PackageType DotnetPlatform;
+        public static readonly PackageType DotnetTool;
+        public static readonly System.Version EmptyVersion;
+        public static readonly PackageType Legacy;
+        public static readonly System.StringComparer PackageTypeNameComparer;
+        public static readonly PackageType SymbolsPackage;
+        public PackageType(string name, System.Version version) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public int CompareTo(PackageType other) { throw null; }
+
+        public bool Equals(PackageType other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(PackageType a, PackageType b) { throw null; }
+
+        public static bool operator !=(PackageType a, PackageType b) { throw null; }
+    }
+
+    public static partial class PackagingCoreConstants
+    {
+        public static readonly string EmptyFolder;
+        public static readonly string ForwardSlashEmptyFolder;
+        public static readonly string HashFileExtension;
+        public static readonly string NupkgExtension;
+        public static readonly string NupkgMetadataFileExtension;
+        public static readonly string NuspecExtension;
+        public static readonly string PackageDownloadMarkerFileExtension;
+    }
+
+    public partial class PackagingException : System.Exception, Common.ILogMessageException
+    {
+        public PackagingException(Common.NuGetLogCode logCode, string message, System.Exception innerException) { }
+
+        public PackagingException(Common.NuGetLogCode logCode, string message) { }
+
+        public PackagingException(string message, System.Exception innerException) { }
+
+        public PackagingException(string message) { }
+
+        public virtual Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class RepositoryMetadata : System.IEquatable<RepositoryMetadata>
+    {
+        public RepositoryMetadata() { }
+
+        public RepositoryMetadata(string type, string url, string branch, string commit) { }
+
+        public string Branch { get { throw null; } set { } }
+
+        public string Commit { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public string Url { get { throw null; } set { } }
+
+        public bool Equals(RepositoryMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(RepositoryMetadata a, RepositoryMetadata b) { throw null; }
+
+        public static bool operator !=(RepositoryMetadata a, RepositoryMetadata b) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Licenses
+{
+    public partial class ExceptionData
+    {
+        public ExceptionData(string licenseID, bool isDeprecatedLicenseId) { }
+
+        public bool IsDeprecatedLicenseId { get { throw null; } }
+
+        public string LicenseExceptionID { get { throw null; } }
+    }
+
+    public partial class LicenseData
+    {
+        public LicenseData(string licenseID, bool isOsiApproved, bool isDeprecatedLicenseId, bool isFsfLibre) { }
+
+        public bool IsDeprecatedLicenseId { get { throw null; } }
+
+        public bool IsFsfLibre { get { throw null; } }
+
+        public bool IsOsiApproved { get { throw null; } }
+
+        public string LicenseID { get { throw null; } }
+    }
+
+    public enum LicenseExpressionType
+    {
+        License = 0,
+        Operator = 1
+    }
+
+    public abstract partial class LicenseOperator : NuGetLicenseExpression
+    {
+        protected LicenseOperator(LicenseOperatorType operatorType) { }
+
+        public LicenseOperatorType OperatorType { get { throw null; } }
+    }
+
+    public enum LicenseOperatorType
+    {
+        WithOperator = 0,
+        LogicalOperator = 1
+    }
+
+    public partial class LogicalOperator : LicenseOperator
+    {
+        public LogicalOperator(LogicalOperatorType logicalOperatorType, NuGetLicenseExpression left, NuGetLicenseExpression right) : base(default) { }
+
+        public NuGetLicenseExpression Left { get { throw null; } }
+
+        public LogicalOperatorType LogicalOperatorType { get { throw null; } }
+
+        public NuGetLicenseExpression Right { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum LogicalOperatorType
+    {
+        And = 0,
+        Or = 1
+    }
+
+    public partial class NuGetLicense : NuGetLicenseExpression
+    {
+        public string Identifier { get { throw null; } }
+
+        public bool IsStandardLicense { get { throw null; } }
+
+        public bool Plus { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class NuGetLicenseData
+    {
+        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, ExceptionData> ExceptionList;
+        public static readonly System.Collections.Generic.IReadOnlyDictionary<string, LicenseData> LicenseList;
+        public static string LicenseListVersion { get { throw null; } }
+    }
+
+    public partial class NuGetLicenseException
+    {
+        public string Identifier { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class NuGetLicenseExpression
+    {
+        protected NuGetLicenseExpression() { }
+
+        public LicenseExpressionType Type { get { throw null; } protected set { } }
+
+        public static NuGetLicenseExpression Parse(string expression) { throw null; }
+    }
+
+    public static partial class NuGetLicenseExpressionExtensions
+    {
+        public static bool HasOnlyStandardIdentifiers(this NuGetLicenseExpression expression) { throw null; }
+
+        public static bool IsUnlicensed(this NuGetLicense license) { throw null; }
+
+        public static bool IsUnlicensed(this NuGetLicenseExpression expression) { throw null; }
+
+        public static void OnEachLeafNode(this NuGetLicenseExpression expression, System.Action<NuGetLicense> licenseProcessor, System.Action<NuGetLicenseException> exceptionProcessor) { }
+    }
+
+    public partial class NuGetLicenseExpressionParsingException : System.Exception
+    {
+        public NuGetLicenseExpressionParsingException(string message, System.Exception innerException) { }
+
+        public NuGetLicenseExpressionParsingException(string message) { }
+    }
+
+    public partial class WithOperator : LicenseOperator
+    {
+        public WithOperator(NuGetLicense license, NuGetLicenseException exception) : base(default) { }
+
+        public NuGetLicenseException Exception { get { throw null; } }
+
+        public NuGetLicense License { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.PackageExtraction
+{
+    public static partial class PackageExtractionBehavior
+    {
+        public static XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+}
+
+namespace NuGet.Packaging.Rules
+{
+    [System.CodeDom.Compiler.GeneratedCode("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    public partial class AnalysisResources
+    {
+        public static string AssemblyDirectlyUnderLibWarning { get { throw null; } }
+
+        public static string AssemblyOutsideLibWarning { get { throw null; } }
+
+        public static string BuildConventionIsViolatedWarning { get { throw null; } }
+
+        public static System.Globalization.CultureInfo Culture { get { throw null; } set { } }
+
+        public static string DefaultSpecValueWarning { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMBeginningToFiles { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMBeginningToNuspec { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMEndingToFile { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMEndingToNuspec { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMHasCompatMatch { get { throw null; } }
+
+        public static string DependenciesGroupsForEachTFMHasNoExactMatch { get { throw null; } }
+
+        public static string FilePathTooLongWarning { get { throw null; } }
+
+        public static string IconUrlDeprecationWarning { get { throw null; } }
+
+        public static string InvalidFrameworkWarning { get { throw null; } }
+
+        public static string InvalidPlaceholderFileWarning { get { throw null; } }
+
+        public static string InvalidPrereleaseDependencyWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInDependencyGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInFilesWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInFrameworkAssemblyGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkInReferenceGroupsWarning { get { throw null; } }
+
+        public static string InvalidUndottedFrameworkWarning { get { throw null; } }
+
+        public static string LegacyVersionWarning { get { throw null; } }
+
+        public static string LicenseUrlDeprecationWarning { get { throw null; } }
+
+        public static string Migrator_AssemblyDirectlyUnderLibWarning { get { throw null; } }
+
+        public static string Migrator_PackageHasContentFolder { get { throw null; } }
+
+        public static string Migrator_PackageHasInstallScript { get { throw null; } }
+
+        public static string Migrator_XdtTransformInPackage { get { throw null; } }
+
+        public static string MisplacedInitScriptWarning { get { throw null; } }
+
+        public static string MisplacedTransformFileWarning { get { throw null; } }
+
+        public static string NoRefOrLibFolderInPackage { get { throw null; } }
+
+        public static string PlaceholderFileInPackageWarning { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarning { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecListItemFormat { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToNuspecNoTfmListItemFormat { get { throw null; } }
+
+        public static string ReferencesInNuspecAndRefFilesDontMatchWarningAddToRefListItemFormat { get { throw null; } }
+
+        public static System.Resources.ResourceManager ResourceManager { get { throw null; } }
+
+        public static string ScriptOutsideToolsWarning { get { throw null; } }
+
+        public static string UnrecognizedLicenseIdentifier { get { throw null; } }
+
+        public static string UnrecognizedScriptWarning { get { throw null; } }
+
+        public static string UnspecifiedDependencyVersionWarning { get { throw null; } }
+
+        public static string WinRTObsoleteWarning { get { throw null; } }
+    }
+
+    public partial class DefaultManifestValuesRule : IPackageRule
+    {
+        public DefaultManifestValuesRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial class IconUrlDeprecationWarning : IPackageRule
+    {
+        public IconUrlDeprecationWarning(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial interface IPackageRule
+    {
+        string MessageFormat { get; }
+
+        System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder);
+    }
+
+    public partial class LicenseUrlDeprecationWarning : IPackageRule
+    {
+        public LicenseUrlDeprecationWarning(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public partial class PathTooLongRule : IPackageRule
+    {
+        public PathTooLongRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+
+    public static partial class RuleSet
+    {
+        public static System.Collections.Generic.IEnumerable<IPackageRule> PackageCreationRuleSet { get { throw null; } }
+
+        public static System.Collections.Generic.IEnumerable<IPackageRule> PackagesConfigToPackageReferenceMigrationRuleSet { get { throw null; } }
+    }
+
+    public partial class UnspecifiedDependencyVersionRule : IPackageRule
+    {
+        public UnspecifiedDependencyVersionRule(string messageFormat) { }
+
+        public string MessageFormat { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.PackagingLogMessage> Validate(PackageArchiveReader builder) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Signing
+{
+    public sealed partial class Accuracy
+    {
+        public int? Microseconds { get { throw null; } }
+
+        public int? Milliseconds { get { throw null; } }
+
+        public int? Seconds { get { throw null; } }
+
+        public long? GetTotalMicroseconds() { throw null; }
+
+        public static Accuracy Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class AlgorithmIdentifier
+    {
+        public System.Security.Cryptography.Oid Algorithm { get { throw null; } }
+
+        public static AlgorithmIdentifier Read(byte[] bytes) { throw null; }
+    }
+
+    public partial class AllowListVerificationProvider : ISignatureVerificationProvider
+    {
+        public AllowListVerificationProvider(System.Collections.Generic.IReadOnlyCollection<VerificationAllowListEntry> allowList, bool requireNonEmptyAllowList = false, string emptyListErrorMessage = "", string noMatchErrorMessage = "") { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class AttributeUtility
+    {
+    }
+
+    public sealed partial class AuthorPrimarySignature : PrimarySignature
+    {
+        public AuthorPrimarySignature() { }
+    }
+
+    public sealed partial class AuthorSignPackageRequest : SignPackageRequest
+    {
+        public AuthorSignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm) : base(default!, default, default) { }
+
+        public AuthorSignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) : base(default!, default, default) { }
+
+        public override SignatureType SignatureType { get { throw null; } }
+    }
+
+    public sealed partial class CentralDirectoryHeaderMetadata
+    {
+        public CentralDirectoryHeaderMetadata() { }
+
+        public long ChangeInOffset { get { throw null; } set { } }
+
+        public long FileEntryTotalSize { get { throw null; } set { } }
+
+        public long HeaderSize { get { throw null; } set { } }
+
+        public int IndexInHeaders { get { throw null; } set { } }
+
+        public bool IsPackageSignatureFile { get { throw null; } set { } }
+
+        public long OffsetToLocalFileHeader { get { throw null; } set { } }
+
+        public long Position { get { throw null; } set { } }
+    }
+
+    public static partial class CertificateChainUtility
+    {
+        public static IX509CertificateChain GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Certificate2Collection extraStore, Common.ILogger logger, CertificateType certificateType) { throw null; }
+
+        public static IX509CertificateChain GetCertificateChain(System.Security.Cryptography.X509Certificates.X509Chain x509Chain) { throw null; }
+    }
+
+    public partial class CertificateHashAllowListEntry : VerificationAllowListEntry
+    {
+        public CertificateHashAllowListEntry(VerificationTarget target, SignaturePlacement placement, string fingerprint, Common.HashAlgorithmName algorithm) : base(default, default) { }
+
+        public string Fingerprint { get { throw null; } }
+
+        public Common.HashAlgorithmName FingerprintAlgorithm { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum CertificateType
+    {
+        Signature = 0,
+        Timestamp = 1
+    }
+
+    public static partial class CertificateUtility
+    {
+        public static byte[] GetHash(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static string GetHashString(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithm) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<byte[]> GetRawDataForCollection(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { throw null; }
+
+        public static bool HasExtendedKeyUsage(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string ekuOid) { throw null; }
+
+        public static bool HasLifetimeSigningEku(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsCertificatePublicKeyValid(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsCertificateValidityPeriodInTheFuture(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsDateInsideValidityPeriod(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.DateTimeOffset date) { throw null; }
+
+        public static bool IsSelfIssued(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsSignatureAlgorithmSupported(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static bool IsValidForPurposeFast(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, string ekuOid) { throw null; }
+
+        public static string X509Certificate2CollectionToString(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certCollection, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+
+        public static string X509Certificate2ToString(System.Security.Cryptography.X509Certificates.X509Certificate2 cert, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+
+        public static string X509ChainToString(System.Security.Cryptography.X509Certificates.X509Chain chain, Common.HashAlgorithmName fingerprintAlgorithm) { throw null; }
+    }
+
+    public partial class ClientPolicyContext
+    {
+        public System.Collections.Generic.IReadOnlyCollection<TrustedSignerAllowListEntry> AllowList { get { throw null; } }
+
+        public Common.SignatureValidationMode Policy { get { throw null; } }
+
+        public SignedPackageVerifierSettings VerifierSettings { get { throw null; } }
+
+        public static ClientPolicyContext GetClientPolicy(Configuration.ISettings settings, Common.ILogger logger) { throw null; }
+    }
+
+    public sealed partial class CommitmentTypeIndication
+    {
+        public System.Security.Cryptography.Oid CommitmentTypeId { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<CommitmentTypeQualifier> Qualifiers { get { throw null; } }
+
+        public static CommitmentTypeIndication Create(System.Security.Cryptography.Oid commitmentTypeId) { throw null; }
+
+        public static CommitmentTypeIndication Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class CommitmentTypeQualifier
+    {
+        public System.Security.Cryptography.Oid CommitmentTypeIdentifier { get { throw null; } }
+
+        public byte[] Qualifier { get { throw null; } }
+
+        public static CommitmentTypeQualifier Read(byte[] bytes) { throw null; }
+    }
+
+    public static partial class Crc32
+    {
+        [System.CLSCompliant(false)]
+        public static uint CalculateCrc(byte[] data) { throw null; }
+    }
+
+    public sealed partial class EssCertId
+    {
+        public byte[] CertificateHash { get { throw null; } }
+
+        public IssuerSerial IssuerSerial { get { throw null; } }
+
+        public static EssCertId Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class EssCertIdV2
+    {
+        public byte[] CertificateHash { get { throw null; } }
+
+        public AlgorithmIdentifier HashAlgorithm { get { throw null; } }
+
+        public IssuerSerial IssuerSerial { get { throw null; } }
+
+        public static EssCertIdV2 Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public static EssCertIdV2 Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class Extension
+    {
+        public bool Critical { get { throw null; } }
+
+        public System.Security.Cryptography.Oid Id { get { throw null; } }
+
+        public byte[] Value { get { throw null; } }
+    }
+
+    public sealed partial class Extensions
+    {
+        public System.Collections.Generic.IReadOnlyList<Extension> ExtensionsList { get { throw null; } }
+
+        public static Extensions Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class GeneralName
+    {
+        public System.Security.Cryptography.X509Certificates.X500DistinguishedName DirectoryName { get { throw null; } }
+
+        public static GeneralName Create(System.Security.Cryptography.X509Certificates.X500DistinguishedName distinguishedName) { throw null; }
+
+        public static GeneralName Read(byte[] bytes) { throw null; }
+    }
+
+    public partial class IntegrityVerificationProvider : ISignatureVerificationProvider
+    {
+        public IntegrityVerificationProvider() { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class InvalidSignaturePackageVerificationResult : PackageVerificationResult
+    {
+        public InvalidSignaturePackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+    }
+
+    public partial interface IPackageSignatureVerifier
+    {
+        System.Threading.Tasks.Task<VerifySignaturesResult> VerifySignaturesAsync(ISignedPackageReader package, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token, System.Guid telemetryOperationId);
+    }
+
+    public partial interface IRepositorySignature : ISignature
+    {
+    }
+
+    public partial interface ISignature
+    {
+    }
+
+    public partial interface ISignatureProvider
+    {
+        System.Threading.Tasks.Task<PrimarySignature> CreatePrimarySignatureAsync(SignPackageRequest request, SignatureContent signatureContent, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<PrimarySignature> CreateRepositoryCountersignatureAsync(RepositorySignPackageRequest request, PrimarySignature primarySignature, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignatureVerificationProvider
+    {
+        System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignedPackage : ISignedPackageReader, System.IDisposable, ISignedPackageWriter
+    {
+    }
+
+    public partial interface ISignedPackageReader : System.IDisposable
+    {
+        bool CanVerifySignedPackages(SignedPackageVerifierSettings verifierSettings);
+        System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token);
+        string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null);
+        System.Threading.Tasks.Task<PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task ValidateIntegrityAsync(SignatureContent signatureContent, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ISignedPackageWriter
+    {
+    }
+
+    public sealed partial class IssuerSerial
+    {
+        public System.Collections.Generic.IReadOnlyList<GeneralName> GeneralNames { get { throw null; } }
+
+        public byte[] SerialNumber { get { throw null; } }
+
+        public static IssuerSerial Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public static IssuerSerial Read(byte[] bytes) { throw null; }
+    }
+
+    public partial interface ITimestampProvider
+    {
+        System.Threading.Tasks.Task<PrimarySignature> TimestampSignatureAsync(PrimarySignature primarySignature, TimestampRequest request, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial interface ITrustedSignersProvider
+    {
+        void AddOrUpdateTrustedSigner(Configuration.TrustedSignerItem trustedSigner);
+        System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> GetTrustedSigners();
+        void Remove(System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> trustedSigners);
+    }
+
+    public partial interface IX509CertificateChain : System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.IDisposable
+    {
+    }
+
+    public partial class KeyPairFileReader : System.IDisposable
+    {
+        public KeyPairFileReader(System.IO.Stream stream, System.Text.Encoding encoding) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public System.Collections.Generic.Dictionary<string, string> ReadSection() { throw null; }
+    }
+
+    public static partial class KeyPairFileUtility
+    {
+        public static string GetValueOrThrow(System.Collections.Generic.Dictionary<string, string> values, string key) { throw null; }
+    }
+
+    public partial class KeyPairFileWriter : System.IDisposable
+    {
+        public KeyPairFileWriter(System.IO.Stream stream, System.Text.Encoding encoding, bool leaveOpen) { }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public void WritePair(string key, string value) { }
+
+        public void WriteSectionBreak() { }
+    }
+
+    public sealed partial class MessageImprint
+    {
+        public AlgorithmIdentifier HashAlgorithm { get { throw null; } }
+
+        public byte[] HashedMessage { get { throw null; } }
+
+        public static MessageImprint Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class NuGetPackageOwners
+    {
+        public NuGetPackageOwners(System.Collections.Generic.IReadOnlyList<string> packageOwners) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public static NuGetPackageOwners Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class NuGetV3ServiceIndexUrl
+    {
+        public NuGetV3ServiceIndexUrl(System.Uri v3ServiceIndexUrl) { }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public static NuGetV3ServiceIndexUrl Read(byte[] bytes) { throw null; }
+    }
+
+    public static partial class Oids
+    {
+        public const string AnyPolicy = "2.5.29.32.0";
+        public const string AuthorityKeyIdentifier = "2.5.29.35";
+        public const string BaselineTimestampPolicy = "0.4.0.2023.1.1";
+        public const string CodeSigningEku = "1.3.6.1.5.5.7.3.3";
+        public const string CommitmentTypeIdentifierProofOfOrigin = "1.2.840.113549.1.9.16.6.1";
+        public const string CommitmentTypeIdentifierProofOfReceipt = "1.2.840.113549.1.9.16.6.2";
+        public const string CommitmentTypeIndication = "1.2.840.113549.1.9.16.2.16";
+        public const string Countersignature = "1.2.840.113549.1.9.6";
+        public const string EnhancedKeyUsage = "2.5.29.37";
+        public const string IdQtCps = "1.3.6.1.5.5.7.2.1";
+        public const string IdQtUnotice = "1.3.6.1.5.5.7.2.2";
+        public const string LifetimeSigningEku = "1.3.6.1.4.1.311.10.3.13";
+        public const string NuGetPackageOwners = "1.3.6.1.4.1.311.84.2.1.1.2";
+        public const string NuGetV3ServiceIndexUrl = "1.3.6.1.4.1.311.84.2.1.1.1";
+        public const string Pkcs7Data = "1.2.840.113549.1.7.1";
+        public const string Sha1 = "1.3.14.3.2.26";
+        public const string Sha256 = "2.16.840.1.101.3.4.2.1";
+        public const string Sha256WithRSAEncryption = "1.2.840.113549.1.1.11";
+        public const string Sha384 = "2.16.840.1.101.3.4.2.2";
+        public const string Sha384WithRSAEncryption = "1.2.840.113549.1.1.12";
+        public const string Sha512 = "2.16.840.1.101.3.4.2.3";
+        public const string Sha512WithRSAEncryption = "1.2.840.113549.1.1.13";
+        public const string SignatureTimeStampTokenAttribute = "1.2.840.113549.1.9.16.2.14";
+        public const string SigningCertificate = "1.2.840.113549.1.9.16.2.12";
+        public const string SigningCertificateV2 = "1.2.840.113549.1.9.16.2.47";
+        public const string SigningTime = "1.2.840.113549.1.9.5";
+        public const string SubjectKeyIdentifier = "2.5.29.14";
+        public const string TimeStampingEku = "1.3.6.1.5.5.7.3.8";
+        public const string TSTInfoContentType = "1.2.840.113549.1.9.16.1.4";
+    }
+
+    public partial class PackageSignatureVerifier : IPackageSignatureVerifier
+    {
+        public PackageSignatureVerifier(System.Collections.Generic.IEnumerable<ISignatureVerificationProvider> verificationProviders) { }
+
+        public System.Threading.Tasks.Task<VerifySignaturesResult> VerifySignaturesAsync(ISignedPackageReader package, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token, System.Guid parentId = default) { throw null; }
+    }
+
+    public abstract partial class PackageVerificationResult
+    {
+        public PackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public virtual System.Collections.Generic.IEnumerable<SignatureLog> Issues { get { throw null; } }
+
+        public virtual SignatureVerificationStatus Trust { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> GetErrorIssues() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> GetWarningIssues() { throw null; }
+    }
+
+    public sealed partial class PolicyInformation
+    {
+        public System.Security.Cryptography.Oid PolicyIdentifier { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyQualifierInfo> PolicyQualifiers { get { throw null; } }
+
+        public static PolicyInformation Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class PolicyQualifierInfo
+    {
+        public System.Security.Cryptography.Oid PolicyQualifierId { get { throw null; } }
+
+        public byte[] Qualifier { get { throw null; } }
+
+        public static PolicyQualifierInfo Read(byte[] bytes) { throw null; }
+    }
+
+    public abstract partial class PrimarySignature : Signature
+    {
+        protected PrimarySignature() { }
+
+        public byte[] GetBytes() { throw null; }
+    }
+
+    public static partial class PrimarySignatureFactory
+    {
+    }
+
+    public sealed partial class ReadOnlyBufferedStream : System.IO.Stream
+    {
+        public ReadOnlyBufferedStream(System.IO.Stream stream, bool leaveOpen, int bufferSize) { }
+
+        public ReadOnlyBufferedStream(System.IO.Stream stream, bool leaveOpen) { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanSeek { get { throw null; } }
+
+        public override bool CanTimeout { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override long Length { get { throw null; } }
+
+        public override long Position { get { throw null; } set { } }
+
+        public override int ReadTimeout { get { throw null; } set { } }
+
+        public override int WriteTimeout { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void Flush() { }
+
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override int Read(byte[] buffer, int offset, int count) { throw null; }
+
+        public override int ReadByte() { throw null; }
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+
+        public override void SetLength(long value) { }
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override void WriteByte(byte value) { }
+    }
+
+    public sealed partial class RepositoryCountersignature : Signature, IRepositorySignature, ISignature
+    {
+        public RepositoryCountersignature() { }
+
+        public static RepositoryCountersignature GetRepositoryCountersignature(PrimarySignature primarySignature) { throw null; }
+    }
+
+    public sealed partial class RepositoryPrimarySignature : PrimarySignature, IRepositorySignature, ISignature
+    {
+        public RepositoryPrimarySignature() { }
+    }
+
+    public static partial class RepositorySignatureInfoUtility
+    {
+        public static System.Collections.Generic.IReadOnlyCollection<CertificateHashAllowListEntry> GetRepositoryAllowList(System.Collections.Generic.IEnumerable<Core.IRepositoryCertificateInfo> repositoryCertificateInfos) { throw null; }
+
+        public static SignedPackageVerifierSettings GetSignedPackageVerifierSettings(RepositorySignatureInfo repoSignatureInfo, SignedPackageVerifierSettings fallbackSettings) { throw null; }
+    }
+
+    public sealed partial class RepositorySignPackageRequest : SignPackageRequest
+    {
+        public RepositorySignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm, System.Uri v3ServiceIndexUrl, System.Collections.Generic.IReadOnlyList<string> packageOwners) : base(default!, default, default) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackageOwners { get { throw null; } }
+
+        public override SignatureType SignatureType { get { throw null; } }
+
+        public System.Uri V3ServiceIndexUrl { get { throw null; } }
+    }
+
+    public partial class Rfc3161TimestampProvider : ITimestampProvider
+    {
+        public Rfc3161TimestampProvider(System.Uri timeStampServerUrl) { }
+
+        public System.Threading.Tasks.Task<PrimarySignature> TimestampSignatureAsync(PrimarySignature primarySignature, TimestampRequest timestampRequest, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo : System.Security.Cryptography.AsnEncodedData
+    {
+        public Rfc3161TimestampTokenInfo() { }
+    }
+
+    public abstract partial class Signature : ISignature
+    {
+        protected Signature() { }
+    }
+
+    public sealed partial class SignatureContent
+    {
+        public SignatureContent(SigningSpecifications signingSpecifications, Common.HashAlgorithmName hashAlgorithm, string hashValue) { }
+
+        public Common.HashAlgorithmName HashAlgorithm { get { throw null; } }
+
+        public string HashValue { get { throw null; } }
+
+        public byte[] GetBytes() { throw null; }
+
+        public static SignatureContent Load(byte[] bytes, SigningSpecifications signingSpecifications) { throw null; }
+    }
+
+    public partial class SignatureException : Core.PackagingException
+    {
+        public SignatureException(Common.NuGetLogCode code, string message, Core.PackageIdentity package) : base(default!) { }
+
+        public SignatureException(Common.NuGetLogCode code, string message, System.Exception innerException) : base(default!) { }
+
+        public SignatureException(Common.NuGetLogCode code, string message) : base(default!) { }
+
+        public SignatureException(System.Collections.Generic.IReadOnlyList<PackageVerificationResult> results, Core.PackageIdentity package) : base(default!) { }
+
+        public SignatureException(string message) : base(default!) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PackageVerificationResult> Results { get { throw null; } }
+
+        public System.TimeSpan VerifyDuration { get { throw null; } set { } }
+    }
+
+    public partial class SignatureLog : Common.ILogMessage, System.IEquatable<SignatureLog>
+    {
+        public Common.NuGetLogCode Code { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } set { } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public System.DateTimeOffset Time { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public Common.RestoreLogMessage AsRestoreLogMessage() { throw null; }
+
+        public static SignatureLog DebugLog(string message) { throw null; }
+
+        public static SignatureLog DetailedLog(string message) { throw null; }
+
+        public bool Equals(SignatureLog other) { throw null; }
+
+        public static SignatureLog Error(Common.NuGetLogCode code, string message) { throw null; }
+
+        public static SignatureLog InformationLog(string message) { throw null; }
+
+        public static SignatureLog Issue(bool fatal, Common.NuGetLogCode code, string message) { throw null; }
+
+        public static SignatureLog MinimalLog(string message) { throw null; }
+    }
+
+    [System.Flags]
+    public enum SignaturePlacement
+    {
+        PrimarySignature = 1,
+        Countersignature = 2,
+        Any = 3
+    }
+
+    public sealed partial class SignatureTrustAndValidityVerificationProvider : ISignatureVerificationProvider
+    {
+        public SignatureTrustAndValidityVerificationProvider(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Common.HashAlgorithmName>> allowUntrustedRootList = null) { }
+
+        public System.Threading.Tasks.Task<PackageVerificationResult> GetTrustResultAsync(ISignedPackageReader package, PrimarySignature signature, SignedPackageVerifierSettings settings, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public enum SignatureType
+    {
+        Unknown = 0,
+        Author = 1,
+        Repository = 2
+    }
+
+    public enum SignatureVerificationBehavior
+    {
+        Never = 0,
+        IfExists = 1,
+        IfExistsAndIsNecessary = 2,
+        Always = 3
+    }
+
+    public enum SignatureVerificationStatus
+    {
+        Unknown = 0,
+        Suspect = 1,
+        Disallowed = 2,
+        Valid = 3
+    }
+
+    [System.Flags]
+    public enum SignatureVerificationStatusFlags
+    {
+        NoErrors = 0,
+        NoSignature = 1,
+        NoCertificate = 2,
+        MultipleSignatures = 4,
+        SignatureCheckFailed = 8,
+        SignatureAlgorithmUnsupported = 16,
+        CertificatePublicKeyInvalid = 32,
+        HasLifetimeSigningEku = 64,
+        CertificateValidityInTheFuture = 128,
+        CertificateExpired = 256,
+        HashAlgorithmUnsupported = 512,
+        MessageImprintUnsupportedAlgorithm = 1024,
+        Illegal = 1790,
+        IntegrityCheckFailed = 2048,
+        ChainBuildingFailure = 4096,
+        UnknownRevocation = 8192,
+        CertificateRevoked = 16384,
+        Suspect = 18432,
+        UntrustedRoot = 32768,
+        GeneralizedTimeOutsideValidity = 65536,
+        Untrusted = 110849,
+        NoValidTimestamp = 131072,
+        MultipleTimestamps = 262144
+    }
+
+    public sealed partial class SignatureVerificationSummary
+    {
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, Timestamp timestamp, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, Timestamp timestamp, System.DateTimeOffset? expirationTime, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public SignatureVerificationSummary(SignatureType signatureType, SignatureVerificationStatus status, SignatureVerificationStatusFlags flags, System.Collections.Generic.IEnumerable<SignatureLog> issues) { }
+
+        public System.DateTimeOffset? ExpirationTime { get { throw null; } }
+
+        public SignatureVerificationStatusFlags Flags { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<SignatureLog> Issues { get { throw null; } set { } }
+
+        public SignatureType SignatureType { get { throw null; } }
+
+        public SignatureVerificationStatus Status { get { throw null; } }
+
+        public Timestamp Timestamp { get { throw null; } }
+    }
+
+    public sealed partial class SignatureVerifySettings
+    {
+        public SignatureVerifySettings(bool allowIllegal, bool allowUntrusted, bool allowUnknownRevocation, bool reportUnknownRevocation, bool reportUntrustedRoot, Common.RevocationMode revocationMode) { }
+
+        public bool AllowIllegal { get { throw null; } }
+
+        public bool AllowUnknownRevocation { get { throw null; } }
+
+        public bool AllowUntrusted { get { throw null; } }
+
+        public static SignatureVerifySettings Default { get { throw null; } }
+
+        public bool ReportUnknownRevocation { get { throw null; } }
+
+        public bool ReportUntrustedRoot { get { throw null; } }
+
+        public Common.RevocationMode RevocationMode { get { throw null; } }
+    }
+
+    public partial class SignedPackageArchive : PackageArchiveReader, ISignedPackage, ISignedPackageReader, System.IDisposable, ISignedPackageWriter
+    {
+        public SignedPackageArchive(System.IO.Stream packageReadStream, System.IO.Stream packageWriteStream) : base(packageReadStream) { }
+
+        public System.Threading.Tasks.Task AddSignatureAsync(System.IO.Stream signatureStream, System.Threading.CancellationToken token) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public System.Threading.Tasks.Task<bool> IsZip64Async(System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task RemoveSignatureAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class SignedPackageArchiveIOUtility
+    {
+        public static void HashBytes(System.Security.Cryptography.HashAlgorithm hashAlgorithm, byte[] bytes) { }
+
+        public static void ReadAndHashUntilPosition(System.IO.BinaryReader reader, System.Security.Cryptography.HashAlgorithm hashAlgorithm, long position) { }
+
+        public static void ReadAndWriteUntilPosition(System.IO.BinaryReader reader, System.IO.BinaryWriter writer, long position) { }
+
+        public static SignedPackageArchiveMetadata ReadSignedArchiveMetadata(System.IO.BinaryReader reader, bool validateSignatureEntry = true) { throw null; }
+    }
+
+    public sealed partial class SignedPackageArchiveMetadata
+    {
+        public SignedPackageArchiveMetadata() { }
+
+        public System.Collections.Generic.List<CentralDirectoryHeaderMetadata> CentralDirectoryHeaders { get { throw null; } set { } }
+
+        public long EndOfCentralDirectory { get { throw null; } set { } }
+
+        public int SignatureCentralDirectoryHeaderIndex { get { throw null; } set { } }
+
+        public long StartOfLocalFileHeaders { get { throw null; } set { } }
+
+        public CentralDirectoryHeaderMetadata GetPackageSignatureFileCentralDirectoryHeaderMetadata() { throw null; }
+    }
+
+    public static partial class SignedPackageArchiveUtility
+    {
+        public static bool IsSigned(System.IO.BinaryReader reader) { throw null; }
+
+        public static bool IsZip64(System.IO.BinaryReader reader) { throw null; }
+
+        public static System.IO.Stream OpenPackageSignatureFileStream(System.IO.BinaryReader reader) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> RemoveRepositorySignaturesAsync(System.IO.Stream input, System.IO.Stream output, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class SignedPackageVerificationResult : PackageVerificationResult
+    {
+        public SignedPackageVerificationResult(SignatureVerificationStatus trust, PrimarySignature signature, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+
+        public PrimarySignature Signature { get { throw null; } }
+    }
+
+    public sealed partial class SignedPackageVerifierSettings
+    {
+        public SignedPackageVerifierSettings(bool allowUnsigned, bool allowIllegal, bool allowUntrusted, bool allowIgnoreTimestamp, bool allowMultipleTimestamps, bool allowNoTimestamp, bool allowUnknownRevocation, bool reportUnknownRevocation, VerificationTarget verificationTarget, SignaturePlacement signaturePlacement, SignatureVerificationBehavior repositoryCountersignatureVerificationBehavior, Common.RevocationMode revocationMode) { }
+
+        public bool AllowIgnoreTimestamp { get { throw null; } }
+
+        public bool AllowIllegal { get { throw null; } }
+
+        public bool AllowMultipleTimestamps { get { throw null; } }
+
+        public bool AllowNoTimestamp { get { throw null; } }
+
+        public bool AllowUnknownRevocation { get { throw null; } }
+
+        public bool AllowUnsigned { get { throw null; } }
+
+        public bool AllowUntrusted { get { throw null; } }
+
+        public bool ReportUnknownRevocation { get { throw null; } }
+
+        public SignatureVerificationBehavior RepositoryCountersignatureVerificationBehavior { get { throw null; } }
+
+        public Common.RevocationMode RevocationMode { get { throw null; } }
+
+        public SignaturePlacement SignaturePlacement { get { throw null; } }
+
+        public VerificationTarget VerificationTarget { get { throw null; } }
+
+        public static SignedPackageVerifierSettings GetAcceptModeDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetDefault(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetRequireModeDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+
+        public static SignedPackageVerifierSettings GetVerifyCommandDefaultPolicy(Common.IEnvironmentVariableReader environmentVariableReader = null) { throw null; }
+    }
+
+    public sealed partial class SigningCertificate
+    {
+        public System.Collections.Generic.IReadOnlyList<EssCertId> Certificates { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyInformation> Policies { get { throw null; } }
+
+        public static SigningCertificate Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class SigningCertificateV2
+    {
+        public System.Collections.Generic.IReadOnlyList<EssCertIdV2> Certificates { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PolicyInformation> Policies { get { throw null; } }
+
+        public static SigningCertificateV2 Create(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName hashAlgorithmName) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public static SigningCertificateV2 Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class SigningOptions : System.IDisposable
+    {
+        public SigningOptions(System.Lazy<System.IO.Stream> inputPackageStream, System.Lazy<System.IO.Stream> outputPackageStream, bool overwrite, ISignatureProvider signatureProvider, Common.ILogger logger) { }
+
+        public System.IO.Stream InputPackageStream { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public System.IO.Stream OutputPackageStream { get { throw null; } }
+
+        public bool Overwrite { get { throw null; } }
+
+        public ISignatureProvider SignatureProvider { get { throw null; } }
+
+        public static SigningOptions CreateFromFilePaths(string inputPackageFilePath, string outputPackageFilePath, bool overwrite, ISignatureProvider signatureProvider, Common.ILogger logger) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public abstract partial class SigningSpecifications
+    {
+        public static readonly SigningSpecificationsV1 V1;
+        protected SigningSpecifications() { }
+
+        public abstract string[] AllowedHashAlgorithmOids { get; }
+        public abstract Common.HashAlgorithmName[] AllowedHashAlgorithms { get; }
+        public abstract string[] AllowedSignatureAlgorithmOids { get; }
+        public abstract Common.SignatureAlgorithmName[] AllowedSignatureAlgorithms { get; }
+        public abstract System.Text.Encoding Encoding { get; }
+        public abstract int RSAPublicKeyMinLength { get; }
+        public abstract string SignaturePath { get; }
+        public abstract string Version { get; }
+    }
+
+    public sealed partial class SigningSpecificationsV1 : SigningSpecifications
+    {
+        public SigningSpecificationsV1() { }
+
+        public override string[] AllowedHashAlgorithmOids { get { throw null; } }
+
+        public override Common.HashAlgorithmName[] AllowedHashAlgorithms { get { throw null; } }
+
+        public override string[] AllowedSignatureAlgorithmOids { get { throw null; } }
+
+        public override Common.SignatureAlgorithmName[] AllowedSignatureAlgorithms { get { throw null; } }
+
+        public override System.Text.Encoding Encoding { get { throw null; } }
+
+        public override int RSAPublicKeyMinLength { get { throw null; } }
+
+        public override string SignaturePath { get { throw null; } }
+
+        public override string Version { get { throw null; } }
+    }
+
+    public static partial class SigningUtility
+    {
+        public static System.Threading.Tasks.Task SignAsync(SigningOptions options, SignPackageRequest signRequest, System.Threading.CancellationToken token) { throw null; }
+
+        public static void Verify(SignPackageRequest request, Common.ILogger logger) { }
+    }
+
+    public abstract partial class SignPackageRequest : System.IDisposable
+    {
+        protected SignPackageRequest(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, Common.HashAlgorithmName signatureHashAlgorithm, Common.HashAlgorithmName timestampHashAlgorithm) { }
+
+        public System.Security.Cryptography.X509Certificates.X509Certificate2Collection AdditionalCertificates { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public Common.HashAlgorithmName SignatureHashAlgorithm { get { throw null; } }
+
+        public abstract SignatureType SignatureType { get; }
+
+        public Common.HashAlgorithmName TimestampHashAlgorithm { get { throw null; } }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class Timestamp
+    {
+        public Timestamp() { }
+    }
+
+    public partial class TimestampException : SignatureException
+    {
+        public TimestampException() : base(default!) { }
+
+        public TimestampException(Common.NuGetLogCode code, string message, System.Exception innerException) : base(default!) { }
+
+        public TimestampException(Common.NuGetLogCode code, string message) : base(default!) { }
+
+        public TimestampException(string message) : base(default!) { }
+    }
+
+    public partial class TimestampRequest
+    {
+        public TimestampRequest(SigningSpecifications signingSpecifications, byte[] hashedMessage, Common.HashAlgorithmName hashAlgorithm, SignaturePlacement target) { }
+
+        public Common.HashAlgorithmName HashAlgorithm { get { throw null; } }
+
+        public byte[] HashedMessage { get { throw null; } }
+
+        public SigningSpecifications SigningSpecifications { get { throw null; } }
+
+        public SignaturePlacement Target { get { throw null; } }
+    }
+
+    public sealed partial class TrustedSignerAllowListEntry : CertificateHashAllowListEntry
+    {
+        public TrustedSignerAllowListEntry(VerificationTarget target, SignaturePlacement placement, string fingerprint, Common.HashAlgorithmName algorithm, bool allowUntrustedRoot = false, System.Collections.Generic.IReadOnlyList<string> owners = null) : base(default, default, default!, default) { }
+
+        public bool AllowUntrustedRoot { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Owners { get { throw null; } }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public sealed partial class TrustedSignersProvider : ITrustedSignersProvider
+    {
+        public TrustedSignersProvider(Configuration.ISettings settings) { }
+
+        public void AddOrUpdateTrustedSigner(Configuration.TrustedSignerItem trustedSigner) { }
+
+        public static System.Collections.Generic.IReadOnlyList<TrustedSignerAllowListEntry> GetAllowListEntries(Configuration.ISettings settings, Common.ILogger logger) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> GetTrustedSigners() { throw null; }
+
+        public void Remove(System.Collections.Generic.IReadOnlyList<Configuration.TrustedSignerItem> trustedSigners) { }
+    }
+
+    public sealed partial class TstInfo
+    {
+        public Accuracy Accuracy { get { throw null; } }
+
+        public System.Security.Cryptography.X509Certificates.X509ExtensionCollection Extensions { get { throw null; } }
+
+        public System.DateTimeOffset GenTime { get { throw null; } }
+
+        public MessageImprint MessageImprint { get { throw null; } }
+
+        public byte[] Nonce { get { throw null; } }
+
+        public bool Ordering { get { throw null; } }
+
+        public System.Security.Cryptography.Oid Policy { get { throw null; } }
+
+        public byte[] SerialNumber { get { throw null; } }
+
+        public byte[] Tsa { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static TstInfo Read(byte[] bytes) { throw null; }
+    }
+
+    public sealed partial class UnknownPrimarySignature : PrimarySignature
+    {
+        public UnknownPrimarySignature() { }
+    }
+
+    public partial class UnsignedPackageVerificationResult : PackageVerificationResult
+    {
+        public UnsignedPackageVerificationResult(SignatureVerificationStatus trust, System.Collections.Generic.IEnumerable<SignatureLog> issues) : base(default, default!) { }
+    }
+
+    public abstract partial class VerificationAllowListEntry
+    {
+        public VerificationAllowListEntry(VerificationTarget target, SignaturePlacement placement) { }
+
+        public SignaturePlacement Placement { get { throw null; } }
+
+        public VerificationTarget Target { get { throw null; } }
+    }
+
+    [System.Flags]
+    public enum VerificationTarget
+    {
+        None = 0,
+        Unknown = 2,
+        Author = 4,
+        Repository = 8,
+        All = 14
+    }
+
+    public static partial class VerificationUtility
+    {
+        public static SignatureVerificationStatus GetSignatureVerificationStatus(SignatureVerificationStatusFlags flags) { throw null; }
+
+        public static bool IsVerificationTarget(SignatureType signatureType, VerificationTarget target) { throw null; }
+    }
+
+    public sealed partial class VerifySignaturesResult
+    {
+        public VerifySignaturesResult(bool isValid, bool isSigned, System.Collections.Generic.IEnumerable<PackageVerificationResult> results) { }
+
+        public VerifySignaturesResult(bool isValid, bool isSigned) { }
+
+        public bool IsSigned { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<PackageVerificationResult> Results { get { throw null; } }
+    }
+
+    public sealed partial class X509CertificateChain : System.Collections.Generic.List<System.Security.Cryptography.X509Certificates.X509Certificate2>, IX509CertificateChain, System.Collections.Generic.IReadOnlyList<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable, System.Collections.Generic.IReadOnlyCollection<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.IDisposable
+    {
+        public X509CertificateChain() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class X509ChainHolder : System.IDisposable
+    {
+        public X509ChainHolder() { }
+
+        public System.Security.Cryptography.X509Certificates.X509Chain Chain { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public partial class X509SignatureProvider : ISignatureProvider
+    {
+        public X509SignatureProvider(ITimestampProvider timestampProvider) { }
+
+        public System.Threading.Tasks.Task<PrimarySignature> CreatePrimarySignatureAsync(SignPackageRequest request, SignatureContent signatureContent, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<PrimarySignature> CreateRepositoryCountersignatureAsync(RepositorySignPackageRequest request, PrimarySignature primarySignature, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+}
+
+namespace NuGet.Packaging.Signing.DerEncoding
+{
+    public sealed partial class DerGeneralizedTime
+    {
+        public System.DateTime DateTime { get { throw null; } }
+
+        public static DerGeneralizedTime Read(string decodedTime) { throw null; }
+    }
+}
+
+namespace NuGet.RuntimeModel
+{
+    public partial class CompatibilityProfile : System.IEquatable<CompatibilityProfile>
+    {
+        public CompatibilityProfile(string name, System.Collections.Generic.IEnumerable<Frameworks.FrameworkRuntimePair> restoreContexts) { }
+
+        public CompatibilityProfile(string name) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.FrameworkRuntimePair> RestoreContexts { get { throw null; } }
+
+        public CompatibilityProfile Clone() { throw null; }
+
+        public bool Equals(CompatibilityProfile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial interface IObjectWriter
+    {
+        void WriteArrayEnd();
+        void WriteArrayStart(string name);
+        void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values);
+        void WriteNameValue(string name, bool value);
+        void WriteNameValue(string name, int value);
+        void WriteNameValue(string name, string value);
+        void WriteObjectEnd();
+        void WriteObjectStart();
+        void WriteObjectStart(string name);
+    }
+
+    public sealed partial class JsonObjectWriter : IObjectWriter, System.IDisposable
+    {
+        public JsonObjectWriter(Newtonsoft.Json.JsonWriter writer) { }
+
+        public void Dispose() { }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public static partial class JsonRuntimeFormat
+    {
+        public static RuntimeGraph ReadRuntimeGraph(Newtonsoft.Json.Linq.JToken json) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(System.IO.Stream stream) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(System.IO.TextReader textReader) { throw null; }
+
+        public static RuntimeGraph ReadRuntimeGraph(string filePath) { throw null; }
+
+        public static void WriteRuntimeGraph(IObjectWriter writer, RuntimeGraph runtimeGraph) { }
+
+        public static void WriteRuntimeGraph(string filePath, RuntimeGraph runtimeGraph) { }
+    }
+
+    public partial class RuntimeDependencySet : System.IEquatable<RuntimeDependencySet>
+    {
+        public RuntimeDependencySet(string id, System.Collections.Generic.IEnumerable<RuntimePackageDependency> dependencies) { }
+
+        public RuntimeDependencySet(string id) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimePackageDependency> Dependencies { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public RuntimeDependencySet Clone() { throw null; }
+
+        public bool Equals(RuntimeDependencySet other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RuntimeDescription : System.IEquatable<RuntimeDescription>
+    {
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<RuntimeDependencySet> runtimeDependencySets) { }
+
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<string> inheritedRuntimes, System.Collections.Generic.IEnumerable<RuntimeDependencySet> runtimeDependencySets) { }
+
+        public RuntimeDescription(string runtimeIdentifier, System.Collections.Generic.IEnumerable<string> inheritedRuntimes) { }
+
+        public RuntimeDescription(string runtimeIdentifier) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InheritedRuntimes { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimeDependencySet> RuntimeDependencySets { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public RuntimeDescription Clone() { throw null; }
+
+        public bool Equals(RuntimeDescription other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static RuntimeDescription Merge(RuntimeDescription left, RuntimeDescription right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RuntimeGraph : System.IEquatable<RuntimeGraph>
+    {
+        public static readonly RuntimeGraph Empty;
+        public static readonly string RuntimeGraphFileName;
+        public RuntimeGraph() { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<CompatibilityProfile> supports) { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<RuntimeDescription> runtimes, System.Collections.Generic.IEnumerable<CompatibilityProfile> supports) { }
+
+        public RuntimeGraph(System.Collections.Generic.IEnumerable<RuntimeDescription> runtimes) { }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, RuntimeDescription> Runtimes { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, CompatibilityProfile> Supports { get { throw null; } set { } }
+
+        public bool AreCompatible(string criteria, string provided) { throw null; }
+
+        public RuntimeGraph Clone() { throw null; }
+
+        public bool Equals(RuntimeGraph other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<string> ExpandRuntime(string runtime) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<RuntimePackageDependency> FindRuntimeDependencies(string runtimeName, string packageId) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static RuntimeGraph Merge(RuntimeGraph left, RuntimeGraph right) { throw null; }
+    }
+
+    public partial class RuntimePackageDependency : System.IEquatable<RuntimePackageDependency>
+    {
+        public RuntimePackageDependency(string id, Versioning.VersionRange versionRange) { }
+
+        public string Id { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public RuntimePackageDependency Clone() { throw null; }
+
+        public bool Equals(RuntimePackageDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.packaging/6.2.2/nuget.packaging.nuspec
+++ b/src/referencePackages/src/nuget.packaging/6.2.2/nuget.packaging.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Packaging</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's understanding of packages. Reading nuspec, nupkgs and package signing.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.Configuration" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Versioning" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="5.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Configuration" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Versioning" version="6.2.2" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="5.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.projectmodel/6.2.2/NuGet.ProjectModel.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/6.2.2/NuGet.ProjectModel.6.2.2.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.ProjectModel</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.DependencyResolver.Core" Version="6.2.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.DependencyResolver.Core" Version="6.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.projectmodel/6.2.2/lib/net5.0/NuGet.ProjectModel.cs
+++ b/src/referencePackages/src/nuget.projectmodel/6.2.2/lib/net5.0/NuGet.ProjectModel.cs
@@ -1,0 +1,1224 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.ProjectModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.ProjectModel
+{
+    public partial class AssetsLogMessage : IAssetsLogMessage, System.IEquatable<IAssetsLogMessage>
+    {
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString, string targetGraph) { }
+
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static IAssetsLogMessage Create(Common.IRestoreLogMessage logMessage) { throw null; }
+
+        public bool Equals(IAssetsLogMessage other) { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial struct BuildAction : System.IEquatable<BuildAction>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly BuildAction AndroidAsset;
+        public static readonly BuildAction AndroidResource;
+        public static readonly BuildAction ApplicationDefinition;
+        public static readonly BuildAction BundleResource;
+        public static readonly BuildAction CodeAnalysisDictionary;
+        public static readonly BuildAction Compile;
+        public static readonly BuildAction Content;
+        public static readonly BuildAction DesignData;
+        public static readonly BuildAction DesignDataWithDesignTimeCreatableTypes;
+        public static readonly BuildAction EmbeddedResource;
+        public static readonly BuildAction None;
+        public static readonly BuildAction Page;
+        public static readonly BuildAction Resource;
+        public static readonly BuildAction SplashScreen;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(BuildAction other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildAction left, BuildAction right) { throw null; }
+
+        public static bool operator !=(BuildAction left, BuildAction right) { throw null; }
+
+        public static BuildAction Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildOptions : System.IEquatable<BuildOptions>
+    {
+        public BuildOptions() { }
+
+        public string OutputName { get { throw null; } set { } }
+
+        public BuildOptions Clone() { throw null; }
+
+        public bool Equals(BuildOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class CacheFile : System.IEquatable<CacheFile>
+    {
+        public CacheFile(string dgSpecHash) { }
+
+        public string DgSpecHash { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> ExpectedPackageFilePaths { get { throw null; } set { } }
+
+        public bool HasAnyMissingPackageFiles { get { throw null; } set { } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public string ProjectFilePath { get { throw null; } set { } }
+
+        public bool Success { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(CacheFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class CacheFileFormat
+    {
+        public static CacheFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static void Write(System.IO.Stream stream, CacheFile cacheFile) { }
+
+        public static void Write(string filePath, CacheFile lockFile) { }
+    }
+
+    public partial class CentralTransitiveDependencyGroup : System.IEquatable<CentralTransitiveDependencyGroup>
+    {
+        public CentralTransitiveDependencyGroup(Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> transitiveDependencies) { }
+
+        public string FrameworkName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> TransitiveDependencies { get { throw null; } }
+
+        public bool Equals(CentralTransitiveDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class DependencyGraphSpec
+    {
+        public DependencyGraphSpec() { }
+
+        public DependencyGraphSpec(bool isReadOnly) { }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> Projects { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Restore { get { throw null; } }
+
+        public void AddProject(PackageSpec projectSpec) { }
+
+        public void AddRestore(string projectUniqueName) { }
+
+        public DependencyGraphSpec CreateFromClosure(string projectUniqueName, System.Collections.Generic.IReadOnlyList<PackageSpec> closure) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> GetClosure(string rootUniqueName) { throw null; }
+
+        public static string GetDGSpecFileName(string projectName) { throw null; }
+
+        public string GetHash() { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetParents(string rootUniqueName) { throw null; }
+
+        public PackageSpec GetProjectSpec(string projectUniqueName) { throw null; }
+
+        public static DependencyGraphSpec Load(string path) { throw null; }
+
+        public void Save(string path) { }
+
+        public static System.Collections.Generic.IReadOnlyList<PackageSpec> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<PackageSpec> packages) { throw null; }
+
+        public static DependencyGraphSpec Union(System.Collections.Generic.IEnumerable<DependencyGraphSpec> dgSpecs) { throw null; }
+
+        public DependencyGraphSpec WithoutRestores() { throw null; }
+
+        public DependencyGraphSpec WithoutTools() { throw null; }
+
+        public DependencyGraphSpec WithPackageSpecs(System.Collections.Generic.IEnumerable<PackageSpec> packageSpecs) { throw null; }
+
+        public DependencyGraphSpec WithProjectClosure(string projectUniqueName) { throw null; }
+
+        public DependencyGraphSpec WithReplacedSpec(PackageSpec project) { throw null; }
+    }
+
+    public partial class ExternalProjectReference : System.IEquatable<ExternalProjectReference>, System.IComparable<ExternalProjectReference>
+    {
+        public ExternalProjectReference(string uniqueName, PackageSpec packageSpec, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public ExternalProjectReference(string uniqueName, string packageSpecProjectName, string packageSpecPath, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExternalProjectReferences { get { throw null; } }
+
+        public string MSBuildProjectPath { get { throw null; } }
+
+        public PackageSpec PackageSpec { get { throw null; } }
+
+        public string PackageSpecProjectName { get { throw null; } }
+
+        public string ProjectJsonPath { get { throw null; } }
+
+        public string ProjectName { get { throw null; } }
+
+        public string UniqueName { get { throw null; } }
+
+        public int CompareTo(ExternalProjectReference other) { throw null; }
+
+        public bool Equals(ExternalProjectReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FileFormatException : System.Exception
+    {
+        public FileFormatException(string message, System.Exception innerException) { }
+
+        public FileFormatException(string message) { }
+
+        public int Column { get { throw null; } }
+
+        public int Line { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public static FileFormatException Create(System.Exception exception, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+
+        public static FileFormatException Create(string message, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+    }
+
+    public sealed partial class HashObjectWriter : RuntimeModel.IObjectWriter, System.IDisposable
+    {
+        public HashObjectWriter(Packaging.IHashFunction hashFunc) { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public partial interface IAssetsLogMessage
+    {
+        Common.NuGetLogCode Code { get; }
+
+        int EndColumnNumber { get; }
+
+        int EndLineNumber { get; }
+
+        string FilePath { get; }
+
+        Common.LogLevel Level { get; }
+
+        string LibraryId { get; }
+
+        string Message { get; }
+
+        string ProjectPath { get; }
+
+        int StartColumnNumber { get; }
+
+        int StartLineNumber { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get; }
+
+        Common.WarningLevel WarningLevel { get; }
+    }
+
+    public partial interface IExternalProjectReferenceProvider
+    {
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetEntryPoints();
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetReferences(string entryPointPath);
+    }
+
+    public partial class IncludeExcludeFiles : System.IEquatable<IncludeExcludeFiles>
+    {
+        public IncludeExcludeFiles() { }
+
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> IncludeFiles { get { throw null; } set { } }
+
+        public IncludeExcludeFiles Clone() { throw null; }
+
+        public bool Equals(IncludeExcludeFiles other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool HandleIncludeExcludeFiles(Newtonsoft.Json.Linq.JObject jsonObject) { throw null; }
+    }
+
+    public static partial class JsonPackageSpecReader
+    {
+        public static readonly string Files;
+        public static readonly string HideWarningsAndErrors;
+        public static readonly string PackageType;
+        public static readonly string PackOptions;
+        public static readonly string RestoreOptions;
+        public static readonly string RestoreSettings;
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject rawPackageSpec, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject json) { throw null; }
+
+        public static PackageSpec GetPackageSpec(System.IO.Stream stream, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath) { throw null; }
+    }
+
+    public static partial class JTokenExtensions
+    {
+        public static T GetValue<T>(this Newtonsoft.Json.Linq.JToken token, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken) { throw null; }
+    }
+
+    public partial class LockFile : System.IEquatable<LockFile>
+    {
+        public static readonly char DirectorySeparatorChar;
+        public static readonly Frameworks.NuGetFramework ToolFramework;
+        public LockFile() { }
+
+        public System.Collections.Generic.IList<CentralTransitiveDependencyGroup> CentralTransitiveDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileLibrary> Libraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> PackageFolders { get { throw null; } set { } }
+
+        public PackageSpec PackageSpec { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(LockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public LockFileLibrary GetLibrary(string name, Versioning.NuGetVersion version) { throw null; }
+
+        public LockFileTarget GetTarget(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public LockFileTarget GetTarget(string frameworkAlias, string runtimeIdentifier) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec, int requestLockFileVersion) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec) { throw null; }
+    }
+
+    public partial class LockFileContentFile : LockFileItem
+    {
+        public static readonly string BuildActionProperty;
+        public static readonly string CodeLanguageProperty;
+        public static readonly string CopyToOutputProperty;
+        public static readonly string OutputPathProperty;
+        public static readonly string PPOutputPathProperty;
+        public LockFileContentFile(string path) : base(default!) { }
+
+        public BuildAction BuildAction { get { throw null; } set { } }
+
+        public string CodeLanguage { get { throw null; } set { } }
+
+        public bool CopyToOutput { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PPOutputPath { get { throw null; } set { } }
+    }
+
+    public partial class LockFileDependency : System.IEquatable<LockFileDependency>
+    {
+        public LockFileDependency() { }
+
+        public string ContentHash { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public Versioning.VersionRange RequestedVersion { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion ResolvedVersion { get { throw null; } set { } }
+
+        public PackageDependencyType Type { get { throw null; } set { } }
+
+        public bool Equals(LockFileDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileDependencyIdVersionComparer : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public LockFileDependencyIdVersionComparer() { }
+
+        public static LockFileDependencyIdVersionComparer Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+
+    [System.Obsolete("This is an unused class and will be removed in a future version.")]
+    public partial class LockFileDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public LockFileDependencyProvider(LockFile lockFile) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class LockFileExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<LockFileTarget> GetTargetGraphs(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LockFileTargetLibrary> GetTargetLibraries(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static LockFileTargetLibrary GetTargetLibrary(this LockFileTarget target, string libraryId) { throw null; }
+    }
+
+    public partial class LockFileFormat
+    {
+        public static readonly string AssetsFileName;
+        public static readonly string LockFileName;
+        public static readonly int Version;
+        public LockFileFormat() { }
+
+        public LockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, string path) { throw null; }
+
+        public LockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public LockFile Read(string filePath) { throw null; }
+
+        public string Render(LockFile lockFile) { throw null; }
+
+        public void Write(System.IO.Stream stream, LockFile lockFile) { }
+
+        public void Write(System.IO.TextWriter textWriter, LockFile lockFile) { }
+
+        public void Write(string filePath, LockFile lockFile) { }
+    }
+
+    public partial class LockFileItem : System.IEquatable<LockFileItem>
+    {
+        public static readonly string AliasesProperty;
+        public LockFileItem(string path) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } }
+
+        public bool Equals(LockFileItem other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        protected string GetProperty(string name) { throw null; }
+
+        public static implicit operator LockFileItem(string path) { throw null; }
+
+        protected void SetProperty(string name, string value) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LockFileLibrary : System.IEquatable<LockFileLibrary>
+    {
+        public LockFileLibrary() { }
+
+        public System.Collections.Generic.IList<string> Files { get { throw null; } set { } }
+
+        public bool HasTools { get { throw null; } set { } }
+
+        public bool IsServiceable { get { throw null; } set { } }
+
+        public string MSBuildProject { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string Sha512 { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public LockFileLibrary Clone() { throw null; }
+
+        public bool Equals(LockFileLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileRuntimeTarget : LockFileItem
+    {
+        public static readonly string AssetTypeProperty;
+        public static readonly string RidProperty;
+        public LockFileRuntimeTarget(string path, string runtime, string assetType) : base(default!) { }
+
+        public LockFileRuntimeTarget(string path) : base(default!) { }
+
+        public string AssetType { get { throw null; } set { } }
+
+        public string Runtime { get { throw null; } set { } }
+    }
+
+    public partial class LockFileTarget : System.IEquatable<LockFileTarget>
+    {
+        public LockFileTarget() { }
+
+        public System.Collections.Generic.IList<LockFileTargetLibrary> Libraries { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(LockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileTargetLibrary : System.IEquatable<LockFileTargetLibrary>
+    {
+        public LockFileTargetLibrary() { }
+
+        public System.Collections.Generic.IList<LockFileItem> Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> BuildMultiTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> CompileTimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileContentFile> ContentFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> EmbedAssemblies { get { throw null; } set { } }
+
+        public string Framework { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkReferences { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> NativeLibraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ResourceAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> RuntimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileRuntimeTarget> RuntimeTargets { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ToolsAssemblies { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public bool Equals(LockFileTargetLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class LockFileUtilities
+    {
+        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class LockFileValidationResult
+    {
+        public LockFileValidationResult(bool isValid, System.Collections.Generic.IReadOnlyList<string> invalidReasons) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InvalidReasons { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+    }
+
+    public enum PackageDependencyType
+    {
+        Direct = 0,
+        Transitive = 1,
+        Project = 2,
+        CentralTransitive = 3
+    }
+
+    public partial class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        public PackagesConfigProjectRestoreMetadata() { }
+
+        public string PackagesConfigPath { get { throw null; } set { } }
+
+        public string RepositoryPath { get { throw null; } set { } }
+
+        public override ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackagesLockFile : System.IEquatable<PackagesLockFile>
+    {
+        public PackagesLockFile() { }
+
+        public PackagesLockFile(int version) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<PackagesLockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileFormat
+    {
+        public static readonly string LockFileName;
+        public static readonly int PackagesLockFileVersion;
+        public static readonly int Version;
+        public static PackagesLockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static PackagesLockFile Read(string filePath) { throw null; }
+
+        public static string Render(PackagesLockFile lockFile) { throw null; }
+
+        public static void Write(System.IO.Stream stream, PackagesLockFile lockFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, PackagesLockFile lockFile) { }
+
+        public static void Write(string filePath, PackagesLockFile lockFile) { }
+    }
+
+    public partial class PackagesLockFileTarget : System.IEquatable<PackagesLockFileTarget>
+    {
+        public PackagesLockFileTarget() { }
+
+        public System.Collections.Generic.IList<LockFileDependency> Dependencies { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileUtilities
+    {
+        public static string GetNuGetLockFilePath(PackageSpec project) { throw null; }
+
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName) { throw null; }
+
+        [System.Obsolete("This method is obsolete. Call IsLockFileValid instead.")]
+        public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static LockFileValidityWithMatchedResults IsLockFileStillValid(PackagesLockFile expected, PackagesLockFile actual) { throw null; }
+
+        public static LockFileValidationResult IsLockFileValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static bool IsNuGetLockFileEnabled(PackageSpec project) { throw null; }
+
+        public partial class LockFileValidityWithMatchedResults
+        {
+            public static readonly LockFileValidityWithMatchedResults Invalid;
+            public LockFileValidityWithMatchedResults(bool isValid, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> matchedDependencies) { }
+
+            public bool IsValid { get { throw null; } }
+
+            public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> MatchedDependencies { get { throw null; } }
+        }
+    }
+
+    public partial class PackageSpec
+    {
+        public static readonly Versioning.NuGetVersion DefaultVersion;
+        public static readonly string PackageSpecFileName;
+        public PackageSpec() { }
+
+        public PackageSpec(System.Collections.Generic.IList<TargetFrameworkInformation> frameworks) { }
+
+        [System.Obsolete]
+        public string[] Authors { get { throw null; } set { } }
+
+        public string BaseDirectory { get { throw null; } }
+
+        [System.Obsolete]
+        public BuildOptions BuildOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IList<string> ContentFiles { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Description { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool HasVersionSnapshot { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string IconUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool IsDefaultVersion { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Language { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string LicenseUrl { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Owners { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, string> PackInclude { get { throw null; } }
+
+        [System.Obsolete]
+        public PackOptions PackOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ProjectUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public ProjectRestoreMetadata RestoreMetadata { get { throw null; } set { } }
+
+        public ProjectRestoreSettings RestoreSettings { get { throw null; } set { } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<string>> Scripts { get { throw null; } }
+
+        [System.Obsolete]
+        public string Summary { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Tags { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<TargetFrameworkInformation> TargetFrameworks { get { throw null; } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public PackageSpec Clone() { throw null; }
+
+        public bool Equals(PackageSpec other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackageSpecExtensions
+    {
+        public static ProjectRestoreMetadataFrameworkInfo GetRestoreMetadataFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+    }
+
+    public static partial class PackageSpecOperations
+    {
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity) { }
+
+        public static bool HasPackage(PackageSpec spec, string packageId) { throw null; }
+
+        public static void RemoveDependency(PackageSpec spec, string packageId) { }
+    }
+
+    public partial class PackageSpecReferenceDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public PackageSpecReferenceDependencyProvider(System.Collections.Generic.IEnumerable<ExternalProjectReference> externalProjects, Common.ILogger logger) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class PackageSpecUtility
+    {
+        public static bool IsSnapshotVersion(string version) { throw null; }
+
+        public static Versioning.NuGetVersion SpecifySnapshot(string version, string snapshotValue) { throw null; }
+    }
+
+    public sealed partial class PackageSpecWriter
+    {
+        public PackageSpecWriter() { }
+
+        public static void Write(PackageSpec packageSpec, RuntimeModel.IObjectWriter writer) { }
+
+        public static void WriteToFile(PackageSpec packageSpec, string filePath) { }
+    }
+
+    public partial class PackOptions : System.IEquatable<PackOptions>
+    {
+        public PackOptions() { }
+
+        public IncludeExcludeFiles IncludeExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, IncludeExcludeFiles> Mappings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public PackOptions Clone() { throw null; }
+
+        public bool Equals(PackOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectFileDependencyGroup : System.IEquatable<ProjectFileDependencyGroup>
+    {
+        public ProjectFileDependencyGroup(string frameworkName, System.Collections.Generic.IEnumerable<string> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<string> Dependencies { get { throw null; } }
+
+        public string FrameworkName { get { throw null; } }
+
+        public bool Equals(ProjectFileDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadata : System.IEquatable<ProjectRestoreMetadata>
+    {
+        public ProjectRestoreMetadata() { }
+
+        public string CacheFilePath { get { throw null; } set { } }
+
+        public bool CentralPackageTransitivePinningEnabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionOverrideDisabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionsEnabled { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> ConfigFilePaths { get { throw null; } set { } }
+
+        public bool CrossTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FallbackFolders { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFile> Files { get { throw null; } set { } }
+
+        public bool LegacyPackagesDirectory { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> OriginalTargetFrameworks { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PackagesPath { get { throw null; } set { } }
+
+        public string ProjectJsonPath { get { throw null; } set { } }
+
+        public string ProjectName { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public WarningProperties ProjectWideWarningProperties { get { throw null; } set { } }
+
+        public RestoreLockProperties RestoreLockProperties { get { throw null; } set { } }
+
+        public bool SkipContentFileWrite { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> Sources { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFrameworkInfo> TargetFrameworks { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public virtual ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        protected void FillClone(ProjectRestoreMetadata clone) { }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFile : System.IEquatable<ProjectRestoreMetadataFile>, System.IComparable<ProjectRestoreMetadataFile>
+    {
+        public ProjectRestoreMetadataFile(string packagePath, string absolutePath) { }
+
+        public string AbsolutePath { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public ProjectRestoreMetadataFile Clone() { throw null; }
+
+        public int CompareTo(ProjectRestoreMetadataFile other) { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFrameworkInfo : System.IEquatable<ProjectRestoreMetadataFrameworkInfo>
+    {
+        public ProjectRestoreMetadataFrameworkInfo() { }
+
+        public ProjectRestoreMetadataFrameworkInfo(Frameworks.NuGetFramework frameworkName) { }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreReference> ProjectReferences { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public ProjectRestoreMetadataFrameworkInfo Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFrameworkInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreReference : System.IEquatable<ProjectRestoreReference>
+    {
+        public ProjectRestoreReference() { }
+
+        public LibraryModel.LibraryIncludeFlags ExcludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags IncludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags PrivateAssets { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public ProjectRestoreReference Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreSettings
+    {
+        public ProjectRestoreSettings() { }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public ProjectRestoreSettings Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreSettings other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum ProjectStyle : ushort
+    {
+        Unknown = 0,
+        ProjectJson = 1,
+        PackageReference = 2,
+        DotnetCliTool = 3,
+        Standalone = 4,
+        PackagesConfig = 5,
+        DotnetToolReference = 6
+    }
+
+    public partial class RestoreLockProperties : System.IEquatable<RestoreLockProperties>
+    {
+        public RestoreLockProperties() { }
+
+        public RestoreLockProperties(string restorePackagesWithLockFile, string nuGetLockFilePath, bool restoreLockedMode) { }
+
+        public string NuGetLockFilePath { get { throw null; } }
+
+        public bool RestoreLockedMode { get { throw null; } }
+
+        public string RestorePackagesWithLockFile { get { throw null; } }
+
+        public RestoreLockProperties Clone() { throw null; }
+
+        public bool Equals(RestoreLockProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class TargetFrameworkInformation : System.IEquatable<TargetFrameworkInformation>
+    {
+        public TargetFrameworkInformation() { }
+
+        public bool AssetTargetFallback { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, LibraryModel.CentralPackageVersion> CentralPackageVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.DownloadDependency> DownloadDependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<LibraryModel.FrameworkDependency> FrameworkReferences { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> Imports { get { throw null; } set { } }
+
+        public string RuntimeIdentifierGraphPath { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public bool Warn { get { throw null; } set { } }
+
+        public TargetFrameworkInformation Clone() { throw null; }
+
+        public bool Equals(TargetFrameworkInformation other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ToolPathResolver
+    {
+        public ToolPathResolver(string packagesDirectory, bool isLowercase) { }
+
+        public ToolPathResolver(string packagesDirectory) { }
+
+        public string GetBestToolDirectoryPath(string packageId, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string toolDirectory) { throw null; }
+
+        public string GetToolDirectoryPath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class WarningProperties : System.IEquatable<WarningProperties>
+    {
+        public WarningProperties() { }
+
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors) { }
+
+        public bool AllWarningsAsErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> NoWarn { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsAsErrors { get { throw null; } }
+
+        public WarningProperties Clone() { throw null; }
+
+        public bool Equals(WarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn) { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn) { throw null; }
+    }
+}
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public partial class LockFileDependencyComparerWithoutContentHash : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public LockFileDependencyComparerWithoutContentHash() { }
+
+        public static LockFileDependencyComparerWithoutContentHash Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.projectmodel/6.2.2/lib/netstandard2.0/NuGet.ProjectModel.cs
+++ b/src/referencePackages/src/nuget.projectmodel/6.2.2/lib/netstandard2.0/NuGet.ProjectModel.cs
@@ -1,0 +1,1224 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.ProjectModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.ProjectModel
+{
+    public partial class AssetsLogMessage : IAssetsLogMessage, System.IEquatable<IAssetsLogMessage>
+    {
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString, string targetGraph) { }
+
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static IAssetsLogMessage Create(Common.IRestoreLogMessage logMessage) { throw null; }
+
+        public bool Equals(IAssetsLogMessage other) { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial struct BuildAction : System.IEquatable<BuildAction>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly BuildAction AndroidAsset;
+        public static readonly BuildAction AndroidResource;
+        public static readonly BuildAction ApplicationDefinition;
+        public static readonly BuildAction BundleResource;
+        public static readonly BuildAction CodeAnalysisDictionary;
+        public static readonly BuildAction Compile;
+        public static readonly BuildAction Content;
+        public static readonly BuildAction DesignData;
+        public static readonly BuildAction DesignDataWithDesignTimeCreatableTypes;
+        public static readonly BuildAction EmbeddedResource;
+        public static readonly BuildAction None;
+        public static readonly BuildAction Page;
+        public static readonly BuildAction Resource;
+        public static readonly BuildAction SplashScreen;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(BuildAction other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildAction left, BuildAction right) { throw null; }
+
+        public static bool operator !=(BuildAction left, BuildAction right) { throw null; }
+
+        public static BuildAction Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildOptions : System.IEquatable<BuildOptions>
+    {
+        public BuildOptions() { }
+
+        public string OutputName { get { throw null; } set { } }
+
+        public BuildOptions Clone() { throw null; }
+
+        public bool Equals(BuildOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class CacheFile : System.IEquatable<CacheFile>
+    {
+        public CacheFile(string dgSpecHash) { }
+
+        public string DgSpecHash { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> ExpectedPackageFilePaths { get { throw null; } set { } }
+
+        public bool HasAnyMissingPackageFiles { get { throw null; } set { } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public string ProjectFilePath { get { throw null; } set { } }
+
+        public bool Success { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(CacheFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class CacheFileFormat
+    {
+        public static CacheFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static void Write(System.IO.Stream stream, CacheFile cacheFile) { }
+
+        public static void Write(string filePath, CacheFile lockFile) { }
+    }
+
+    public partial class CentralTransitiveDependencyGroup : System.IEquatable<CentralTransitiveDependencyGroup>
+    {
+        public CentralTransitiveDependencyGroup(Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> transitiveDependencies) { }
+
+        public string FrameworkName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> TransitiveDependencies { get { throw null; } }
+
+        public bool Equals(CentralTransitiveDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class DependencyGraphSpec
+    {
+        public DependencyGraphSpec() { }
+
+        public DependencyGraphSpec(bool isReadOnly) { }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> Projects { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Restore { get { throw null; } }
+
+        public void AddProject(PackageSpec projectSpec) { }
+
+        public void AddRestore(string projectUniqueName) { }
+
+        public DependencyGraphSpec CreateFromClosure(string projectUniqueName, System.Collections.Generic.IReadOnlyList<PackageSpec> closure) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> GetClosure(string rootUniqueName) { throw null; }
+
+        public static string GetDGSpecFileName(string projectName) { throw null; }
+
+        public string GetHash() { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetParents(string rootUniqueName) { throw null; }
+
+        public PackageSpec GetProjectSpec(string projectUniqueName) { throw null; }
+
+        public static DependencyGraphSpec Load(string path) { throw null; }
+
+        public void Save(string path) { }
+
+        public static System.Collections.Generic.IReadOnlyList<PackageSpec> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<PackageSpec> packages) { throw null; }
+
+        public static DependencyGraphSpec Union(System.Collections.Generic.IEnumerable<DependencyGraphSpec> dgSpecs) { throw null; }
+
+        public DependencyGraphSpec WithoutRestores() { throw null; }
+
+        public DependencyGraphSpec WithoutTools() { throw null; }
+
+        public DependencyGraphSpec WithPackageSpecs(System.Collections.Generic.IEnumerable<PackageSpec> packageSpecs) { throw null; }
+
+        public DependencyGraphSpec WithProjectClosure(string projectUniqueName) { throw null; }
+
+        public DependencyGraphSpec WithReplacedSpec(PackageSpec project) { throw null; }
+    }
+
+    public partial class ExternalProjectReference : System.IEquatable<ExternalProjectReference>, System.IComparable<ExternalProjectReference>
+    {
+        public ExternalProjectReference(string uniqueName, PackageSpec packageSpec, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public ExternalProjectReference(string uniqueName, string packageSpecProjectName, string packageSpecPath, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExternalProjectReferences { get { throw null; } }
+
+        public string MSBuildProjectPath { get { throw null; } }
+
+        public PackageSpec PackageSpec { get { throw null; } }
+
+        public string PackageSpecProjectName { get { throw null; } }
+
+        public string ProjectJsonPath { get { throw null; } }
+
+        public string ProjectName { get { throw null; } }
+
+        public string UniqueName { get { throw null; } }
+
+        public int CompareTo(ExternalProjectReference other) { throw null; }
+
+        public bool Equals(ExternalProjectReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FileFormatException : System.Exception
+    {
+        public FileFormatException(string message, System.Exception innerException) { }
+
+        public FileFormatException(string message) { }
+
+        public int Column { get { throw null; } }
+
+        public int Line { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public static FileFormatException Create(System.Exception exception, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+
+        public static FileFormatException Create(string message, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+    }
+
+    public sealed partial class HashObjectWriter : RuntimeModel.IObjectWriter, System.IDisposable
+    {
+        public HashObjectWriter(Packaging.IHashFunction hashFunc) { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public partial interface IAssetsLogMessage
+    {
+        Common.NuGetLogCode Code { get; }
+
+        int EndColumnNumber { get; }
+
+        int EndLineNumber { get; }
+
+        string FilePath { get; }
+
+        Common.LogLevel Level { get; }
+
+        string LibraryId { get; }
+
+        string Message { get; }
+
+        string ProjectPath { get; }
+
+        int StartColumnNumber { get; }
+
+        int StartLineNumber { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get; }
+
+        Common.WarningLevel WarningLevel { get; }
+    }
+
+    public partial interface IExternalProjectReferenceProvider
+    {
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetEntryPoints();
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetReferences(string entryPointPath);
+    }
+
+    public partial class IncludeExcludeFiles : System.IEquatable<IncludeExcludeFiles>
+    {
+        public IncludeExcludeFiles() { }
+
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> IncludeFiles { get { throw null; } set { } }
+
+        public IncludeExcludeFiles Clone() { throw null; }
+
+        public bool Equals(IncludeExcludeFiles other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool HandleIncludeExcludeFiles(Newtonsoft.Json.Linq.JObject jsonObject) { throw null; }
+    }
+
+    public static partial class JsonPackageSpecReader
+    {
+        public static readonly string Files;
+        public static readonly string HideWarningsAndErrors;
+        public static readonly string PackageType;
+        public static readonly string PackOptions;
+        public static readonly string RestoreOptions;
+        public static readonly string RestoreSettings;
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject rawPackageSpec, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject json) { throw null; }
+
+        public static PackageSpec GetPackageSpec(System.IO.Stream stream, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath) { throw null; }
+    }
+
+    public static partial class JTokenExtensions
+    {
+        public static T GetValue<T>(this Newtonsoft.Json.Linq.JToken token, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken) { throw null; }
+    }
+
+    public partial class LockFile : System.IEquatable<LockFile>
+    {
+        public static readonly char DirectorySeparatorChar;
+        public static readonly Frameworks.NuGetFramework ToolFramework;
+        public LockFile() { }
+
+        public System.Collections.Generic.IList<CentralTransitiveDependencyGroup> CentralTransitiveDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileLibrary> Libraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> PackageFolders { get { throw null; } set { } }
+
+        public PackageSpec PackageSpec { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(LockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public LockFileLibrary GetLibrary(string name, Versioning.NuGetVersion version) { throw null; }
+
+        public LockFileTarget GetTarget(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public LockFileTarget GetTarget(string frameworkAlias, string runtimeIdentifier) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec, int requestLockFileVersion) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec) { throw null; }
+    }
+
+    public partial class LockFileContentFile : LockFileItem
+    {
+        public static readonly string BuildActionProperty;
+        public static readonly string CodeLanguageProperty;
+        public static readonly string CopyToOutputProperty;
+        public static readonly string OutputPathProperty;
+        public static readonly string PPOutputPathProperty;
+        public LockFileContentFile(string path) : base(default!) { }
+
+        public BuildAction BuildAction { get { throw null; } set { } }
+
+        public string CodeLanguage { get { throw null; } set { } }
+
+        public bool CopyToOutput { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PPOutputPath { get { throw null; } set { } }
+    }
+
+    public partial class LockFileDependency : System.IEquatable<LockFileDependency>
+    {
+        public LockFileDependency() { }
+
+        public string ContentHash { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public Versioning.VersionRange RequestedVersion { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion ResolvedVersion { get { throw null; } set { } }
+
+        public PackageDependencyType Type { get { throw null; } set { } }
+
+        public bool Equals(LockFileDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileDependencyIdVersionComparer : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public LockFileDependencyIdVersionComparer() { }
+
+        public static LockFileDependencyIdVersionComparer Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+
+    [System.Obsolete("This is an unused class and will be removed in a future version.")]
+    public partial class LockFileDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public LockFileDependencyProvider(LockFile lockFile) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class LockFileExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<LockFileTarget> GetTargetGraphs(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LockFileTargetLibrary> GetTargetLibraries(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static LockFileTargetLibrary GetTargetLibrary(this LockFileTarget target, string libraryId) { throw null; }
+    }
+
+    public partial class LockFileFormat
+    {
+        public static readonly string AssetsFileName;
+        public static readonly string LockFileName;
+        public static readonly int Version;
+        public LockFileFormat() { }
+
+        public LockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, string path) { throw null; }
+
+        public LockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public LockFile Read(string filePath) { throw null; }
+
+        public string Render(LockFile lockFile) { throw null; }
+
+        public void Write(System.IO.Stream stream, LockFile lockFile) { }
+
+        public void Write(System.IO.TextWriter textWriter, LockFile lockFile) { }
+
+        public void Write(string filePath, LockFile lockFile) { }
+    }
+
+    public partial class LockFileItem : System.IEquatable<LockFileItem>
+    {
+        public static readonly string AliasesProperty;
+        public LockFileItem(string path) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } }
+
+        public bool Equals(LockFileItem other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        protected string GetProperty(string name) { throw null; }
+
+        public static implicit operator LockFileItem(string path) { throw null; }
+
+        protected void SetProperty(string name, string value) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LockFileLibrary : System.IEquatable<LockFileLibrary>
+    {
+        public LockFileLibrary() { }
+
+        public System.Collections.Generic.IList<string> Files { get { throw null; } set { } }
+
+        public bool HasTools { get { throw null; } set { } }
+
+        public bool IsServiceable { get { throw null; } set { } }
+
+        public string MSBuildProject { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string Sha512 { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public LockFileLibrary Clone() { throw null; }
+
+        public bool Equals(LockFileLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileRuntimeTarget : LockFileItem
+    {
+        public static readonly string AssetTypeProperty;
+        public static readonly string RidProperty;
+        public LockFileRuntimeTarget(string path, string runtime, string assetType) : base(default!) { }
+
+        public LockFileRuntimeTarget(string path) : base(default!) { }
+
+        public string AssetType { get { throw null; } set { } }
+
+        public string Runtime { get { throw null; } set { } }
+    }
+
+    public partial class LockFileTarget : System.IEquatable<LockFileTarget>
+    {
+        public LockFileTarget() { }
+
+        public System.Collections.Generic.IList<LockFileTargetLibrary> Libraries { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(LockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileTargetLibrary : System.IEquatable<LockFileTargetLibrary>
+    {
+        public LockFileTargetLibrary() { }
+
+        public System.Collections.Generic.IList<LockFileItem> Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> BuildMultiTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> CompileTimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileContentFile> ContentFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> EmbedAssemblies { get { throw null; } set { } }
+
+        public string Framework { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkReferences { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> NativeLibraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ResourceAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> RuntimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileRuntimeTarget> RuntimeTargets { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ToolsAssemblies { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public bool Equals(LockFileTargetLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class LockFileUtilities
+    {
+        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class LockFileValidationResult
+    {
+        public LockFileValidationResult(bool isValid, System.Collections.Generic.IReadOnlyList<string> invalidReasons) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InvalidReasons { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+    }
+
+    public enum PackageDependencyType
+    {
+        Direct = 0,
+        Transitive = 1,
+        Project = 2,
+        CentralTransitive = 3
+    }
+
+    public partial class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        public PackagesConfigProjectRestoreMetadata() { }
+
+        public string PackagesConfigPath { get { throw null; } set { } }
+
+        public string RepositoryPath { get { throw null; } set { } }
+
+        public override ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackagesLockFile : System.IEquatable<PackagesLockFile>
+    {
+        public PackagesLockFile() { }
+
+        public PackagesLockFile(int version) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<PackagesLockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileFormat
+    {
+        public static readonly string LockFileName;
+        public static readonly int PackagesLockFileVersion;
+        public static readonly int Version;
+        public static PackagesLockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static PackagesLockFile Read(string filePath) { throw null; }
+
+        public static string Render(PackagesLockFile lockFile) { throw null; }
+
+        public static void Write(System.IO.Stream stream, PackagesLockFile lockFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, PackagesLockFile lockFile) { }
+
+        public static void Write(string filePath, PackagesLockFile lockFile) { }
+    }
+
+    public partial class PackagesLockFileTarget : System.IEquatable<PackagesLockFileTarget>
+    {
+        public PackagesLockFileTarget() { }
+
+        public System.Collections.Generic.IList<LockFileDependency> Dependencies { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileUtilities
+    {
+        public static string GetNuGetLockFilePath(PackageSpec project) { throw null; }
+
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName) { throw null; }
+
+        [System.Obsolete("This method is obsolete. Call IsLockFileValid instead.")]
+        public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static LockFileValidityWithMatchedResults IsLockFileStillValid(PackagesLockFile expected, PackagesLockFile actual) { throw null; }
+
+        public static LockFileValidationResult IsLockFileValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static bool IsNuGetLockFileEnabled(PackageSpec project) { throw null; }
+
+        public partial class LockFileValidityWithMatchedResults
+        {
+            public static readonly LockFileValidityWithMatchedResults Invalid;
+            public LockFileValidityWithMatchedResults(bool isValid, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> matchedDependencies) { }
+
+            public bool IsValid { get { throw null; } }
+
+            public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> MatchedDependencies { get { throw null; } }
+        }
+    }
+
+    public partial class PackageSpec
+    {
+        public static readonly Versioning.NuGetVersion DefaultVersion;
+        public static readonly string PackageSpecFileName;
+        public PackageSpec() { }
+
+        public PackageSpec(System.Collections.Generic.IList<TargetFrameworkInformation> frameworks) { }
+
+        [System.Obsolete]
+        public string[] Authors { get { throw null; } set { } }
+
+        public string BaseDirectory { get { throw null; } }
+
+        [System.Obsolete]
+        public BuildOptions BuildOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IList<string> ContentFiles { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Description { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool HasVersionSnapshot { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string IconUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool IsDefaultVersion { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Language { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string LicenseUrl { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Owners { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, string> PackInclude { get { throw null; } }
+
+        [System.Obsolete]
+        public PackOptions PackOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ProjectUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public ProjectRestoreMetadata RestoreMetadata { get { throw null; } set { } }
+
+        public ProjectRestoreSettings RestoreSettings { get { throw null; } set { } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<string>> Scripts { get { throw null; } }
+
+        [System.Obsolete]
+        public string Summary { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Tags { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<TargetFrameworkInformation> TargetFrameworks { get { throw null; } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public PackageSpec Clone() { throw null; }
+
+        public bool Equals(PackageSpec other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackageSpecExtensions
+    {
+        public static ProjectRestoreMetadataFrameworkInfo GetRestoreMetadataFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+    }
+
+    public static partial class PackageSpecOperations
+    {
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity) { }
+
+        public static bool HasPackage(PackageSpec spec, string packageId) { throw null; }
+
+        public static void RemoveDependency(PackageSpec spec, string packageId) { }
+    }
+
+    public partial class PackageSpecReferenceDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public PackageSpecReferenceDependencyProvider(System.Collections.Generic.IEnumerable<ExternalProjectReference> externalProjects, Common.ILogger logger) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class PackageSpecUtility
+    {
+        public static bool IsSnapshotVersion(string version) { throw null; }
+
+        public static Versioning.NuGetVersion SpecifySnapshot(string version, string snapshotValue) { throw null; }
+    }
+
+    public sealed partial class PackageSpecWriter
+    {
+        public PackageSpecWriter() { }
+
+        public static void Write(PackageSpec packageSpec, RuntimeModel.IObjectWriter writer) { }
+
+        public static void WriteToFile(PackageSpec packageSpec, string filePath) { }
+    }
+
+    public partial class PackOptions : System.IEquatable<PackOptions>
+    {
+        public PackOptions() { }
+
+        public IncludeExcludeFiles IncludeExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, IncludeExcludeFiles> Mappings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public PackOptions Clone() { throw null; }
+
+        public bool Equals(PackOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectFileDependencyGroup : System.IEquatable<ProjectFileDependencyGroup>
+    {
+        public ProjectFileDependencyGroup(string frameworkName, System.Collections.Generic.IEnumerable<string> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<string> Dependencies { get { throw null; } }
+
+        public string FrameworkName { get { throw null; } }
+
+        public bool Equals(ProjectFileDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadata : System.IEquatable<ProjectRestoreMetadata>
+    {
+        public ProjectRestoreMetadata() { }
+
+        public string CacheFilePath { get { throw null; } set { } }
+
+        public bool CentralPackageTransitivePinningEnabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionOverrideDisabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionsEnabled { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> ConfigFilePaths { get { throw null; } set { } }
+
+        public bool CrossTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FallbackFolders { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFile> Files { get { throw null; } set { } }
+
+        public bool LegacyPackagesDirectory { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> OriginalTargetFrameworks { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PackagesPath { get { throw null; } set { } }
+
+        public string ProjectJsonPath { get { throw null; } set { } }
+
+        public string ProjectName { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public WarningProperties ProjectWideWarningProperties { get { throw null; } set { } }
+
+        public RestoreLockProperties RestoreLockProperties { get { throw null; } set { } }
+
+        public bool SkipContentFileWrite { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> Sources { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFrameworkInfo> TargetFrameworks { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public virtual ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        protected void FillClone(ProjectRestoreMetadata clone) { }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFile : System.IEquatable<ProjectRestoreMetadataFile>, System.IComparable<ProjectRestoreMetadataFile>
+    {
+        public ProjectRestoreMetadataFile(string packagePath, string absolutePath) { }
+
+        public string AbsolutePath { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public ProjectRestoreMetadataFile Clone() { throw null; }
+
+        public int CompareTo(ProjectRestoreMetadataFile other) { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFrameworkInfo : System.IEquatable<ProjectRestoreMetadataFrameworkInfo>
+    {
+        public ProjectRestoreMetadataFrameworkInfo() { }
+
+        public ProjectRestoreMetadataFrameworkInfo(Frameworks.NuGetFramework frameworkName) { }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreReference> ProjectReferences { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public ProjectRestoreMetadataFrameworkInfo Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFrameworkInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreReference : System.IEquatable<ProjectRestoreReference>
+    {
+        public ProjectRestoreReference() { }
+
+        public LibraryModel.LibraryIncludeFlags ExcludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags IncludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags PrivateAssets { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public ProjectRestoreReference Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreSettings
+    {
+        public ProjectRestoreSettings() { }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public ProjectRestoreSettings Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreSettings other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum ProjectStyle : ushort
+    {
+        Unknown = 0,
+        ProjectJson = 1,
+        PackageReference = 2,
+        DotnetCliTool = 3,
+        Standalone = 4,
+        PackagesConfig = 5,
+        DotnetToolReference = 6
+    }
+
+    public partial class RestoreLockProperties : System.IEquatable<RestoreLockProperties>
+    {
+        public RestoreLockProperties() { }
+
+        public RestoreLockProperties(string restorePackagesWithLockFile, string nuGetLockFilePath, bool restoreLockedMode) { }
+
+        public string NuGetLockFilePath { get { throw null; } }
+
+        public bool RestoreLockedMode { get { throw null; } }
+
+        public string RestorePackagesWithLockFile { get { throw null; } }
+
+        public RestoreLockProperties Clone() { throw null; }
+
+        public bool Equals(RestoreLockProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class TargetFrameworkInformation : System.IEquatable<TargetFrameworkInformation>
+    {
+        public TargetFrameworkInformation() { }
+
+        public bool AssetTargetFallback { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, LibraryModel.CentralPackageVersion> CentralPackageVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.DownloadDependency> DownloadDependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<LibraryModel.FrameworkDependency> FrameworkReferences { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> Imports { get { throw null; } set { } }
+
+        public string RuntimeIdentifierGraphPath { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public bool Warn { get { throw null; } set { } }
+
+        public TargetFrameworkInformation Clone() { throw null; }
+
+        public bool Equals(TargetFrameworkInformation other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ToolPathResolver
+    {
+        public ToolPathResolver(string packagesDirectory, bool isLowercase) { }
+
+        public ToolPathResolver(string packagesDirectory) { }
+
+        public string GetBestToolDirectoryPath(string packageId, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string toolDirectory) { throw null; }
+
+        public string GetToolDirectoryPath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class WarningProperties : System.IEquatable<WarningProperties>
+    {
+        public WarningProperties() { }
+
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors) { }
+
+        public bool AllWarningsAsErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> NoWarn { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsAsErrors { get { throw null; } }
+
+        public WarningProperties Clone() { throw null; }
+
+        public bool Equals(WarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn) { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn) { throw null; }
+    }
+}
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public partial class LockFileDependencyComparerWithoutContentHash : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public LockFileDependencyComparerWithoutContentHash() { }
+
+        public static LockFileDependencyComparerWithoutContentHash Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.projectmodel/6.2.2/nuget.projectmodel.nuspec
+++ b/src/referencePackages/src/nuget.projectmodel/6.2.2/nuget.projectmodel.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.ProjectModel</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.DependencyResolver.Core" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.DependencyResolver.Core" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.protocol/6.2.2/NuGet.Protocol.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.protocol/6.2.2/NuGet.Protocol.6.2.2.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Protocol</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.Packaging" Version="6.2.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Packaging" Version="6.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.protocol/6.2.2/lib/net5.0/NuGet.Protocol.cs
+++ b/src/referencePackages/src/nuget.protocol/6.2.2/lib/net5.0/NuGet.Protocol.cs
@@ -1,0 +1,4360 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Credentials.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Protocol.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Protocol.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.VisualStudio.Common.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.CommandLine.Xplat.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.PackageManagement.VisualStudio.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's implementation for interacting with feeds. Contains functionality for all feed types.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Protocol")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Protocol
+{
+    public partial class AlternatePackageMetadata
+    {
+        public AlternatePackageMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "range", ItemConverterType = typeof(VersionRangeConverter))]
+        public Versioning.VersionRange Range { get { throw null; } }
+    }
+
+    public partial class AmbientAuthenticationState
+    {
+        public AmbientAuthenticationState() { }
+
+        public int AuthenticationRetriesCount { get { throw null; } }
+
+        public bool IsBlocked { get { throw null; } }
+
+        public void Block() { }
+
+        public void Increment() { }
+    }
+
+    public partial class AutoCompleteResourceV2Feed : Core.Types.AutoCompleteResource
+    {
+        public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public AutoCompleteResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV3 : Core.Types.AutoCompleteResource
+    {
+        public AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public AutoCompleteResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class CachingSourceProvider : Core.Types.ISourceRepositoryProvider
+    {
+        public CachingSourceProvider(Configuration.IPackageSourceProvider packageSourceProvider) { }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider { get { throw null; } }
+
+        public void AddSourceRepository(Core.Types.SourceRepository source) { }
+
+        public Core.Types.SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public Core.Types.SourceRepository CreateRepository(Configuration.PackageSource source) { throw null; }
+
+        public Core.Types.SourceRepository CreateRepository(string source) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Core.Types.SourceRepository> GetRepositories() { throw null; }
+    }
+
+    public static partial class CachingUtility
+    {
+        public const int BufferSize = 8192;
+        public static string ComputeHash(string value, bool addIdentifiableCharacters = true) { throw null; }
+
+        public static bool IsFileAlreadyOpen(string filePath) { throw null; }
+
+        public static System.IO.Stream ReadCacheFile(System.TimeSpan maxAge, string cacheFile) { throw null; }
+
+        public static string RemoveInvalidFileNameChars(string value) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV2Feed : Core.Types.DependencyInfoResource
+    {
+        public DependencyInfoResourceV2Feed(V2FeedParser feedParser, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public DependencyInfoResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class DependencyInfoResourceV3 : Core.Types.DependencyInfoResource
+    {
+        public DependencyInfoResourceV3(HttpSource client, RegistrationResourceV3 regResource, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.RemoteSourceDependencyInfo>> ResolvePackages(string packageId, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public DependencyInfoResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class DownloadResourcePlugin : Core.Types.DownloadResource
+    {
+        public DownloadResourcePlugin(Plugins.IPlugin plugin, Plugins.IPluginMulticlientUtilities utilities, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class DownloadResourcePluginProvider : Core.Types.ResourceProvider
+    {
+        public DownloadResourcePluginProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class DownloadResourceV2Feed : Core.Types.DownloadResource
+    {
+        public DownloadResourceV2Feed(V2FeedParser feedParser, string source) { }
+
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV2Feed(V2FeedParser feedParser) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public DownloadResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV3 : Core.Types.DownloadResource
+    {
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV3(HttpSource client, RegistrationResourceV3 regResource) { }
+
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV3(HttpSource client, string packageBaseAddress) { }
+
+        public DownloadResourceV3(string source, HttpSource client, RegistrationResourceV3 regResource) { }
+
+        public DownloadResourceV3(string source, HttpSource client, string packageBaseAddress) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public DownloadResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadTimeoutStream : System.IO.Stream
+    {
+        public DownloadTimeoutStream(string downloadName, System.IO.Stream networkStream, System.TimeSpan timeout) { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanSeek { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override long Length { get { throw null; } }
+
+        public override long Position { get { throw null; } set { } }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) { throw null; }
+
+        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+
+        public override void SetLength(long value) { }
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+    }
+
+    public partial class DownloadTimeoutStreamContent : System.Net.Http.StreamContent
+    {
+        public DownloadTimeoutStreamContent(string downloadName, System.IO.Stream networkStream, System.TimeSpan timeout) : base(default!) { }
+    }
+
+    public static partial class FactoryExtensionsV3
+    {
+        public static Core.Types.SourceRepository GetCoreV2(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.Lazy<Core.Types.INuGetResourceProvider>> GetCoreV3(this Core.Types.Repository.ProviderFactory factory) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, string source, FeedType type) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, string source) { throw null; }
+    }
+
+    public enum FeedType
+    {
+        Undefined = 0,
+        HttpV2 = 1,
+        HttpV3 = 2,
+        FileSystemV2 = 4,
+        FileSystemV3 = 8,
+        FileSystemUnzipped = 16,
+        FileSystemPackagesConfig = 32,
+        FileSystemUnknown = 1024
+    }
+
+    public partial class FeedTypePackageSource : Configuration.PackageSource
+    {
+        public FeedTypePackageSource(string source, FeedType feedType) : base(default!) { }
+
+        public FeedType FeedType { get { throw null; } }
+    }
+
+    public partial class FeedTypeResource : Core.Types.INuGetResource
+    {
+        public FeedTypeResource(FeedType feedType) { }
+
+        public FeedType FeedType { get { throw null; } }
+    }
+
+    public partial class FeedTypeResourceProvider : Core.Types.ResourceProvider
+    {
+        public FeedTypeResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class FeedTypeUtility
+    {
+        public static FeedType GetFeedType(Configuration.PackageSource packageSource) { throw null; }
+    }
+
+    public abstract partial class FindLocalPackagesResource : Core.Types.INuGetResource
+    {
+        protected FindLocalPackagesResource() { }
+
+        public string Root { get { throw null; } protected set { } }
+
+        public virtual bool Exists(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual bool Exists(string packageId, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial class FindLocalPackagesResourcePackagesConfig : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourcePackagesConfig(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourcePackagesConfigProvider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourcePackagesConfigProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceUnzipped : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceUnzipped(string root) { }
+
+        public override bool Exists(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceUnzippedProvider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceUnzippedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV2 : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceV2(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceV2Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV3 : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceV3(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindPackagesByIdNupkgDownloader
+    {
+        public FindPackagesByIdNupkgDownloader(HttpSource httpSource) { }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(Packaging.Core.PackageIdentity identity, string url, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.NuspecReader> GetNuspecReaderFromNupkgAsync(Packaging.Core.PackageIdentity identity, string url, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FingerprintsConverter : Newtonsoft.Json.JsonConverter
+    {
+        public FingerprintsConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public static partial class GetDownloadResultUtility
+    {
+        public static void CleanUpDirectDownloads(Core.Types.PackageDownloadContext downloadContext) { }
+
+        public static System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResultAsync(HttpSource client, Packaging.Core.PackageIdentity identity, System.Uri uri, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class GlobalPackagesFolderUtility
+    {
+        public static System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> AddPackageAsync(string source, Packaging.Core.PackageIdentity packageIdentity, System.IO.Stream packageStream, string globalPackagesFolder, System.Guid parentId, Packaging.Signing.ClientPolicyContext clientPolicyContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static Core.Types.DownloadResourceResult GetPackage(Packaging.Core.PackageIdentity packageIdentity, string globalPackagesFolder) { throw null; }
+    }
+
+    public partial class HttpCacheResult
+    {
+        public HttpCacheResult(System.TimeSpan maxAge, string newFile, string cacheFule) { }
+
+        public string CacheFile { get { throw null; } }
+
+        public System.TimeSpan MaxAge { get { throw null; } }
+
+        public string NewFile { get { throw null; } }
+
+        public System.IO.Stream Stream { get { throw null; } set { } }
+    }
+
+    public static partial class HttpCacheUtility
+    {
+        public static System.Threading.Tasks.Task CreateCacheFileAsync(HttpCacheResult result, System.Net.Http.HttpResponseMessage response, System.Action<System.IO.Stream> ensureValidContents, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static HttpCacheResult InitializeHttpCacheResult(string httpCacheDirectory, System.Uri sourceUri, string cacheKey, Core.Types.HttpSourceCacheContext context) { throw null; }
+    }
+
+    public partial class HttpFileSystemBasedFindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public HttpFileSystemBasedFindPackageByIdResource(System.Collections.Generic.IReadOnlyList<System.Uri> baseUris, HttpSource httpSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpFileSystemBasedFindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public HttpFileSystemBasedFindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpHandlerResourceV3 : Core.Types.HttpHandlerResource
+    {
+        public HttpHandlerResourceV3(System.Net.Http.HttpClientHandler clientHandler, System.Net.Http.HttpMessageHandler messageHandler) { }
+
+        public override System.Net.Http.HttpClientHandler ClientHandler { get { throw null; } }
+
+        public static System.Lazy<Configuration.ICredentialService> CredentialService { get { throw null; } set { } }
+
+        public static System.Action<System.Uri, System.Net.ICredentials> CredentialsSuccessfullyUsed { get { throw null; } set { } }
+
+        public override System.Net.Http.HttpMessageHandler MessageHandler { get { throw null; } }
+    }
+
+    public partial class HttpHandlerResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public HttpHandlerResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpRequestMessageConfiguration
+    {
+        public static readonly HttpRequestMessageConfiguration Default;
+        public HttpRequestMessageConfiguration(Common.ILogger logger = null, bool promptOn403 = true) { }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public bool PromptOn403 { get { throw null; } }
+    }
+
+    public static partial class HttpRequestMessageExtensions
+    {
+        public static HttpRequestMessageConfiguration GetOrCreateConfiguration(this System.Net.Http.HttpRequestMessage request) { throw null; }
+
+        public static void SetConfiguration(this System.Net.Http.HttpRequestMessage request, HttpRequestMessageConfiguration configuration) { }
+    }
+
+    public static partial class HttpRequestMessageFactory
+    {
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, string requestUri, Common.ILogger log) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, string requestUri, HttpRequestMessageConfiguration configuration) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, System.Uri requestUri, Common.ILogger log) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, System.Uri requestUri, HttpRequestMessageConfiguration configuration) { throw null; }
+    }
+
+    public static partial class HttpResponseMessageExtensions
+    {
+        public static void LogServerWarning(this System.Net.Http.HttpResponseMessage response, Common.ILogger log) { }
+    }
+
+    public partial class HttpRetryHandler : IHttpRetryHandler
+    {
+        public HttpRetryHandler() { }
+
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, string source, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpRetryHandlerRequest
+    {
+        public static readonly System.TimeSpan DefaultDownloadTimeout;
+        public static readonly int DefaultMaxTries;
+        public HttpRetryHandlerRequest(System.Net.Http.HttpClient httpClient, System.Func<System.Net.Http.HttpRequestMessage> requestFactory) { }
+
+        public System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>> AddHeaders { get { throw null; } set { } }
+
+        public System.Net.Http.HttpCompletionOption CompletionOption { get { throw null; } set { } }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public System.Net.Http.HttpClient HttpClient { get { throw null; } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.Func<System.Net.Http.HttpRequestMessage> RequestFactory { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+
+        public System.TimeSpan RetryDelay { get { throw null; } set { } }
+    }
+
+    public partial class HttpSource : System.IDisposable
+    {
+        public HttpSource(Configuration.PackageSource packageSource, System.Func<System.Threading.Tasks.Task<Core.Types.HttpHandlerResource>> messageHandlerFactory, IThrottle throttle) { }
+
+        public string HttpCacheDirectory { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } }
+
+        public IHttpRetryHandler RetryHandler { get { throw null; } set { } }
+
+        public static HttpSource Create(Core.Types.SourceRepository source, IThrottle throttle) { throw null; }
+
+        public static HttpSource Create(Core.Types.SourceRepository source) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public virtual System.Threading.Tasks.Task<T> GetAsync<T>(HttpSourceCachedRequest request, System.Func<HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> GetJObjectAsync(HttpSourceRequest request, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessResponseAsync<T>(HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessResponseAsync<T>(HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessStreamAsync<T>(HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessStreamAsync<T>(HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        protected virtual System.IO.Stream TryReadCacheFile(string uri, System.TimeSpan maxAge, string cacheFile) { throw null; }
+    }
+
+    public partial class HttpSourceAuthenticationHandler : System.Net.Http.DelegatingHandler
+    {
+        public static readonly int MaxAuthRetries;
+        public HttpSourceAuthenticationHandler(Configuration.PackageSource packageSource, System.Net.Http.HttpClientHandler clientHandler, Configuration.ICredentialService credentialService) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpSourceCachedRequest
+    {
+        public HttpSourceCachedRequest(string uri, string cacheKey, Core.Types.HttpSourceCacheContext cacheContext) { }
+
+        public System.Collections.Generic.IList<System.Net.Http.Headers.MediaTypeWithQualityHeaderValue> AcceptHeaderValues { get { throw null; } }
+
+        public Core.Types.HttpSourceCacheContext CacheContext { get { throw null; } }
+
+        public string CacheKey { get { throw null; } }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public System.Action<System.IO.Stream> EnsureValidContents { get { throw null; } set { } }
+
+        public bool IgnoreNotFounds { get { throw null; } set { } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } }
+    }
+
+    public partial class HttpSourceCredentials : System.Net.CredentialCache, System.Net.ICredentials
+    {
+        public HttpSourceCredentials() { }
+
+        public HttpSourceCredentials(System.Net.ICredentials credentials = null) { }
+
+        public System.Net.ICredentials Credentials { get { throw null; } set { } }
+
+        public System.Guid Version { get { throw null; } }
+
+        System.Net.NetworkCredential System.Net.ICredentials.GetCredential(System.Uri uri, string authType) { throw null; }
+    }
+
+    public partial class HttpSourceRequest
+    {
+        public static readonly System.TimeSpan DefaultRequestTimeout;
+        public HttpSourceRequest(System.Func<System.Net.Http.HttpRequestMessage> requestFactory) { }
+
+        public HttpSourceRequest(string uri, Common.ILogger log) { }
+
+        public HttpSourceRequest(System.Uri uri, Common.ILogger log) { }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public bool IgnoreNotFounds { get { throw null; } set { } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.Func<System.Net.Http.HttpRequestMessage> RequestFactory { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+    }
+
+    public partial class HttpSourceResource : Core.Types.INuGetResource
+    {
+        public HttpSourceResource(HttpSource httpSource) { }
+
+        public HttpSource HttpSource { get { throw null; } }
+    }
+
+    public partial class HttpSourceResourceProvider : Core.Types.ResourceProvider
+    {
+        public HttpSourceResourceProvider() : base(default!) { }
+
+        public static IThrottle Throttle { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpSourceResult : System.IDisposable
+    {
+        public HttpSourceResult(HttpSourceResultStatus status, string cacheFileName, System.IO.Stream stream) { }
+
+        public HttpSourceResult(HttpSourceResultStatus status) { }
+
+        public string CacheFile { get { throw null; } }
+
+        public HttpSourceResultStatus Status { get { throw null; } }
+
+        public System.IO.Stream Stream { get { throw null; } }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+    }
+
+    public enum HttpSourceResultStatus
+    {
+        NotFound = 0,
+        NoContent = 1,
+        OpenedFromDisk = 2,
+        OpenedFromNetwork = 3
+    }
+
+    public static partial class HttpStreamValidation
+    {
+        public static void ValidateJObject(string uri, System.IO.Stream stream) { }
+
+        public static void ValidateNupkg(string uri, System.IO.Stream stream) { }
+
+        public static void ValidateXml(string uri, System.IO.Stream stream) { }
+    }
+
+    public partial interface IHttpRetryHandler
+    {
+        System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, string sourceUri, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public abstract partial class InvalidCacheProtocolException : Core.Types.FatalProtocolException
+    {
+        public InvalidCacheProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public InvalidCacheProtocolException(string message) : base(default!) { }
+    }
+
+    public partial interface IThrottle
+    {
+        void Release();
+        System.Threading.Tasks.Task WaitAsync();
+    }
+
+    public partial interface IV2FeedParser
+    {
+        System.Threading.Tasks.Task<V2FeedPage> GetPackagesPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<V2FeedPage> GetSearchPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public static partial class JsonExtensions
+    {
+        public const int JsonSerializationMaxDepth = 512;
+        public static readonly Newtonsoft.Json.JsonSerializerSettings ObjectSerializationSettings;
+        public static object FromJson(this string json, System.Type type) { throw null; }
+
+        public static T FromJson<T>(this string json, Newtonsoft.Json.JsonSerializerSettings settings) { throw null; }
+
+        public static T FromJson<T>(this string json) { throw null; }
+
+        public static object FromJToken(this Newtonsoft.Json.Linq.JToken jtoken, System.Type type) { throw null; }
+
+        public static T FromJToken<T>(this Newtonsoft.Json.Linq.JToken jtoken) { throw null; }
+
+        public static bool? GetBoolean(this Newtonsoft.Json.Linq.JObject json, string propertyName) { throw null; }
+
+        public static T GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject jobject, string propertyName) { throw null; }
+
+        public static string ToJson(this object obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) { throw null; }
+
+        public static Newtonsoft.Json.Linq.JToken ToJToken(this object obj) { throw null; }
+    }
+
+    public static partial class JsonProperties
+    {
+        public const string AdvisoryUrl = "advisoryUrl";
+        public const string AllRepositorySigned = "allRepositorySigned";
+        public const string AlternatePackage = "alternatePackage";
+        public const string Authors = "authors";
+        public const string ContentUrl = "contentUrl";
+        public const string Created = "created";
+        public const string Data = "data";
+        public const string Dependencies = "dependencies";
+        public const string DependencyGroups = "dependencyGroups";
+        public const string Deprecation = "deprecation";
+        public const string DeprecationMessage = "message";
+        public const string DeprecationReasons = "reasons";
+        public const string Description = "description";
+        public const string DownloadCount = "totalDownloads";
+        public const string Fingerprints = "fingerprints";
+        public const string IconUrl = "iconUrl";
+        public const string Issuer = "issuer";
+        public const string Language = "language";
+        public const string LastEdited = "lastEdited";
+        public const string LatestVersion = "latestVersion";
+        public const string LicenseExpression = "licenseExpression";
+        public const string LicenseExpressionVersion = "licenseExpressionVersion";
+        public const string LicenseUrl = "licenseUrl";
+        public const string Listed = "listed";
+        public const string MinimumClientVersion = "minClientVersion";
+        public const string NotAfter = "notAfter";
+        public const string NotBefore = "notBefore";
+        public const string Owners = "owners";
+        public const string PackageContent = "packageContent";
+        public const string PackageId = "id";
+        public const string PrefixReserved = "verified";
+        public const string ProjectUrl = "projectUrl";
+        public const string Published = "published";
+        public const string Range = "range";
+        public const string ReadmeUrl = "readmeUrl";
+        public const string RequireLicenseAcceptance = "requireLicenseAcceptance";
+        public const string Severity = "severity";
+        public const string SigningCertificates = "signingCertificates";
+        public const string Subject = "subject";
+        public const string SubjectId = "@id";
+        public const string Summary = "summary";
+        public const string Tags = "tags";
+        public const string TargetFramework = "targetFramework";
+        public const string Title = "title";
+        public const string Type = "@type";
+        public const string Version = "version";
+        public const string Versions = "versions";
+        public const string Vulnerabilities = "vulnerabilities";
+    }
+
+    public partial class LegacyFeedCapabilityResourceV2Feed : Core.Types.LegacyFeedCapabilityResource
+    {
+        public LegacyFeedCapabilityResourceV2Feed(V2FeedParser feedParser, string baseAddress) { }
+
+        public override System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalAutoCompleteResource : Core.Types.AutoCompleteResource
+    {
+        public LocalAutoCompleteResource(FindLocalPackagesResource localResource) { }
+
+        protected System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetPackageVersionsFromLocalPackageRepository(string packageId, string versionPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalAutoCompleteResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalAutoCompleteResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDependencyInfoResource : Core.Types.DependencyInfoResource
+    {
+        public LocalDependencyInfoResource(FindLocalPackagesResource localResource, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDependencyInfoResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalDependencyInfoResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDownloadResource : Core.Types.DownloadResource
+    {
+        [System.Obsolete("Use constructor with source parameter")]
+        public LocalDownloadResource(FindLocalPackagesResource localResource) { }
+
+        public LocalDownloadResource(string source, FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDownloadResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalDownloadResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class LocalFolderUtility
+    {
+        public static void EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) { }
+
+        public static void GenerateNupkgMetadataFile(string nupkgPath, string installPath, string hashPath, string nupkgMetadataPath) { }
+
+        public static System.IO.DirectoryInfo GetAndVerifyRootDirectory(string root) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetDistinctPackages(System.Collections.Generic.IEnumerable<LocalPackageInfo> packages) { throw null; }
+
+        public static Packaging.Core.PackageIdentity GetIdentityFromNupkgPath(System.IO.FileInfo file, string id) { throw null; }
+
+        public static FeedType GetLocalFeedType(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, string id, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackage(System.Uri path, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackagesConfigFolderPackage(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackagesConfigFolderPackage(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, string id, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, string id, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, string id, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, string id, Versioning.NuGetVersion version, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV3(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV3(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionFromFileName(string fileName, string id, string extension) { throw null; }
+
+        public static bool IsPossiblePackageMatch(System.IO.FileInfo file, Packaging.Core.PackageIdentity identity) { throw null; }
+
+        public static bool IsPossiblePackageMatch(System.IO.FileInfo file, string id) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> ResolvePackageFromPath(string packagePath, bool isSnupkg = false) { throw null; }
+    }
+
+    public partial class LocalMetadataResource : Core.Types.MetadataResource
+    {
+        public LocalMetadataResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalMetadataResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalMetadataResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class LocalPackageArchiveDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public LocalPackageArchiveDownloader(string source, string packageFilePath, Packaging.Core.PackageIdentity packageIdentity, Common.ILogger logger) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class LocalPackageFileCache
+    {
+        public LocalPackageFileCache() { }
+
+        public virtual System.Lazy<System.Collections.Generic.IReadOnlyList<string>> GetOrAddFiles(string expandedPath) { throw null; }
+
+        public virtual System.Lazy<Packaging.NuspecReader> GetOrAddNuspec(string manifestPath, string expandedPath) { throw null; }
+
+        public virtual System.Lazy<RuntimeModel.RuntimeGraph> GetOrAddRuntimeGraph(string expandedPath) { throw null; }
+
+        public virtual System.Lazy<string> GetOrAddSha512(string sha512Path) { throw null; }
+
+        public virtual bool Sha512Exists(string sha512Path) { throw null; }
+
+        public void UpdateLastAccessTime(string nupkgMetadataPath) { }
+    }
+
+    public partial class LocalPackageInfo
+    {
+        protected LocalPackageInfo() { }
+
+        public LocalPackageInfo(Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<Packaging.NuspecReader> nuspec, bool useFolder) { }
+
+        [System.Obsolete("use other constructor")]
+        public LocalPackageInfo(Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<Packaging.NuspecReader> nuspec, System.Func<Packaging.PackageReaderBase> getPackageReader) { }
+
+        public virtual Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public virtual bool IsNupkg { get { throw null; } }
+
+        public virtual System.DateTime LastWriteTimeUtc { get { throw null; } }
+
+        public virtual Packaging.NuspecReader Nuspec { get { throw null; } }
+
+        public virtual string Path { get { throw null; } }
+
+        public virtual Packaging.PackageReaderBase GetReader() { throw null; }
+    }
+
+    public partial class LocalPackageListResource : Core.Types.ListResource
+    {
+        public LocalPackageListResource(Core.Types.PackageSearchResource localPackageSearchResource, string baseAddress) { }
+
+        public override string Source { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<Common.IEnumerableAsync<Core.Types.IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageMetadataResource : Core.Types.PackageMetadataResource
+    {
+        public LocalPackageMetadataResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageMetadataResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageMetadataResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageSearchMetadata : Core.Types.IPackageSearchMetadata
+    {
+        public LocalPackageSearchMetadata(LocalPackageInfo package) { }
+
+        public string Authors { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public string Owners { get { throw null; } }
+
+        public System.Uri PackageDetailsUrl { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public System.Func<Packaging.PackageReaderBase> PackageReader { get { throw null; } }
+
+        public bool PrefixReserved { get { throw null; } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        public System.Uri ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+
+        public string LoadFileAsText(string path) { throw null; }
+    }
+
+    public partial class LocalPackageSearchResource : Core.Types.PackageSearchResource
+    {
+        public LocalPackageSearchResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageSearchResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageSearchResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalV2FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public LocalV2FindPackageByIdResource(Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalV2FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalV2FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalV3FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public LocalV3FindPackageByIdResource(Configuration.PackageSource packageSource) { }
+
+        public bool IsFallbackFolder { get { throw null; } set { } }
+
+        public LocalPackageFileCache PackageFileCache { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalV3FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalV3FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataFieldConverter : Newtonsoft.Json.JsonConverter
+    {
+        public MetadataFieldConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class MetadataReferenceCache
+    {
+        public MetadataReferenceCache() { }
+
+        public T GetObject<T>(T input) { throw null; }
+
+        public string GetString(string s) { throw null; }
+
+        public Versioning.NuGetVersion GetVersion(string s) { throw null; }
+    }
+
+    public partial class MetadataResourceV2Feed : Core.Types.MetadataResource
+    {
+        public MetadataResourceV2Feed(V2FeedParser feedParser, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public MetadataResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV3 : Core.Types.MetadataResource
+    {
+        public MetadataResourceV3(RegistrationResourceV3 regResource) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public MetadataResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class NuGetVersionConverter : Newtonsoft.Json.JsonConverter
+    {
+        public NuGetVersionConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class NullThrottle : IThrottle
+    {
+        public NullThrottle() { }
+
+        public static NullThrottle Instance { get { throw null; } }
+
+        public void Release() { }
+
+        public System.Threading.Tasks.Task WaitAsync() { throw null; }
+    }
+
+    public partial class ODataServiceDocumentResourceV2 : Core.Types.INuGetResource
+    {
+        public ODataServiceDocumentResourceV2(string baseAddress, System.DateTime requestTime) { }
+
+        public string BaseAddress { get { throw null; } }
+
+        public virtual System.DateTime RequestTime { get { throw null; } }
+    }
+
+    public partial class ODataServiceDocumentResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public ODataServiceDocumentResourceV2Provider() : base(default!) { }
+
+        public System.TimeSpan MaxCacheDuration { get { throw null; } protected set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+
+        protected partial class ODataServiceDocumentCacheInfo
+        {
+            public ODataServiceDocumentCacheInfo() { }
+
+            public System.DateTime CachedTime { get { throw null; } set { } }
+
+            public ODataServiceDocumentResourceV2 ServiceDocument { get { throw null; } set { } }
+        }
+    }
+
+    public partial class PackageDependencyGroupConverter : Newtonsoft.Json.JsonConverter
+    {
+        public PackageDependencyGroupConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class PackageDeprecationMetadata
+    {
+        public PackageDeprecationMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "alternatePackage")]
+        public AlternatePackageMetadata AlternatePackage { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        public string Message { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "reasons")]
+        public System.Collections.Generic.IEnumerable<string> Reasons { get { throw null; } }
+    }
+
+    public partial class PackageDetailsUriResourceV3 : Core.Types.INuGetResource
+    {
+        public static PackageDetailsUriResourceV3 CreateOrNull(string uriTemplate) { throw null; }
+
+        public System.Uri GetUri(string id, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class PackageDetailsUriResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageDetailsUriResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV2Feed : Core.Types.PackageMetadataResource
+    {
+        public PackageMetadataResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public PackageMetadataResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV3 : Core.Types.PackageMetadataResource
+    {
+        public PackageMetadataResourceV3(HttpSource client, RegistrationResourceV3 regResource, ReportAbuseResourceV3 reportAbuseResource, PackageDetailsUriResourceV3 packageDetailsUriResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageMetadataResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageNotFoundProtocolException : InvalidCacheProtocolException
+    {
+        public PackageNotFoundProtocolException(Packaging.Core.PackageIdentity package, System.Exception innerException) : base(default!) { }
+
+        public PackageNotFoundProtocolException(Packaging.Core.PackageIdentity package) : base(default!) { }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadata : Core.Types.IPackageSearchMetadata
+    {
+        public PackageSearchMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "authors")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Authors { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "dependencyGroups", ItemConverterType = typeof(PackageDependencyGroupConverter))]
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySetsInternal { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "deprecation")]
+        public PackageDeprecationMetadata DeprecationMetadata { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "description")]
+        public string Description { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "totalDownloads")]
+        public long? DownloadCount { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "iconUrl")]
+        public System.Uri IconUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "listed")]
+        public bool IsListed { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseExpression")]
+        public string LicenseExpression { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseExpressionVersion")]
+        public string LicenseExpressionVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "owners")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Owners { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Uri PackageDetailsUrl { get { throw null; } set { } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "versions")]
+        public Core.Types.VersionInfo[] ParsedVersions { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "verified")]
+        public bool PrefixReserved { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "projectUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "published")]
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "readmeUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Uri ReportAbuseUrl { get { throw null; } set { } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "requireLicenseAcceptance", DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Populate)]
+        [System.ComponentModel.DefaultValue(false)]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeBoolConverter))]
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "summary")]
+        public string Summary { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "tags")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Tags { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "title")]
+        public string Title { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "version")]
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "vulnerabilities")]
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+    }
+
+    public partial class PackageSearchMetadataRegistration : PackageSearchMetadata
+    {
+        public PackageSearchMetadataRegistration() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "@id")]
+        public System.Uri CatalogUri { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadataV2Feed : Core.Types.IPackageSearchMetadata
+    {
+        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package, MetadataReferenceCache metadataCache) { }
+
+        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package) { }
+
+        public string Authors { get { throw null; } }
+
+        public System.DateTimeOffset? Created { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public PackageDeprecationMetadata DeprecationMetadata { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public System.DateTimeOffset? LastEdited { get { throw null; } }
+
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public string Owners { get { throw null; } }
+
+        public System.Uri PackageDetailsUrl { get { throw null; } }
+
+        public string PackageId { get { throw null; } }
+
+        public bool PrefixReserved { get { throw null; } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        public System.Uri ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+    }
+
+    public partial class PackageSearchResourceV2Feed : Core.Types.PackageSearchResource
+    {
+        public PackageSearchResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public PackageSearchResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV3 : Core.Types.PackageSearchResource
+    {
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public PackageSearchResourceV3(RawSearchResourceV3 searchResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filter, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageSearchResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageUpdateResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public PackageUpdateResourceV2Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageUpdateResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageUpdateResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageVulnerabilityMetadata
+    {
+        public PackageVulnerabilityMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "advisoryUrl", ItemConverterType = typeof(SafeUriConverter))]
+        public System.Uri AdvisoryUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "severity")]
+        public int Severity { get { throw null; } }
+    }
+
+    public sealed partial class PluginFindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public PluginFindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public static partial class ProtocolConstants
+    {
+        public static readonly string ApiKeyHeader;
+        public static readonly string ServerWarningHeader;
+        public static readonly string SessionId;
+    }
+
+    public partial class ProxyAuthenticationHandler : System.Net.Http.DelegatingHandler
+    {
+        public static readonly int MaxAuthRetries;
+        public ProxyAuthenticationHandler(System.Net.Http.HttpClientHandler clientHandler, Configuration.ICredentialService credentialService, Configuration.IProxyCredentialCache credentialCache) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+    public partial class RawSearchResourceV3 : Core.Types.INuGetResource
+    {
+        public RawSearchResourceV3(HttpSource client, System.Collections.Generic.IEnumerable<System.Uri> searchEndpoints) { }
+
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> Search(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public virtual System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> SearchPage(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+    public partial class RawSearchResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public RawSearchResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RegistrationResourceV3 : Core.Types.INuGetResource
+    {
+        public RegistrationResourceV3(HttpSource client, System.Uri baseUrl) { }
+
+        public System.Uri BaseUri { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageEntries(string packageId, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> GetPackageMetadata(Packaging.Core.PackageIdentity identity, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageMetadata(string packageId, Versioning.VersionRange range, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Uri GetUri(Packaging.Core.PackageIdentity package) { throw null; }
+
+        public virtual System.Uri GetUri(string id, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual System.Uri GetUri(string packageId) { throw null; }
+    }
+
+    public partial class RegistrationResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public RegistrationResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class RegistrationUtility
+    {
+        public static Versioning.VersionRange CreateVersionRange(string stringToParse) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> LoadRanges(HttpSource httpSource, System.Uri registrationUri, string packageId, Versioning.VersionRange range, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class RemotePackageArchiveDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public RemotePackageArchiveDownloader(string source, Core.Types.FindPackageByIdResource resource, Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class RemoteV2FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public RemoteV2FindPackageByIdResource(Configuration.PackageSource packageSource, HttpSource httpSource) { }
+
+        public Configuration.PackageSource PackageSource { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteV2FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public RemoteV2FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RemoteV3FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public RemoteV3FindPackageByIdResource(Core.Types.SourceRepository sourceRepository, HttpSource httpSource) { }
+
+        public Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteV3FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public RemoteV3FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class ReportAbuseResourceV3 : Core.Types.INuGetResource
+    {
+        public ReportAbuseResourceV3(string uriTemplate) { }
+
+        public System.Uri GetReportAbuseUrl(string id, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class ReportAbuseResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public ReportAbuseResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RepositoryCertificateInfo : Packaging.Core.IRepositoryCertificateInfo
+    {
+        public RepositoryCertificateInfo() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "contentUrl")]
+        public string ContentUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "fingerprints")]
+        public Packaging.Core.Fingerprints Fingerprints { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "issuer")]
+        public string Issuer { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "notAfter")]
+        public System.DateTimeOffset NotAfter { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "notBefore")]
+        public System.DateTimeOffset NotBefore { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "subject")]
+        public string Subject { get { throw null; } }
+    }
+
+    public partial class RepositorySignatureResource : Core.Types.INuGetResource
+    {
+        public RepositorySignatureResource(Newtonsoft.Json.Linq.JObject repoSignInformationContent, Core.Types.SourceRepository source) { }
+
+        public RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<Packaging.Core.IRepositoryCertificateInfo> repositoryCertInfos) { }
+
+        public bool AllRepositorySigned { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.Core.IRepositoryCertificateInfo> RepositoryCertificateInfos { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public void UpdateRepositorySignatureInfo() { }
+    }
+
+    public partial class RepositorySignatureResourceProvider : Core.Types.ResourceProvider
+    {
+        public RepositorySignatureResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SafeBoolConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SafeBoolConverter() { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class SafeUriConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SafeUriConverter() { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public sealed partial class SemanticVersionConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SemanticVersionConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class SemaphoreSlimThrottle : IThrottle
+    {
+        public SemaphoreSlimThrottle(System.Threading.SemaphoreSlim semaphore) { }
+
+        public int CurrentCount { get { throw null; } }
+
+        public static SemaphoreSlimThrottle CreateBinarySemaphore() { throw null; }
+
+        public static SemaphoreSlimThrottle CreateSemaphoreThrottle(int initialCount) { throw null; }
+
+        public void Release() { }
+
+        public System.Threading.Tasks.Task WaitAsync() { throw null; }
+    }
+
+    public partial class ServerWarningLogHandler : System.Net.Http.DelegatingHandler
+    {
+        public ServerWarningLogHandler(System.Net.Http.HttpClientHandler clientHandler) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class ServiceIndexEntry
+    {
+        public ServiceIndexEntry(System.Uri serviceUri, string serviceType, Versioning.SemanticVersion clientVersion) { }
+
+        public Versioning.SemanticVersion ClientVersion { get { throw null; } }
+
+        public string Type { get { throw null; } }
+
+        public System.Uri Uri { get { throw null; } }
+    }
+
+    public partial class ServiceIndexResourceV3 : Core.Types.INuGetResource
+    {
+        public ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) { }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> Entries { get { throw null; } }
+
+        public virtual string Json { get { throw null; } }
+
+        public virtual System.DateTime RequestTime { get { throw null; } }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> GetServiceEntries(Versioning.NuGetVersion clientVersion, params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> GetServiceEntries(params string[] orderedTypes) { throw null; }
+
+        public virtual System.Uri GetServiceEntryUri(params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<System.Uri> GetServiceEntryUris(Versioning.NuGetVersion clientVersion, params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<System.Uri> GetServiceEntryUris(params string[] orderedTypes) { throw null; }
+    }
+
+    public partial class ServiceIndexResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public ServiceIndexResourceV3Provider() : base(default!) { }
+
+        public System.TimeSpan MaxCacheDuration { get { throw null; } protected set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+
+        protected partial class ServiceIndexCacheInfo
+        {
+            public ServiceIndexCacheInfo() { }
+
+            public System.DateTime CachedTime { get { throw null; } set { } }
+
+            public ServiceIndexResourceV3 Index { get { throw null; } set { } }
+        }
+    }
+
+    public static partial class ServiceTypes
+    {
+        public static readonly string[] LegacyGallery;
+        public static readonly string[] PackageBaseAddress;
+        public static readonly string[] PackageDetailsUriTemplate;
+        public static readonly string[] PackagePublish;
+        public static readonly string[] RegistrationsBaseUrl;
+        public static readonly string[] ReportAbuse;
+        public static readonly string[] RepositorySignatures;
+        public static readonly string[] SearchAutocompleteService;
+        public static readonly string[] SearchQueryService;
+        public static readonly string[] SymbolPackagePublish;
+        public static readonly string Version200;
+        public static readonly string Version300;
+        public static readonly string Version300beta;
+        public static readonly string Version340;
+        public static readonly string Version470;
+        public static readonly string Version490;
+        public static readonly string Version500;
+        public static readonly string Version510;
+        public static readonly string Versioned;
+    }
+
+    public static partial class StreamExtensions
+    {
+        public static readonly int BufferSize;
+        public static System.Threading.Tasks.Task CopyToAsync(this System.IO.Stream stream, System.IO.Stream destination, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SymbolPackageUpdateResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public SymbolPackageUpdateResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class TimeoutUtility
+    {
+        public static System.Threading.Tasks.Task StartWithTimeout(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> getTask, System.TimeSpan timeout, string timeoutMessage, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<T> StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> getTask, System.TimeSpan timeout, string timeoutMessage, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class TokenStore
+    {
+        public TokenStore() { }
+
+        public static TokenStore Instance { get { throw null; } }
+
+        public System.Guid Version { get { throw null; } }
+
+        public void AddToken(System.Uri sourceUri, string token) { }
+
+        public string GetToken(System.Uri sourceUri) { throw null; }
+    }
+
+    public partial class V2FeedListResource : Core.Types.ListResource
+    {
+        public V2FeedListResource(IV2FeedParser feedParser, Core.Types.ILegacyFeedCapabilityResource feedCapabilities, string baseAddress) { }
+
+        public override string Source { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<Common.IEnumerableAsync<Core.Types.IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedListResourceProvider : Core.Types.ResourceProvider
+    {
+        public V2FeedListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedPackageInfo : Packaging.Core.PackageIdentity
+    {
+        public V2FeedPackageInfo(Packaging.Core.PackageIdentity identity, string title, string summary, string description, System.Collections.Generic.IEnumerable<string> authors, System.Collections.Generic.IEnumerable<string> owners, string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl, string tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount, string packageHash, string packageHashAlgorithm, Versioning.NuGetVersion minClientVersion) : base(default!, default!) { }
+
+        public System.Collections.Generic.IEnumerable<string> Authors { get { throw null; } }
+
+        public System.DateTimeOffset? Created { get { throw null; } }
+
+        public string Dependencies { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public string DownloadCount { get { throw null; } }
+
+        public int DownloadCountAsInt { get { throw null; } }
+
+        public string DownloadUrl { get { throw null; } }
+
+        public string GalleryDetailsUrl { get { throw null; } }
+
+        public string IconUrl { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public System.DateTimeOffset? LastEdited { get { throw null; } }
+
+        public string LicenseUrl { get { throw null; } }
+
+        public Versioning.NuGetVersion MinClientVersion { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } }
+
+        public string PackageHash { get { throw null; } }
+
+        public string PackageHashAlgorithm { get { throw null; } }
+
+        public string ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public string ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+    }
+
+    public partial class V2FeedPage
+    {
+        public V2FeedPage(System.Collections.Generic.List<V2FeedPackageInfo> items, string nextUri) { }
+
+        public System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo> Items { get { throw null; } }
+
+        public string NextUri { get { throw null; } }
+    }
+
+    public sealed partial class V2FeedParser : IV2FeedParser
+    {
+        public V2FeedParser(HttpSource httpSource, string baseAddress, string source) { }
+
+        public V2FeedParser(HttpSource httpSource, string baseAddress) { }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> DownloadFromIdentity(Packaging.Core.PackageIdentity package, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> DownloadFromUrl(Packaging.Core.PackageIdentity package, System.Uri downloadUri, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> FindPackagesByIdAsync(string id, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPackageInfo> GetPackage(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> GetPackagesPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> GetSearchPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> QueryV2FeedAsync(string relativeUri, string id, int max, bool ignoreNotFounds, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> Search(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedQueryBuilder
+    {
+        public V2FeedQueryBuilder() { }
+
+        public string BuildFindPackagesByIdUri(string id) { throw null; }
+
+        public string BuildGetPackagesUri(string searchTerm, Core.Types.SearchFilter filters, int? skip, int? take) { throw null; }
+
+        public string BuildGetPackageUri(Packaging.Core.PackageIdentity package) { throw null; }
+
+        public string BuildSearchUri(string searchTerm, Core.Types.SearchFilter filters, int skip, int take) { throw null; }
+    }
+
+    public static partial class V2FeedUtilities
+    {
+        public static Core.Types.IPackageSearchMetadata CreatePackageSearchResult(V2FeedPackageInfo package, MetadataReferenceCache metadataCache, Core.Types.SearchFilter filter, V2FeedParser feedParser, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class V3FeedListResourceProvider : Core.Types.ResourceProvider
+    {
+        public V3FeedListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class VersionInfoConverter : Newtonsoft.Json.JsonConverter
+    {
+        public VersionInfoConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class VersionRangeConverter : Newtonsoft.Json.JsonConverter
+    {
+        public VersionRangeConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+}
+
+namespace NuGet.Protocol.Core.Types
+{
+    public abstract partial class AutoCompleteResource : INuGetResource
+    {
+        protected AutoCompleteResource() { }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class DependencyInfoResource : INuGetResource
+    {
+        protected DependencyInfoResource() { }
+
+        public abstract System.Threading.Tasks.Task<SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public abstract partial class DownloadResource : INuGetResource
+    {
+        protected DownloadResource() { }
+
+        public abstract System.Threading.Tasks.Task<DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public sealed partial class DownloadResourceResult : System.IDisposable
+    {
+        public DownloadResourceResult(Packaging.PackageReaderBase packageReader, string source) { }
+
+        public DownloadResourceResult(DownloadResourceResultStatus status) { }
+
+        public DownloadResourceResult(System.IO.Stream stream, Packaging.PackageReaderBase packageReader, string source) { }
+
+        public DownloadResourceResult(System.IO.Stream stream, string source) { }
+
+        public Packaging.PackageReaderBase PackageReader { get { throw null; } }
+
+        public string PackageSource { get { throw null; } }
+
+        public System.IO.Stream PackageStream { get { throw null; } }
+
+        public bool SignatureVerified { get { throw null; } set { } }
+
+        public DownloadResourceResultStatus Status { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public enum DownloadResourceResultStatus
+    {
+        Available = 0,
+        AvailableWithoutStream = 1,
+        NotFound = 2,
+        Cancelled = 3
+    }
+
+    public partial class FatalProtocolException : NuGetProtocolException
+    {
+        public FatalProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public FatalProtocolException(string message) : base(default!) { }
+    }
+
+    public partial class FindPackageByIdDependencyInfo
+    {
+        public FindPackageByIdDependencyInfo(Packaging.Core.PackageIdentity packageIdentity, System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> dependencyGroups, System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> frameworkReferenceGroups) { }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.FrameworkSpecificGroup> FrameworkReferenceGroups { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+    }
+
+    public abstract partial class FindPackageByIdResource : INuGetResource
+    {
+        protected FindPackageByIdResource() { }
+
+        public abstract System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        protected static FindPackageByIdDependencyInfo GetDependencyInfo(Packaging.NuspecReader reader) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public abstract partial class HttpHandlerResource : INuGetResource
+    {
+        protected HttpHandlerResource() { }
+
+        public abstract System.Net.Http.HttpClientHandler ClientHandler { get; }
+        public abstract System.Net.Http.HttpMessageHandler MessageHandler { get; }
+    }
+
+    public partial class HttpSourceCacheContext
+    {
+        public bool DirectDownload { get { throw null; } }
+
+        public System.TimeSpan MaxAge { get { throw null; } }
+
+        public string RootTempFolder { get { throw null; } }
+
+        public SourceCacheContext SourceCacheContext { get { throw null; } }
+
+        public static HttpSourceCacheContext Create(SourceCacheContext cacheContext, bool isFirstAttempt) { throw null; }
+
+        public static HttpSourceCacheContext Create(SourceCacheContext cacheContext, int retryCount) { throw null; }
+    }
+
+    public partial interface ILegacyFeedCapabilityResource
+    {
+        System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public partial interface INuGetResource
+    {
+    }
+
+    public partial interface INuGetResourceProvider
+    {
+        System.Collections.Generic.IEnumerable<string> After { get; }
+
+        System.Collections.Generic.IEnumerable<string> Before { get; }
+
+        string Name { get; }
+
+        System.Type ResourceType { get; }
+
+        System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken token);
+    }
+
+    public partial interface IPackageSearchMetadata
+    {
+        string Authors { get; }
+
+        System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get; }
+
+        string Description { get; }
+
+        long? DownloadCount { get; }
+
+        System.Uri IconUrl { get; }
+
+        Packaging.Core.PackageIdentity Identity { get; }
+
+        bool IsListed { get; }
+
+        Packaging.LicenseMetadata LicenseMetadata { get; }
+
+        System.Uri LicenseUrl { get; }
+
+        string Owners { get; }
+
+        System.Uri PackageDetailsUrl { get; }
+
+        bool PrefixReserved { get; }
+
+        System.Uri ProjectUrl { get; }
+
+        System.DateTimeOffset? Published { get; }
+
+        System.Uri ReadmeUrl { get; }
+
+        System.Uri ReportAbuseUrl { get; }
+
+        bool RequireLicenseAcceptance { get; }
+
+        string Summary { get; }
+
+        string Tags { get; }
+
+        string Title { get; }
+
+        System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; }
+
+        System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync();
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>> GetVersionsAsync();
+    }
+
+    public partial interface ISourceRepositoryProvider
+    {
+        Configuration.IPackageSourceProvider PackageSourceProvider { get; }
+
+        SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type);
+        SourceRepository CreateRepository(Configuration.PackageSource source);
+        System.Collections.Generic.IEnumerable<SourceRepository> GetRepositories();
+    }
+
+    public abstract partial class LegacyFeedCapabilityResource : INuGetResource, ILegacyFeedCapabilityResource
+    {
+        protected LegacyFeedCapabilityResource() { }
+
+        public abstract System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class ListResource : INuGetResource
+    {
+        protected ListResource() { }
+
+        public abstract string Source { get; }
+
+        public abstract System.Threading.Tasks.Task<Common.IEnumerableAsync<IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class MetadataResource : INuGetResource
+    {
+        protected MetadataResource() { }
+
+        public System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<bool> Exists(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<Versioning.NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class NuGetProtocolException : System.Exception
+    {
+        public NuGetProtocolException(string message, System.Exception innerException) { }
+
+        public NuGetProtocolException(string message) { }
+    }
+
+    public sealed partial class NuGetResourceProviderPositions
+    {
+        public const string First = "First";
+        public const string Last = "Last";
+        public NuGetResourceProviderPositions() { }
+    }
+
+    public static partial class NuGetTestMode
+    {
+        public const string NuGetTestClientName = "NuGet Test Client";
+        public static bool Enabled { get { throw null; } }
+
+        public static T InvokeTestFunctionAgainstTestMode<T>(System.Func<T> function, bool testModeEnabled) { throw null; }
+    }
+
+    public partial class NullSourceCacheContext : SourceCacheContext
+    {
+        public NullSourceCacheContext() { }
+
+        public override string GeneratedTempFolder { get { throw null; } }
+
+        public static SourceCacheContext Instance { get { throw null; } }
+
+        public override SourceCacheContext Clone() { throw null; }
+
+        public override SourceCacheContext WithRefreshCacheTrue() { throw null; }
+    }
+
+    public partial class OfflineFeedAddContext
+    {
+        public OfflineFeedAddContext(string packagePath, string source, Common.ILogger logger, bool throwIfSourcePackageIsInvalid, bool throwIfPackageExistsAndInvalid, bool throwIfPackageExists, Packaging.PackageExtractionContext extractionContext) { }
+
+        public Packaging.PackageExtractionContext ExtractionContext { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public bool ThrowIfPackageExists { get { throw null; } }
+
+        public bool ThrowIfPackageExistsAndInvalid { get { throw null; } }
+
+        public bool ThrowIfSourcePackageIsInvalid { get { throw null; } }
+    }
+
+    public static partial class OfflineFeedUtility
+    {
+        public static System.Threading.Tasks.Task AddPackageToSource(OfflineFeedAddContext offlineFeedAddContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static string GetPackageDirectory(Packaging.Core.PackageIdentity packageIdentity, string offlineFeed) { throw null; }
+
+        public static bool PackageExists(Packaging.Core.PackageIdentity packageIdentity, string offlineFeed, out bool isValidPackage) { throw null; }
+
+        public static void ThrowIfInvalid(string path) { }
+
+        public static void ThrowIfInvalidOrNotFound(string path, bool isDirectory, string resourceString) { }
+    }
+
+    public partial class PackageDownloadContext
+    {
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory, bool directDownload, Configuration.PackageSourceMapping packageSourceMappingConfiguration) { }
+
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory, bool directDownload) { }
+
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext) { }
+
+        public Packaging.Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } set { } }
+
+        public bool DirectDownload { get { throw null; } }
+
+        public string DirectDownloadDirectory { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public SourceCacheContext SourceCacheContext { get { throw null; } }
+    }
+
+    public abstract partial class PackageMetadataResource : INuGetResource
+    {
+        protected PackageMetadataResource() { }
+
+        public abstract System.Threading.Tasks.Task<IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public partial class PackageProgressEventArgs : System.EventArgs
+    {
+        public PackageProgressEventArgs(Packaging.Core.PackageIdentity identity, Configuration.PackageSource source, double complete) { }
+
+        public double Complete { get { throw null; } }
+
+        public bool HasPackageSource { get { throw null; } }
+
+        public bool IsComplete { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public Configuration.PackageSource PackageSource { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadataBuilder
+    {
+        public IPackageSearchMetadata Build() { throw null; }
+
+        public static PackageSearchMetadataBuilder FromIdentity(Packaging.Core.PackageIdentity identity) { throw null; }
+
+        public static PackageSearchMetadataBuilder FromMetadata(IPackageSearchMetadata metadata) { throw null; }
+
+        public PackageSearchMetadataBuilder WithDeprecation(Common.AsyncLazy<PackageDeprecationMetadata> lazyDeprecationFactory) { throw null; }
+
+        public PackageSearchMetadataBuilder WithVersions(Common.AsyncLazy<System.Collections.Generic.IEnumerable<VersionInfo>> lazyVersionsFactory) { throw null; }
+
+        public partial class ClonedPackageSearchMetadata : IPackageSearchMetadata
+        {
+            public ClonedPackageSearchMetadata() { }
+
+            public string Authors { get { throw null; } set { } }
+
+            public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } set { } }
+
+            public string Description { get { throw null; } set { } }
+
+            public long? DownloadCount { get { throw null; } set { } }
+
+            public System.Uri IconUrl { get { throw null; } set { } }
+
+            public Packaging.Core.PackageIdentity Identity { get { throw null; } set { } }
+
+            public bool IsListed { get { throw null; } set { } }
+
+            public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+            public System.Uri LicenseUrl { get { throw null; } set { } }
+
+            public string Owners { get { throw null; } set { } }
+
+            public System.Uri PackageDetailsUrl { get { throw null; } set { } }
+
+            public string PackagePath { get { throw null; } set { } }
+
+            [System.Obsolete("PackagePath is recommended in place of PackageReader")]
+            public System.Func<Packaging.PackageReaderBase> PackageReader { get { throw null; } set { } }
+
+            public bool PrefixReserved { get { throw null; } set { } }
+
+            public System.Uri ProjectUrl { get { throw null; } set { } }
+
+            public System.DateTimeOffset? Published { get { throw null; } set { } }
+
+            public System.Uri ReadmeUrl { get { throw null; } set { } }
+
+            public System.Uri ReportAbuseUrl { get { throw null; } set { } }
+
+            public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+            public string Summary { get { throw null; } set { } }
+
+            public string Tags { get { throw null; } set { } }
+
+            public string Title { get { throw null; } set { } }
+
+            public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } set { } }
+
+            public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+            public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>> GetVersionsAsync() { throw null; }
+        }
+    }
+
+    public static partial class PackageSearchMetadataExtensions
+    {
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Collections.Generic.IEnumerable<VersionInfo> versions) { throw null; }
+
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<VersionInfo>> valueFactory) { throw null; }
+
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>>> asyncValueFactory) { throw null; }
+    }
+
+    public abstract partial class PackageSearchResource : INuGetResource
+    {
+        protected PackageSearchResource() { }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial class PackageUpdateResource : INuGetResource
+    {
+        public PackageUpdateResource(string source, HttpSource httpSource) { }
+
+        public Configuration.ISettings Settings { get { throw null; } set { } }
+
+        public System.Uri SourceUri { get { throw null; } }
+
+        public System.Threading.Tasks.Task Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, Common.ILogger log) { throw null; }
+
+        public static void ForceDeleteDirectory(string path) { }
+
+        public System.Threading.Tasks.Task Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, Common.ILogger log) { throw null; }
+
+        [System.Obsolete("Consolidating to one PackageUpdateResource.Push method which has all parameters defined.")]
+        public System.Threading.Tasks.Task Push(string packagePath, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, Common.ILogger log) { throw null; }
+
+        [System.Obsolete("Use Push method which takes multiple package paths.")]
+        public System.Threading.Tasks.Task Push(string packagePath, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, Common.ILogger log) { throw null; }
+    }
+
+    public sealed partial class PluginFindPackageByIdResource : FindPackageByIdResource
+    {
+        public PluginFindPackageByIdResource(Plugins.IPlugin plugin, Plugins.IPluginMulticlientUtilities utilities, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginResource : INuGetResource
+    {
+        public PluginResource(System.Collections.Generic.IEnumerable<Plugins.PluginCreationResult> pluginCreationResults, Configuration.PackageSource packageSource, Configuration.ICredentialService credentialService) { }
+
+        public System.Threading.Tasks.Task<GetPluginResult> GetPluginAsync(Plugins.OperationClaim requiredClaim, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public sealed partial class GetPluginResult
+        {
+            public Plugins.IPlugin Plugin { get { throw null; } }
+
+            public Plugins.IPluginMulticlientUtilities PluginMulticlientUtilities { get { throw null; } }
+        }
+    }
+
+    public partial class PluginResourceProvider : ResourceProvider
+    {
+        public PluginResourceProvider() : base(default!) { }
+
+        public PluginResourceProvider(Plugins.IPluginManager pluginManager) : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteSourceDependencyInfo : System.IEquatable<RemoteSourceDependencyInfo>
+    {
+        public RemoteSourceDependencyInfo(Packaging.Core.PackageIdentity identity, bool listed, System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> dependencyGroups, string contentUri) { }
+
+        public string ContentUri { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool Listed { get { throw null; } }
+
+        public bool Equals(RemoteSourceDependencyInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class Repository
+    {
+        public static RepositoryFactory Factory { get { throw null; } }
+
+        public static ProviderFactory Provider { get { throw null; } set { } }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public static ISourceRepositoryProvider CreateProvider(System.Collections.Generic.IEnumerable<INuGetResourceProvider> resourceProviders, string rootPath) { throw null; }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public static ISourceRepositoryProvider CreateProvider(System.Collections.Generic.IEnumerable<INuGetResourceProvider> resourceProviders) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, Configuration.PackageSource source) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, string sourceUrl, FeedType type) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, string sourceUrl) { throw null; }
+
+        public partial class ProviderFactory
+        {
+            public ProviderFactory() { }
+
+            public virtual System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> GetCoreV3() { throw null; }
+        }
+
+        public partial class RepositoryFactory
+        {
+            public RepositoryFactory() { }
+        }
+    }
+
+    public abstract partial class ResourceProvider : INuGetResourceProvider
+    {
+        public ResourceProvider(System.Type resourceType, string name, System.Collections.Generic.IEnumerable<string> before, System.Collections.Generic.IEnumerable<string> after) { }
+
+        public ResourceProvider(System.Type resourceType, string name, string before) { }
+
+        public ResourceProvider(System.Type resourceType, string name) { }
+
+        public ResourceProvider(System.Type resourceType) { }
+
+        public virtual System.Collections.Generic.IEnumerable<string> After { get { throw null; } }
+
+        public virtual System.Collections.Generic.IEnumerable<string> Before { get { throw null; } }
+
+        public virtual string Name { get { throw null; } }
+
+        public virtual System.Type ResourceType { get { throw null; } }
+
+        public abstract System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken token);
+    }
+
+    public partial class RetriableProtocolException : NuGetProtocolException
+    {
+        public RetriableProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public RetriableProtocolException(string message) : base(default!) { }
+    }
+
+    public partial class SearchFilter
+    {
+        public SearchFilter(bool includePrerelease, SearchFilterType? filter) { }
+
+        public SearchFilter(bool includePrerelease) { }
+
+        public SearchFilterType? Filter { get { throw null; } }
+
+        public bool IncludeDelisted { get { throw null; } set { } }
+
+        public bool IncludePrerelease { get { throw null; } }
+
+        public SearchOrderBy? OrderBy { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> PackageTypes { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> SupportedFrameworks { get { throw null; } set { } }
+    }
+
+    public enum SearchFilterType
+    {
+        IsLatestVersion = 0,
+        IsAbsoluteLatestVersion = 1
+    }
+
+    public enum SearchOrderBy
+    {
+        Id = 0
+    }
+
+    public partial class SourceCacheContext : System.IDisposable
+    {
+        public SourceCacheContext() { }
+
+        public bool DirectDownload { get { throw null; } set { } }
+
+        public virtual string GeneratedTempFolder { get { throw null; } set { } }
+
+        public bool IgnoreFailedSources { get { throw null; } set { } }
+
+        public System.DateTimeOffset? MaxAge { get { throw null; } set { } }
+
+        public System.TimeSpan MaxAgeTimeSpan { get { throw null; } }
+
+        public bool NoCache { get { throw null; } set { } }
+
+        public bool RefreshMemoryCache { get { throw null; } set { } }
+
+        public System.Guid SessionId { get { throw null; } set { } }
+
+        public virtual SourceCacheContext Clone() { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public virtual SourceCacheContext WithRefreshCacheTrue() { throw null; }
+    }
+
+    public partial class SourcePackageDependencyInfo : Packaging.Core.PackageDependencyInfo
+    {
+        public SourcePackageDependencyInfo(Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source, System.Uri downloadUri, string packageHash) : base(identity, dependencies) { }
+
+        public SourcePackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source, System.Uri downloadUri, string packageHash) : base(id, version) { }
+
+        public SourcePackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source) : base(id, version) { }
+
+        public System.Uri DownloadUri { get { throw null; } }
+
+        public bool Listed { get { throw null; } }
+
+        public string PackageHash { get { throw null; } }
+
+        public SourceRepository Source { get { throw null; } }
+    }
+
+    public partial class SourceRepository
+    {
+        protected SourceRepository() { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<INuGetResourceProvider> providers) { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> providers, FeedType feedTypeOverride) { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> providers) { }
+
+        public FeedType FeedTypeOverride { get { throw null; } }
+
+        public virtual Configuration.PackageSource PackageSource { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task<FeedType> GetFeedType(System.Threading.CancellationToken token) { throw null; }
+
+        public virtual T GetResource<T>()
+            where T : class, INuGetResource { throw null; }
+
+        public virtual T GetResource<T>(System.Threading.CancellationToken token)
+            where T : class, INuGetResource { throw null; }
+
+        public virtual System.Threading.Tasks.Task<T> GetResourceAsync<T>()
+            where T : class, INuGetResource { throw null; }
+
+        public virtual System.Threading.Tasks.Task<T> GetResourceAsync<T>(System.Threading.CancellationToken token)
+            where T : class, INuGetResource { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class SourceRepositoryProvider : ISourceRepositoryProvider
+    {
+        public SourceRepositoryProvider(Configuration.IPackageSourceProvider packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders) { }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public SourceRepositoryProvider(Configuration.ISettings settings, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders) { }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider { get { throw null; } }
+
+        public SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public SourceRepository CreateRepository(Configuration.PackageSource source) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<SourceRepository> GetRepositories() { throw null; }
+    }
+
+    public partial class SymbolPackageUpdateResourceV3 : INuGetResource
+    {
+        public SymbolPackageUpdateResourceV3(string source, HttpSource httpSource) { }
+
+        public System.Uri SourceUri { get { throw null; } }
+    }
+
+    public static partial class UserAgent
+    {
+        public static string UserAgentString { get { throw null; } }
+
+        public static void SetUserAgent(System.Net.Http.HttpClient client) { }
+
+        public static void SetUserAgentString(UserAgentStringBuilder builder) { }
+    }
+
+    public partial class UserAgentStringBuilder
+    {
+        public static readonly string DefaultNuGetClientName;
+        public UserAgentStringBuilder() { }
+
+        public UserAgentStringBuilder(string clientName) { }
+
+        public string NuGetClientVersion { get { throw null; } }
+
+        public string Build() { throw null; }
+
+        public UserAgentStringBuilder WithOSDescription(string osInfo) { throw null; }
+
+        public UserAgentStringBuilder WithVisualStudioSKU(string vsInfo) { throw null; }
+    }
+
+    public partial class VersionInfo
+    {
+        public VersionInfo(Versioning.NuGetVersion version, long? downloadCount) { }
+
+        public VersionInfo(Versioning.NuGetVersion version, string downloadCount) { }
+
+        public VersionInfo(Versioning.NuGetVersion version) { }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public IPackageSearchMetadata PackageSearchMetadata { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+    }
+}
+
+namespace NuGet.Protocol.Events
+{
+    public sealed partial class ProtocolDiagnosticHttpEvent : ProtocolDiagnosticHttpEventBase
+    {
+        internal ProtocolDiagnosticHttpEvent() : base(default!) { }
+
+        public long Bytes { get { throw null; } }
+
+        public System.TimeSpan EventDuration { get { throw null; } }
+
+        public bool IsSuccess { get { throw null; } }
+
+        public System.DateTime Timestamp { get { throw null; } }
+    }
+
+    public abstract partial class ProtocolDiagnosticHttpEventBase
+    {
+        protected ProtocolDiagnosticHttpEventBase(ProtocolDiagnosticHttpEventBase other) { }
+
+        protected ProtocolDiagnosticHttpEventBase(string source, System.Uri url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) { }
+
+        public System.TimeSpan? HeaderDuration { get { throw null; } }
+
+        public int? HttpStatusCode { get { throw null; } }
+
+        public bool IsCancelled { get { throw null; } }
+
+        public bool IsLastAttempt { get { throw null; } }
+
+        public bool IsRetry { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Uri Url { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolDiagnosticNupkgCopiedEvent
+    {
+        public ProtocolDiagnosticNupkgCopiedEvent(string source, long fileSize) { }
+
+        public long FileSize { get { throw null; } }
+
+        public string Source { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolDiagnosticResourceEvent
+    {
+        public ProtocolDiagnosticResourceEvent(string source, string resourceType, string type, string method, System.TimeSpan duration) { }
+
+        public System.TimeSpan Duration { get { throw null; } }
+
+        public string Method { get { throw null; } }
+
+        public string ResourceType { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public string Type { get { throw null; } }
+    }
+
+    public static partial class ProtocolDiagnostics
+    {
+        public static event ProtocolDiagnosticHttpEventHandler HttpEvent { add { } remove { } }
+
+        public static event ProtocolDiagnosticsNupkgCopiedEventHandler NupkgCopiedEvent { add { } remove { } }
+
+        public static event ProtocolDiagnosticResourceEventHandler ResourceEvent { add { } remove { } }
+
+        public delegate void ProtocolDiagnosticHttpEventHandler(ProtocolDiagnosticHttpEvent pdEvent);
+        public delegate void ProtocolDiagnosticResourceEventHandler(ProtocolDiagnosticResourceEvent pdrEvent);
+        public delegate void ProtocolDiagnosticsNupkgCopiedEventHandler(ProtocolDiagnosticNupkgCopiedEvent ncEvent);
+    }
+}
+
+namespace NuGet.Protocol.LocalRepositories
+{
+    public partial class LocalPackageListResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+}
+
+namespace NuGet.Protocol.Plugins
+{
+    public sealed partial class AutomaticProgressReporter : System.IDisposable
+    {
+        public static AutomaticProgressReporter Create(IConnection connection, Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class CloseRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public CloseRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class Connection : IConnection, System.IDisposable
+    {
+        public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options) { }
+
+        public IMessageDispatcher MessageDispatcher { get { throw null; } }
+
+        public ConnectionOptions Options { get { throw null; } }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        public ConnectionState State { get { throw null; } }
+
+        public event System.EventHandler<ProtocolErrorEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<MessageEventArgs> MessageReceived { add { } remove { } }
+
+        public void Close() { }
+
+        public System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class { throw null; }
+    }
+
+    public sealed partial class ConnectionOptions
+    {
+        public ConnectionOptions(Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) { }
+
+        public System.TimeSpan HandshakeTimeout { get { throw null; } }
+
+        public Versioning.SemanticVersion MinimumProtocolVersion { get { throw null; } }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } }
+
+        public static ConnectionOptions CreateDefault(Common.IEnvironmentVariableReader reader = null) { throw null; }
+
+        public void SetRequestTimeout(System.TimeSpan requestTimeout) { }
+    }
+
+    public enum ConnectionState
+    {
+        FailedToHandshake = 0,
+        Closing = 1,
+        Closed = 2,
+        ReadyToConnect = 3,
+        Connecting = 4,
+        Handshaking = 5,
+        Connected = 6
+    }
+
+    public sealed partial class CopyFilesInPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion, System.Collections.Generic.IEnumerable<string> filesInPackage, string destinationFolderPath) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string DestinationFolderPath { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Collections.Generic.IEnumerable<string> FilesInPackage { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class CopyFilesInPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyFilesInPackageResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> copiedFiles) { }
+
+        public System.Collections.Generic.IEnumerable<string> CopiedFiles { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class CopyNupkgFileRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string DestinationFilePath { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class CopyNupkgFileResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyNupkgFileResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public abstract partial class EmbeddedSignatureVerifier
+    {
+        protected EmbeddedSignatureVerifier() { }
+
+        public static EmbeddedSignatureVerifier Create() { throw null; }
+
+        public abstract bool IsValid(string filePath);
+    }
+
+    public sealed partial class FallbackEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public FallbackEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+
+    public sealed partial class Fault
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Fault(string message) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Message { get { throw null; } }
+    }
+
+    public sealed partial class FaultedPluginEventArgs : System.EventArgs
+    {
+        public FaultedPluginEventArgs(IPlugin plugin, System.Exception exception) { }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public IPlugin Plugin { get { throw null; } }
+    }
+
+    public sealed partial class GetAuthenticationCredentialsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool CanShowDialog { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool IsNonInteractive { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool IsRetry { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Uri Uri { get { throw null; } }
+    }
+
+    public sealed partial class GetAuthenticationCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetAuthenticationCredentialsResponse(string username, string password, string message, System.Collections.Generic.IList<string> authenticationTypes, MessageResponseCode responseCode) { }
+
+        public System.Collections.Generic.IList<string> AuthenticationTypes { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public string Username { get { throw null; } }
+
+        public bool IsValid() { throw null; }
+    }
+
+    public sealed partial class GetCredentialsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Net.HttpStatusCode StatusCode { get { throw null; } }
+    }
+
+    public sealed partial class GetCredentialsRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public GetCredentialsRequestHandler(IPlugin plugin, System.Net.IWebProxy proxy, Configuration.ICredentialService credentialService) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void AddOrUpdateSourceRepository(Core.Types.SourceRepository sourceRepository) { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class GetCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetCredentialsResponse(MessageResponseCode responseCode, string username, string password, System.Collections.Generic.IReadOnlyList<string> authenticationTypes = null) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> AuthenticationTypes { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public string Username { get { throw null; } }
+    }
+
+    public sealed partial class GetFilesInPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class GetFilesInPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetFilesInPackageResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> files) { }
+
+        public System.Collections.Generic.IEnumerable<string> Files { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class GetOperationClaimsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetOperationClaimsRequest(string packageSourceRepository, Newtonsoft.Json.Linq.JObject serviceIndex) { }
+
+        public string PackageSourceRepository { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject ServiceIndex { get { throw null; } }
+    }
+
+    public sealed partial class GetOperationClaimsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<OperationClaim> claims) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> Claims { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageHashRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageHashRequest(string packageSourceRepository, string packageId, string packageVersion, string hashAlgorithm) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string HashAlgorithm { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageHashResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageHashResponse(MessageResponseCode responseCode, string hash) { }
+
+        public string Hash { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageVersionsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageVersionsRequest(string packageSourceRepository, string packageId) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageVersionsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageVersionsResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> versions) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Versions { get { throw null; } }
+    }
+
+    public sealed partial class GetServiceIndexRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetServiceIndexRequest(string packageSourceRepository) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+    }
+
+    public sealed partial class GetServiceIndexRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public GetServiceIndexRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void AddOrUpdateSourceRepository(Core.Types.SourceRepository sourceRepository) { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class GetServiceIndexResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetServiceIndexResponse(MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject serviceIndex) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject ServiceIndex { get { throw null; } }
+    }
+
+    public sealed partial class HandshakeRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public HandshakeRequest(Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Versioning.SemanticVersion MinimumProtocolVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+    }
+
+    public sealed partial class HandshakeResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public HandshakeResponse(MessageResponseCode responseCode, Versioning.SemanticVersion protocolVersion) { }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public partial interface IConnection : System.IDisposable
+    {
+        IMessageDispatcher MessageDispatcher { get; }
+
+        ConnectionOptions Options { get; }
+
+        Versioning.SemanticVersion ProtocolVersion { get; }
+
+        event System.EventHandler<ProtocolErrorEventArgs> Faulted;
+        event System.EventHandler<MessageEventArgs> MessageReceived;
+        void Close();
+        System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class;
+    }
+
+    public partial interface IIdGenerator
+    {
+        string GenerateUniqueId();
+    }
+
+    public partial interface IMessageDispatcher : System.IDisposable
+    {
+        IRequestHandlers RequestHandlers { get; }
+
+        void Close();
+        Message CreateMessage(MessageType type, MessageMethod method);
+        Message CreateMessage<TPayload>(MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class;
+        System.Threading.Tasks.Task DispatchCancelAsync(Message request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task DispatchFaultAsync(Message request, Fault fault, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task DispatchProgressAsync(Message request, Progress progress, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class;
+        System.Threading.Tasks.Task DispatchResponseAsync<TOutbound>(Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class;
+        void SetConnection(IConnection connection);
+    }
+
+    public sealed partial class InboundRequestContext : System.IDisposable
+    {
+        public InboundRequestContext(IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) { }
+
+        public string RequestId { get { throw null; } }
+
+        public void BeginFaultAsync(Message request, System.Exception exception) { }
+
+        public void BeginResponseAsync(Message request, IRequestHandler requestHandler, IResponseHandler responseHandler) { }
+
+        public void Cancel() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class InitializeRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public InitializeRequest(string clientVersion, string culture, System.TimeSpan requestTimeout) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string ClientVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Culture { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.TimeSpan RequestTimeout { get { throw null; } }
+    }
+
+    public sealed partial class InitializeResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public InitializeResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public partial interface IPlugin : System.IDisposable
+    {
+        IConnection Connection { get; }
+
+        string FilePath { get; }
+
+        string Id { get; }
+
+        string Name { get; }
+
+        event System.EventHandler BeforeClose;
+        event System.EventHandler Closed;
+        void Close();
+    }
+
+    public partial interface IPluginDiscoverer : System.IDisposable
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> DiscoverAsync(System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginFactory : System.IDisposable
+    {
+        System.Threading.Tasks.Task<IPlugin> GetOrCreateAsync(string filePath, System.Collections.Generic.IEnumerable<string> arguments, IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken);
+    }
+
+    public partial interface IPluginManager
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginCreationResult>> CreatePluginsAsync(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginMulticlientUtilities
+    {
+        System.Threading.Tasks.Task DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginProcess : System.IDisposable
+    {
+        int? ExitCode { get; }
+
+        int? Id { get; }
+
+        event System.EventHandler<IPluginProcess> Exited;
+        event System.EventHandler<LineReadEventArgs> LineRead;
+        void BeginReadLine();
+        void CancelRead();
+        void Kill();
+    }
+
+    public partial interface IReceiver : System.IDisposable
+    {
+        event System.EventHandler<ProtocolErrorEventArgs> Faulted;
+        event System.EventHandler<MessageEventArgs> MessageReceived;
+        void Close();
+        void Connect();
+    }
+
+    public partial interface IRequestHandler
+    {
+        System.Threading.CancellationToken CancellationToken { get; }
+
+        System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IRequestHandlers
+    {
+        void AddOrUpdate(MessageMethod method, System.Func<IRequestHandler> addHandlerFunc, System.Func<IRequestHandler, IRequestHandler> updateHandlerFunc);
+        bool TryAdd(MessageMethod method, IRequestHandler handler);
+        bool TryGet(MessageMethod method, out IRequestHandler handler);
+        bool TryRemove(MessageMethod method);
+    }
+
+    public partial interface IResponseHandler
+    {
+        System.Threading.Tasks.Task SendResponseAsync<TPayload>(Message request, TPayload payload, System.Threading.CancellationToken cancellationToken)
+            where TPayload : class;
+    }
+
+    public partial interface ISender : System.IDisposable
+    {
+        void Close();
+        void Connect();
+        System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public static partial class JsonSerializationUtilities
+    {
+        public static Newtonsoft.Json.JsonSerializer Serializer { get { throw null; } }
+
+        public static T Deserialize<T>(string json)
+            where T : class { throw null; }
+
+        public static Newtonsoft.Json.Linq.JObject FromObject(object value) { throw null; }
+
+        public static void Serialize(Newtonsoft.Json.JsonWriter writer, object value) { }
+
+        public static T ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) { throw null; }
+    }
+
+    public sealed partial class LineReadEventArgs : System.EventArgs
+    {
+        public LineReadEventArgs(string line) { }
+
+        public string Line { get { throw null; } }
+    }
+
+    public sealed partial class LogRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public LogRequest(Common.LogLevel logLevel, string message) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Common.LogLevel LogLevel { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Message { get { throw null; } }
+    }
+
+    public sealed partial class LogRequestHandler : IRequestHandler
+    {
+        public LogRequestHandler(Common.ILogger logger) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public static Common.LogLevel GetLogLevel(Common.ILogger logger) { throw null; }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetLogger(Common.ILogger logger) { }
+    }
+
+    public sealed partial class LogResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public LogResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class Message
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Message(string requestId, MessageType type, MessageMethod method, Newtonsoft.Json.Linq.JObject payload = null) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageMethod Method { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject Payload { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string RequestId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageType Type { get { throw null; } }
+    }
+
+    public sealed partial class MessageDispatcher : IMessageDispatcher, System.IDisposable, IResponseHandler
+    {
+        public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator) { }
+
+        public IRequestHandlers RequestHandlers { get { throw null; } }
+
+        public void Close() { }
+
+        public Message CreateMessage(MessageType type, MessageMethod method) { throw null; }
+
+        public Message CreateMessage<TPayload>(MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class { throw null; }
+
+        public System.Threading.Tasks.Task DispatchCancelAsync(Message request, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task DispatchFaultAsync(Message request, Fault fault, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task DispatchProgressAsync(Message request, Progress progress, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class { throw null; }
+
+        public System.Threading.Tasks.Task DispatchResponseAsync<TOutbound>(Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class { throw null; }
+
+        public void Dispose() { }
+
+        System.Threading.Tasks.Task IResponseHandler.SendResponseAsync<TPayload>(Message request, TPayload payload, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetConnection(IConnection connection) { }
+    }
+
+    public sealed partial class MessageEventArgs : System.EventArgs
+    {
+        public MessageEventArgs(Message message) { }
+
+        public Message Message { get { throw null; } }
+    }
+
+    public enum MessageMethod
+    {
+        None = 0,
+        Close = 1,
+        CopyFilesInPackage = 2,
+        CopyNupkgFile = 3,
+        GetCredentials = 4,
+        GetFilesInPackage = 5,
+        GetOperationClaims = 6,
+        GetPackageHash = 7,
+        GetPackageVersions = 8,
+        GetServiceIndex = 9,
+        Handshake = 10,
+        Initialize = 11,
+        Log = 12,
+        MonitorNuGetProcessExit = 13,
+        PrefetchPackage = 14,
+        SetCredentials = 15,
+        SetLogLevel = 16,
+        GetAuthenticationCredentials = 17
+    }
+
+    public enum MessageResponseCode
+    {
+        Success = 0,
+        Error = 1,
+        NotFound = 2
+    }
+
+    public enum MessageType
+    {
+        Cancel = 0,
+        Fault = 1,
+        Progress = 2,
+        Request = 3,
+        Response = 4
+    }
+
+    public static partial class MessageUtilities
+    {
+        public static Message Create(string requestId, MessageType type, MessageMethod method) { throw null; }
+
+        public static Message Create<TPayload>(string requestId, MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class { throw null; }
+
+        public static TPayload DeserializePayload<TPayload>(Message message) { throw null; }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public MonitorNuGetProcessExitRequest(int processId) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public int ProcessId { get { throw null; } }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public MonitorNuGetProcessExitRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public MonitorNuGetProcessExitResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class NoOpDisposePlugin : IPlugin, System.IDisposable
+    {
+        public NoOpDisposePlugin(IPlugin plugin) { }
+
+        public IConnection Connection { get { throw null; } }
+
+        public string FilePath { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public event System.EventHandler BeforeClose { add { } remove { } }
+
+        public event System.EventHandler Closed { add { } remove { } }
+
+        public void Close() { }
+
+        public void Dispose() { }
+    }
+
+    public enum OperationClaim
+    {
+        DownloadPackage = 0,
+        Authentication = 1
+    }
+
+    public abstract partial class OutboundRequestContext : System.IDisposable
+    {
+        protected OutboundRequestContext() { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } protected set { } }
+
+        public string RequestId { get { throw null; } protected set { } }
+
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract void HandleCancelResponse();
+        public abstract void HandleFault(Message fault);
+        public abstract void HandleProgress(Message progress);
+        public abstract void HandleResponse(Message response);
+    }
+
+    public sealed partial class OutboundRequestContext<TResult> : OutboundRequestContext
+    {
+        public OutboundRequestContext(IConnection connection, Message request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) { }
+
+        public System.Threading.Tasks.Task<TResult> CompletionTask { get { throw null; } }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void HandleCancelResponse() { }
+
+        public override void HandleFault(Message fault) { }
+
+        public override void HandleProgress(Message progress) { }
+
+        public override void HandleResponse(Message response) { }
+    }
+
+    public sealed partial class Plugin : IPlugin, System.IDisposable
+    {
+        public Plugin(string filePath, IConnection connection, IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) { }
+
+        public IConnection Connection { get { throw null; } }
+
+        public string FilePath { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public event System.EventHandler BeforeClose { add { } remove { } }
+
+        public event System.EventHandler Closed { add { } remove { } }
+
+        public event System.EventHandler<PluginEventArgs> Exited { add { } remove { } }
+
+        public event System.EventHandler<FaultedPluginEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<PluginEventArgs> Idle { add { } remove { } }
+
+        public void Close() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class PluginCacheEntry
+    {
+        public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey) { }
+
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> OperationClaims { get { throw null; } set { } }
+
+        public void LoadFromFile() { }
+
+        public System.Threading.Tasks.Task UpdateCacheFileAsync() { throw null; }
+    }
+
+    public static partial class PluginConstants
+    {
+        public static readonly System.TimeSpan CloseTimeout;
+        public static readonly System.TimeSpan IdleTimeout;
+        public static readonly System.Collections.Generic.IEnumerable<string> PluginArguments;
+        public static readonly System.TimeSpan ProgressInterval;
+        public static readonly System.TimeSpan RequestTimeout;
+    }
+
+    public sealed partial class PluginCreationResult
+    {
+        public PluginCreationResult(IPlugin plugin, IPluginMulticlientUtilities utilities, System.Collections.Generic.IReadOnlyList<OperationClaim> claims) { }
+
+        public PluginCreationResult(string message, System.Exception exception) { }
+
+        public PluginCreationResult(string message) { }
+
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> Claims { get { throw null; } }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public IPlugin Plugin { get { throw null; } }
+
+        public IPluginMulticlientUtilities PluginMulticlientUtilities { get { throw null; } }
+    }
+
+    public sealed partial class PluginDiscoverer : IPluginDiscoverer, System.IDisposable
+    {
+        public PluginDiscoverer(string rawPluginPaths, EmbeddedSignatureVerifier verifier) { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> DiscoverAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class PluginDiscoveryResult
+    {
+        public PluginDiscoveryResult(PluginFile pluginFile) { }
+
+        public string Message { get { throw null; } }
+
+        public PluginFile PluginFile { get { throw null; } }
+    }
+
+    public static partial class PluginDiscoveryUtility
+    {
+        public static System.Lazy<string> InternalPluginDiscoveryRoot { get { throw null; } set { } }
+
+        public static System.Collections.Generic.IEnumerable<string> GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) { throw null; }
+
+        public static string GetNuGetHomePluginsPath() { throw null; }
+
+        public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath) { throw null; }
+    }
+
+    public sealed partial class PluginEventArgs : System.EventArgs
+    {
+        public PluginEventArgs(IPlugin plugin) { }
+
+        public IPlugin Plugin { get { throw null; } }
+    }
+
+    public sealed partial class PluginException : System.Exception
+    {
+        public PluginException(string message, System.Exception innerException) { }
+
+        public PluginException(string message) { }
+    }
+
+    public sealed partial class PluginFactory : IPluginFactory, System.IDisposable
+    {
+        public PluginFactory(System.TimeSpan pluginIdleTimeout) { }
+
+        public static System.Threading.Tasks.Task<IPlugin> CreateFromCurrentProcessAsync(IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<IPlugin> GetOrCreateAsync(string filePath, System.Collections.Generic.IEnumerable<string> arguments, IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginFile
+    {
+        public PluginFile(string filePath, System.Lazy<PluginFileState> state) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Lazy<PluginFileState> State { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum PluginFileState
+    {
+        Valid = 0,
+        NotFound = 1,
+        InvalidFilePath = 2,
+        InvalidEmbeddedSignature = 3
+    }
+
+    public sealed partial class PluginManager : IPluginManager, System.IDisposable
+    {
+        public PluginManager(Common.IEnvironmentVariableReader reader, System.Lazy<IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, IPluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) { }
+
+        public Common.IEnvironmentVariableReader EnvironmentVariableReader { get { throw null; } }
+
+        public static IPluginManager Instance { get { throw null; } }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginCreationResult>> CreatePluginsAsync(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginMulticlientUtilities : IPluginMulticlientUtilities
+    {
+        public PluginMulticlientUtilities() { }
+
+        public System.Threading.Tasks.Task DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginPackageDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public PluginPackageDownloader(IPlugin plugin, Packaging.Core.PackageIdentity packageIdentity, PluginPackageReader packageReader, string packageSourceRepository) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public sealed partial class PluginPackageReader : Packaging.PackageReaderBase
+    {
+        public PluginPackageReader(IPlugin plugin, Packaging.Core.PackageIdentity packageIdentity, string packageSourceRepository) : base(default!) { }
+
+        public override Packaging.NuspecReader NuspecReader { get { throw null; } }
+
+        public override bool CanVerifySignedPackages(Packaging.Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Packaging.Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Packaging.Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetBuildItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetContentItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override bool GetDevelopmentDependency() { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetFrameworkItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override Packaging.Core.PackageIdentity GetIdentity() { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.Core.PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetItems(string folderName) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetLibItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public override System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.IO.Stream GetNuspec() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override string GetNuspecFile() { throw null; }
+
+        public override System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.NuspecReader> GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> GetPackageDependencies() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> GetPackageTypes() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetReferenceItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetSupportedFrameworks() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework>> GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetToolItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override bool IsServiceable() { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsServiceableAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Packaging.Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class PluginProcess : IPluginProcess, System.IDisposable
+    {
+        public PluginProcess() { }
+
+        public PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) { }
+
+        public int? ExitCode { get { throw null; } }
+
+        public int? Id { get { throw null; } }
+
+        public event System.EventHandler<IPluginProcess> Exited { add { } remove { } }
+
+        public event System.EventHandler<LineReadEventArgs> LineRead { add { } remove { } }
+
+        public void BeginReadLine() { }
+
+        public void CancelRead() { }
+
+        public void Dispose() { }
+
+        public void Kill() { }
+
+        public void Start() { }
+    }
+
+    public sealed partial class PrefetchPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public PrefetchPackageRequest(string packageSourceRepository, string packageId, string packageVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class PrefetchPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public PrefetchPackageResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class Progress
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Progress(double? percentage = null) { }
+
+        public double? Percentage { get { throw null; } }
+    }
+
+    public static partial class ProtocolConstants
+    {
+        public static readonly Versioning.SemanticVersion CurrentVersion;
+        public static readonly System.TimeSpan HandshakeTimeout;
+        public static readonly System.TimeSpan MaxTimeout;
+        public static readonly System.TimeSpan MinTimeout;
+        public static readonly System.TimeSpan RequestTimeout;
+        public static readonly Versioning.SemanticVersion Version100;
+    }
+
+    public sealed partial class ProtocolErrorEventArgs : System.EventArgs
+    {
+        public ProtocolErrorEventArgs(System.Exception exception, Message message) { }
+
+        public ProtocolErrorEventArgs(System.Exception exception) { }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public Message Message { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolException : System.Exception
+    {
+        public ProtocolException(string message, System.Exception innerException) { }
+
+        public ProtocolException(string message) { }
+    }
+
+    public abstract partial class Receiver : IReceiver, System.IDisposable
+    {
+        protected Receiver() { }
+
+        protected bool IsClosed { get { throw null; } }
+
+        protected bool IsDisposed { get { throw null; } set { } }
+
+        public event System.EventHandler<ProtocolErrorEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<MessageEventArgs> MessageReceived { add { } remove { } }
+
+        public virtual void Close() { }
+
+        public abstract void Connect();
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        protected void FireFaultEvent(System.Exception exception, Message message) { }
+
+        protected void FireMessageReceivedEvent(Message message) { }
+
+        protected void ThrowIfClosed() { }
+
+        protected void ThrowIfDisposed() { }
+    }
+
+    public sealed partial class RequestHandlers : IRequestHandlers
+    {
+        public RequestHandlers() { }
+
+        public void AddOrUpdate(MessageMethod method, System.Func<IRequestHandler> addHandlerFunc, System.Func<IRequestHandler, IRequestHandler> updateHandlerFunc) { }
+
+        public bool TryAdd(MessageMethod method, IRequestHandler handler) { throw null; }
+
+        public bool TryGet(MessageMethod method, out IRequestHandler handler) { throw null; }
+
+        public bool TryRemove(MessageMethod method) { throw null; }
+    }
+
+    public sealed partial class RequestIdGenerator : IIdGenerator
+    {
+        public RequestIdGenerator() { }
+
+        public string GenerateUniqueId() { throw null; }
+    }
+
+    public sealed partial class Sender : ISender, System.IDisposable
+    {
+        public Sender(System.IO.TextWriter writer) { }
+
+        public void Close() { }
+
+        public void Connect() { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class SetCredentialsRequest
+    {
+        public SetCredentialsRequest(string packageSourceRepository, string proxyUsername, string proxyPassword, string username, string password) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        public string ProxyPassword { get { throw null; } }
+
+        public string ProxyUsername { get { throw null; } }
+
+        public string Username { get { throw null; } }
+    }
+
+    public sealed partial class SetCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetCredentialsResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class SetLogLevelRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetLogLevelRequest(Common.LogLevel logLevel) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Common.LogLevel LogLevel { get { throw null; } }
+    }
+
+    public sealed partial class SetLogLevelResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetLogLevelResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class StandardInputReceiver : Receiver
+    {
+        public StandardInputReceiver(System.IO.TextReader reader) { }
+
+        public override void Connect() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class StandardOutputReceiver : Receiver
+    {
+        public StandardOutputReceiver(IPluginProcess process) { }
+
+        public override void Close() { }
+
+        public override void Connect() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class SymmetricHandshake : IRequestHandler, System.IDisposable
+    {
+        public SymmetricHandshake(IConnection connection, System.TimeSpan handshakeTimeout, Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Versioning.SemanticVersion> HandshakeAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public static partial class TimeoutUtilities
+    {
+        public static System.TimeSpan GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) { throw null; }
+
+        public static bool IsValid(System.TimeSpan timeout) { throw null; }
+    }
+
+    public partial class UnixAndMonoPlatformsEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public UnixAndMonoPlatformsEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+
+    public sealed partial class WindowsEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public WindowsEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+}
+
+namespace NuGet.Protocol.VisualStudio
+{
+    public static partial class FactoryExtensionsVS
+    {
+        public static System.Collections.Generic.IEnumerable<System.Lazy<Core.Types.INuGetResourceProvider>> GetVisualStudio(this Core.Types.Repository.ProviderFactory factory) { throw null; }
+
+        public static Core.Types.SourceRepository GetVisualStudio(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static Core.Types.SourceRepository GetVisualStudio(this Core.Types.Repository.RepositoryFactory factory, string source) { throw null; }
+    }
+}
+
+namespace NuGet.Repositories
+{
+    public partial class LocalPackageInfo
+    {
+        public LocalPackageInfo(string packageId, Versioning.NuGetVersion version, string path, string manifestPath, string zipPath, string sha512Path, System.Lazy<Packaging.NuspecReader> nuspec, System.Lazy<System.Collections.Generic.IReadOnlyList<string>> files, System.Lazy<string> sha512, System.Lazy<RuntimeModel.RuntimeGraph> runtimeGraph) { }
+
+        public string ExpandedPath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Files { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string ManifestPath { get { throw null; } }
+
+        public Packaging.NuspecReader Nuspec { get { throw null; } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } }
+
+        public string Sha512 { get { throw null; } }
+
+        public string Sha512Path { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public string ZipPath { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LocalPackageSourceInfo
+    {
+        public LocalPackageSourceInfo(NuGetv3LocalRepository repository, LocalPackageInfo package) { }
+
+        public LocalPackageInfo Package { get { throw null; } }
+
+        public NuGetv3LocalRepository Repository { get { throw null; } }
+    }
+
+    public partial class NuGetv3LocalRepository
+    {
+        public NuGetv3LocalRepository(string path, Protocol.LocalPackageFileCache packageFileCache, bool isFallbackFolder, bool updateLastAccessTime) { }
+
+        public NuGetv3LocalRepository(string path, Protocol.LocalPackageFileCache packageFileCache, bool isFallbackFolder) { }
+
+        public NuGetv3LocalRepository(string path) { }
+
+        public Packaging.VersionFolderPathResolver PathResolver { get { throw null; } }
+
+        public string RepositoryRoot { get { throw null; } }
+
+        public void ClearCacheForIds(System.Collections.Generic.IEnumerable<string> packageIds) { }
+
+        public bool Exists(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public LocalPackageInfo FindPackage(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string packageId) { throw null; }
+    }
+
+    public static partial class NuGetv3LocalRepositoryUtility
+    {
+        public static LocalPackageSourceInfo GetPackage(System.Collections.Generic.IReadOnlyList<NuGetv3LocalRepository> repositories, string id, Versioning.NuGetVersion version) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.protocol/6.2.2/lib/netstandard2.0/NuGet.Protocol.cs
+++ b/src/referencePackages/src/nuget.protocol/6.2.2/lib/netstandard2.0/NuGet.Protocol.cs
@@ -1,0 +1,4360 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Credentials.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Protocol.FuncTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Protocol.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.VisualStudio.Common.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.CommandLine.Xplat.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.PackageManagement.VisualStudio.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's implementation for interacting with feeds. Contains functionality for all feed types.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Protocol")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Protocol
+{
+    public partial class AlternatePackageMetadata
+    {
+        public AlternatePackageMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "range", ItemConverterType = typeof(VersionRangeConverter))]
+        public Versioning.VersionRange Range { get { throw null; } }
+    }
+
+    public partial class AmbientAuthenticationState
+    {
+        public AmbientAuthenticationState() { }
+
+        public int AuthenticationRetriesCount { get { throw null; } }
+
+        public bool IsBlocked { get { throw null; } }
+
+        public void Block() { }
+
+        public void Increment() { }
+    }
+
+    public partial class AutoCompleteResourceV2Feed : Core.Types.AutoCompleteResource
+    {
+        public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public AutoCompleteResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV3 : Core.Types.AutoCompleteResource
+    {
+        public AutoCompleteResourceV3(HttpSource client, ServiceIndexResourceV3 serviceIndex, RegistrationResourceV3 regResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class AutoCompleteResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public AutoCompleteResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class CachingSourceProvider : Core.Types.ISourceRepositoryProvider
+    {
+        public CachingSourceProvider(Configuration.IPackageSourceProvider packageSourceProvider) { }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider { get { throw null; } }
+
+        public void AddSourceRepository(Core.Types.SourceRepository source) { }
+
+        public Core.Types.SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public Core.Types.SourceRepository CreateRepository(Configuration.PackageSource source) { throw null; }
+
+        public Core.Types.SourceRepository CreateRepository(string source) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Core.Types.SourceRepository> GetRepositories() { throw null; }
+    }
+
+    public static partial class CachingUtility
+    {
+        public const int BufferSize = 8192;
+        public static string ComputeHash(string value, bool addIdentifiableCharacters = true) { throw null; }
+
+        public static bool IsFileAlreadyOpen(string filePath) { throw null; }
+
+        public static System.IO.Stream ReadCacheFile(System.TimeSpan maxAge, string cacheFile) { throw null; }
+
+        public static string RemoveInvalidFileNameChars(string value) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV2Feed : Core.Types.DependencyInfoResource
+    {
+        public DependencyInfoResourceV2Feed(V2FeedParser feedParser, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public DependencyInfoResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class DependencyInfoResourceV3 : Core.Types.DependencyInfoResource
+    {
+        public DependencyInfoResourceV3(HttpSource client, RegistrationResourceV3 regResource, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.RemoteSourceDependencyInfo>> ResolvePackages(string packageId, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DependencyInfoResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public DependencyInfoResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class DownloadResourcePlugin : Core.Types.DownloadResource
+    {
+        public DownloadResourcePlugin(Plugins.IPlugin plugin, Plugins.IPluginMulticlientUtilities utilities, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class DownloadResourcePluginProvider : Core.Types.ResourceProvider
+    {
+        public DownloadResourcePluginProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class DownloadResourceV2Feed : Core.Types.DownloadResource
+    {
+        public DownloadResourceV2Feed(V2FeedParser feedParser, string source) { }
+
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV2Feed(V2FeedParser feedParser) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public DownloadResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV3 : Core.Types.DownloadResource
+    {
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV3(HttpSource client, RegistrationResourceV3 regResource) { }
+
+        [System.Obsolete("Use constructor with source parameter")]
+        public DownloadResourceV3(HttpSource client, string packageBaseAddress) { }
+
+        public DownloadResourceV3(string source, HttpSource client, RegistrationResourceV3 regResource) { }
+
+        public DownloadResourceV3(string source, HttpSource client, string packageBaseAddress) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public DownloadResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class DownloadTimeoutStream : System.IO.Stream
+    {
+        public DownloadTimeoutStream(string downloadName, System.IO.Stream networkStream, System.TimeSpan timeout) { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanSeek { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override long Length { get { throw null; } }
+
+        public override long Position { get { throw null; } set { } }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) { throw null; }
+
+        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
+
+        public override void SetLength(long value) { }
+
+        public override void Write(byte[] buffer, int offset, int count) { }
+    }
+
+    public partial class DownloadTimeoutStreamContent : System.Net.Http.StreamContent
+    {
+        public DownloadTimeoutStreamContent(string downloadName, System.IO.Stream networkStream, System.TimeSpan timeout) : base(default!) { }
+    }
+
+    public static partial class FactoryExtensionsV3
+    {
+        public static Core.Types.SourceRepository GetCoreV2(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.Lazy<Core.Types.INuGetResourceProvider>> GetCoreV3(this Core.Types.Repository.ProviderFactory factory) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, string source, FeedType type) { throw null; }
+
+        public static Core.Types.SourceRepository GetCoreV3(this Core.Types.Repository.RepositoryFactory factory, string source) { throw null; }
+    }
+
+    public enum FeedType
+    {
+        Undefined = 0,
+        HttpV2 = 1,
+        HttpV3 = 2,
+        FileSystemV2 = 4,
+        FileSystemV3 = 8,
+        FileSystemUnzipped = 16,
+        FileSystemPackagesConfig = 32,
+        FileSystemUnknown = 1024
+    }
+
+    public partial class FeedTypePackageSource : Configuration.PackageSource
+    {
+        public FeedTypePackageSource(string source, FeedType feedType) : base(default!) { }
+
+        public FeedType FeedType { get { throw null; } }
+    }
+
+    public partial class FeedTypeResource : Core.Types.INuGetResource
+    {
+        public FeedTypeResource(FeedType feedType) { }
+
+        public FeedType FeedType { get { throw null; } }
+    }
+
+    public partial class FeedTypeResourceProvider : Core.Types.ResourceProvider
+    {
+        public FeedTypeResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class FeedTypeUtility
+    {
+        public static FeedType GetFeedType(Configuration.PackageSource packageSource) { throw null; }
+    }
+
+    public abstract partial class FindLocalPackagesResource : Core.Types.INuGetResource
+    {
+        protected FindLocalPackagesResource() { }
+
+        public string Root { get { throw null; } protected set { } }
+
+        public virtual bool Exists(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual bool Exists(string packageId, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token);
+        public abstract System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public partial class FindLocalPackagesResourcePackagesConfig : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourcePackagesConfig(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourcePackagesConfigProvider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourcePackagesConfigProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceUnzipped : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceUnzipped(string root) { }
+
+        public override bool Exists(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceUnzippedProvider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceUnzippedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV2 : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceV2(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceV2Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV3 : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourceV3(string root) { }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string id, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(Packaging.Core.PackageIdentity identity, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override LocalPackageInfo GetPackage(System.Uri path, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackages(Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindLocalPackagesResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public FindLocalPackagesResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FindPackagesByIdNupkgDownloader
+    {
+        public FindPackagesByIdNupkgDownloader(HttpSource httpSource) { }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(Packaging.Core.PackageIdentity identity, string url, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.NuspecReader> GetNuspecReaderFromNupkgAsync(Packaging.Core.PackageIdentity identity, string url, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class FingerprintsConverter : Newtonsoft.Json.JsonConverter
+    {
+        public FingerprintsConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public static partial class GetDownloadResultUtility
+    {
+        public static void CleanUpDirectDownloads(Core.Types.PackageDownloadContext downloadContext) { }
+
+        public static System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResultAsync(HttpSource client, Packaging.Core.PackageIdentity identity, System.Uri uri, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class GlobalPackagesFolderUtility
+    {
+        public static System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> AddPackageAsync(string source, Packaging.Core.PackageIdentity packageIdentity, System.IO.Stream packageStream, string globalPackagesFolder, System.Guid parentId, Packaging.Signing.ClientPolicyContext clientPolicyContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static Core.Types.DownloadResourceResult GetPackage(Packaging.Core.PackageIdentity packageIdentity, string globalPackagesFolder) { throw null; }
+    }
+
+    public partial class HttpCacheResult
+    {
+        public HttpCacheResult(System.TimeSpan maxAge, string newFile, string cacheFule) { }
+
+        public string CacheFile { get { throw null; } }
+
+        public System.TimeSpan MaxAge { get { throw null; } }
+
+        public string NewFile { get { throw null; } }
+
+        public System.IO.Stream Stream { get { throw null; } set { } }
+    }
+
+    public static partial class HttpCacheUtility
+    {
+        public static System.Threading.Tasks.Task CreateCacheFileAsync(HttpCacheResult result, System.Net.Http.HttpResponseMessage response, System.Action<System.IO.Stream> ensureValidContents, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static HttpCacheResult InitializeHttpCacheResult(string httpCacheDirectory, System.Uri sourceUri, string cacheKey, Core.Types.HttpSourceCacheContext context) { throw null; }
+    }
+
+    public partial class HttpFileSystemBasedFindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public HttpFileSystemBasedFindPackageByIdResource(System.Collections.Generic.IReadOnlyList<System.Uri> baseUris, HttpSource httpSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpFileSystemBasedFindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public HttpFileSystemBasedFindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpHandlerResourceV3 : Core.Types.HttpHandlerResource
+    {
+        public HttpHandlerResourceV3(System.Net.Http.HttpClientHandler clientHandler, System.Net.Http.HttpMessageHandler messageHandler) { }
+
+        public override System.Net.Http.HttpClientHandler ClientHandler { get { throw null; } }
+
+        public static System.Lazy<Configuration.ICredentialService> CredentialService { get { throw null; } set { } }
+
+        public static System.Action<System.Uri, System.Net.ICredentials> CredentialsSuccessfullyUsed { get { throw null; } set { } }
+
+        public override System.Net.Http.HttpMessageHandler MessageHandler { get { throw null; } }
+    }
+
+    public partial class HttpHandlerResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public HttpHandlerResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpRequestMessageConfiguration
+    {
+        public static readonly HttpRequestMessageConfiguration Default;
+        public HttpRequestMessageConfiguration(Common.ILogger logger = null, bool promptOn403 = true) { }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public bool PromptOn403 { get { throw null; } }
+    }
+
+    public static partial class HttpRequestMessageExtensions
+    {
+        public static HttpRequestMessageConfiguration GetOrCreateConfiguration(this System.Net.Http.HttpRequestMessage request) { throw null; }
+
+        public static void SetConfiguration(this System.Net.Http.HttpRequestMessage request, HttpRequestMessageConfiguration configuration) { }
+    }
+
+    public static partial class HttpRequestMessageFactory
+    {
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, string requestUri, Common.ILogger log) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, string requestUri, HttpRequestMessageConfiguration configuration) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, System.Uri requestUri, Common.ILogger log) { throw null; }
+
+        public static System.Net.Http.HttpRequestMessage Create(System.Net.Http.HttpMethod method, System.Uri requestUri, HttpRequestMessageConfiguration configuration) { throw null; }
+    }
+
+    public static partial class HttpResponseMessageExtensions
+    {
+        public static void LogServerWarning(this System.Net.Http.HttpResponseMessage response, Common.ILogger log) { }
+    }
+
+    public partial class HttpRetryHandler : IHttpRetryHandler
+    {
+        public HttpRetryHandler() { }
+
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, string source, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpRetryHandlerRequest
+    {
+        public static readonly System.TimeSpan DefaultDownloadTimeout;
+        public static readonly int DefaultMaxTries;
+        public HttpRetryHandlerRequest(System.Net.Http.HttpClient httpClient, System.Func<System.Net.Http.HttpRequestMessage> requestFactory) { }
+
+        public System.Collections.Generic.IList<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.IEnumerable<string>>> AddHeaders { get { throw null; } set { } }
+
+        public System.Net.Http.HttpCompletionOption CompletionOption { get { throw null; } set { } }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public System.Net.Http.HttpClient HttpClient { get { throw null; } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.Func<System.Net.Http.HttpRequestMessage> RequestFactory { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+
+        public System.TimeSpan RetryDelay { get { throw null; } set { } }
+    }
+
+    public partial class HttpSource : System.IDisposable
+    {
+        public HttpSource(Configuration.PackageSource packageSource, System.Func<System.Threading.Tasks.Task<Core.Types.HttpHandlerResource>> messageHandlerFactory, IThrottle throttle) { }
+
+        public string HttpCacheDirectory { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } }
+
+        public IHttpRetryHandler RetryHandler { get { throw null; } set { } }
+
+        public static HttpSource Create(Core.Types.SourceRepository source, IThrottle throttle) { throw null; }
+
+        public static HttpSource Create(Core.Types.SourceRepository source) { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public virtual System.Threading.Tasks.Task<T> GetAsync<T>(HttpSourceCachedRequest request, System.Func<HttpSourceResult, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> GetJObjectAsync(HttpSourceRequest request, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessResponseAsync<T>(HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessResponseAsync<T>(HttpSourceRequest request, System.Func<System.Net.Http.HttpResponseMessage, System.Threading.Tasks.Task<T>> processAsync, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessStreamAsync<T>(HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<T> ProcessStreamAsync<T>(HttpSourceRequest request, System.Func<System.IO.Stream, System.Threading.Tasks.Task<T>> processAsync, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        protected virtual System.IO.Stream TryReadCacheFile(string uri, System.TimeSpan maxAge, string cacheFile) { throw null; }
+    }
+
+    public partial class HttpSourceAuthenticationHandler : System.Net.Http.DelegatingHandler
+    {
+        public static readonly int MaxAuthRetries;
+        public HttpSourceAuthenticationHandler(Configuration.PackageSource packageSource, System.Net.Http.HttpClientHandler clientHandler, Configuration.ICredentialService credentialService) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class HttpSourceCachedRequest
+    {
+        public HttpSourceCachedRequest(string uri, string cacheKey, Core.Types.HttpSourceCacheContext cacheContext) { }
+
+        public System.Collections.Generic.IList<System.Net.Http.Headers.MediaTypeWithQualityHeaderValue> AcceptHeaderValues { get { throw null; } }
+
+        public Core.Types.HttpSourceCacheContext CacheContext { get { throw null; } }
+
+        public string CacheKey { get { throw null; } }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public System.Action<System.IO.Stream> EnsureValidContents { get { throw null; } set { } }
+
+        public bool IgnoreNotFounds { get { throw null; } set { } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } }
+    }
+
+    public partial class HttpSourceCredentials : System.Net.CredentialCache, System.Net.ICredentials
+    {
+        public HttpSourceCredentials() { }
+
+        public HttpSourceCredentials(System.Net.ICredentials credentials = null) { }
+
+        public System.Net.ICredentials Credentials { get { throw null; } set { } }
+
+        public System.Guid Version { get { throw null; } }
+
+        System.Net.NetworkCredential System.Net.ICredentials.GetCredential(System.Uri uri, string authType) { throw null; }
+    }
+
+    public partial class HttpSourceRequest
+    {
+        public static readonly System.TimeSpan DefaultRequestTimeout;
+        public HttpSourceRequest(System.Func<System.Net.Http.HttpRequestMessage> requestFactory) { }
+
+        public HttpSourceRequest(string uri, Common.ILogger log) { }
+
+        public HttpSourceRequest(System.Uri uri, Common.ILogger log) { }
+
+        public System.TimeSpan DownloadTimeout { get { throw null; } set { } }
+
+        public bool IgnoreNotFounds { get { throw null; } set { } }
+
+        public bool IsLastAttempt { get { throw null; } set { } }
+
+        public bool IsRetry { get { throw null; } set { } }
+
+        public int MaxTries { get { throw null; } set { } }
+
+        public System.Func<System.Net.Http.HttpRequestMessage> RequestFactory { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } set { } }
+    }
+
+    public partial class HttpSourceResource : Core.Types.INuGetResource
+    {
+        public HttpSourceResource(HttpSource httpSource) { }
+
+        public HttpSource HttpSource { get { throw null; } }
+    }
+
+    public partial class HttpSourceResourceProvider : Core.Types.ResourceProvider
+    {
+        public HttpSourceResourceProvider() : base(default!) { }
+
+        public static IThrottle Throttle { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class HttpSourceResult : System.IDisposable
+    {
+        public HttpSourceResult(HttpSourceResultStatus status, string cacheFileName, System.IO.Stream stream) { }
+
+        public HttpSourceResult(HttpSourceResultStatus status) { }
+
+        public string CacheFile { get { throw null; } }
+
+        public HttpSourceResultStatus Status { get { throw null; } }
+
+        public System.IO.Stream Stream { get { throw null; } }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+    }
+
+    public enum HttpSourceResultStatus
+    {
+        NotFound = 0,
+        NoContent = 1,
+        OpenedFromDisk = 2,
+        OpenedFromNetwork = 3
+    }
+
+    public static partial class HttpStreamValidation
+    {
+        public static void ValidateJObject(string uri, System.IO.Stream stream) { }
+
+        public static void ValidateNupkg(string uri, System.IO.Stream stream) { }
+
+        public static void ValidateXml(string uri, System.IO.Stream stream) { }
+    }
+
+    public partial interface IHttpRetryHandler
+    {
+        System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(HttpRetryHandlerRequest request, string sourceUri, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public abstract partial class InvalidCacheProtocolException : Core.Types.FatalProtocolException
+    {
+        public InvalidCacheProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public InvalidCacheProtocolException(string message) : base(default!) { }
+    }
+
+    public partial interface IThrottle
+    {
+        void Release();
+        System.Threading.Tasks.Task WaitAsync();
+    }
+
+    public partial interface IV2FeedParser
+    {
+        System.Threading.Tasks.Task<V2FeedPage> GetPackagesPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<V2FeedPage> GetSearchPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public static partial class JsonExtensions
+    {
+        public const int JsonSerializationMaxDepth = 512;
+        public static readonly Newtonsoft.Json.JsonSerializerSettings ObjectSerializationSettings;
+        public static object FromJson(this string json, System.Type type) { throw null; }
+
+        public static T FromJson<T>(this string json, Newtonsoft.Json.JsonSerializerSettings settings) { throw null; }
+
+        public static T FromJson<T>(this string json) { throw null; }
+
+        public static object FromJToken(this Newtonsoft.Json.Linq.JToken jtoken, System.Type type) { throw null; }
+
+        public static T FromJToken<T>(this Newtonsoft.Json.Linq.JToken jtoken) { throw null; }
+
+        public static bool? GetBoolean(this Newtonsoft.Json.Linq.JObject json, string propertyName) { throw null; }
+
+        public static T GetJObjectProperty<T>(this Newtonsoft.Json.Linq.JObject jobject, string propertyName) { throw null; }
+
+        public static string ToJson(this object obj, Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.None) { throw null; }
+
+        public static Newtonsoft.Json.Linq.JToken ToJToken(this object obj) { throw null; }
+    }
+
+    public static partial class JsonProperties
+    {
+        public const string AdvisoryUrl = "advisoryUrl";
+        public const string AllRepositorySigned = "allRepositorySigned";
+        public const string AlternatePackage = "alternatePackage";
+        public const string Authors = "authors";
+        public const string ContentUrl = "contentUrl";
+        public const string Created = "created";
+        public const string Data = "data";
+        public const string Dependencies = "dependencies";
+        public const string DependencyGroups = "dependencyGroups";
+        public const string Deprecation = "deprecation";
+        public const string DeprecationMessage = "message";
+        public const string DeprecationReasons = "reasons";
+        public const string Description = "description";
+        public const string DownloadCount = "totalDownloads";
+        public const string Fingerprints = "fingerprints";
+        public const string IconUrl = "iconUrl";
+        public const string Issuer = "issuer";
+        public const string Language = "language";
+        public const string LastEdited = "lastEdited";
+        public const string LatestVersion = "latestVersion";
+        public const string LicenseExpression = "licenseExpression";
+        public const string LicenseExpressionVersion = "licenseExpressionVersion";
+        public const string LicenseUrl = "licenseUrl";
+        public const string Listed = "listed";
+        public const string MinimumClientVersion = "minClientVersion";
+        public const string NotAfter = "notAfter";
+        public const string NotBefore = "notBefore";
+        public const string Owners = "owners";
+        public const string PackageContent = "packageContent";
+        public const string PackageId = "id";
+        public const string PrefixReserved = "verified";
+        public const string ProjectUrl = "projectUrl";
+        public const string Published = "published";
+        public const string Range = "range";
+        public const string ReadmeUrl = "readmeUrl";
+        public const string RequireLicenseAcceptance = "requireLicenseAcceptance";
+        public const string Severity = "severity";
+        public const string SigningCertificates = "signingCertificates";
+        public const string Subject = "subject";
+        public const string SubjectId = "@id";
+        public const string Summary = "summary";
+        public const string Tags = "tags";
+        public const string TargetFramework = "targetFramework";
+        public const string Title = "title";
+        public const string Type = "@type";
+        public const string Version = "version";
+        public const string Versions = "versions";
+        public const string Vulnerabilities = "vulnerabilities";
+    }
+
+    public partial class LegacyFeedCapabilityResourceV2Feed : Core.Types.LegacyFeedCapabilityResource
+    {
+        public LegacyFeedCapabilityResourceV2Feed(V2FeedParser feedParser, string baseAddress) { }
+
+        public override System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalAutoCompleteResource : Core.Types.AutoCompleteResource
+    {
+        public LocalAutoCompleteResource(FindLocalPackagesResource localResource) { }
+
+        protected System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetPackageVersionsFromLocalPackageRepository(string packageId, string versionPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalAutoCompleteResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalAutoCompleteResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDependencyInfoResource : Core.Types.DependencyInfoResource
+    {
+        public LocalDependencyInfoResource(FindLocalPackagesResource localResource, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDependencyInfoResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalDependencyInfoResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDownloadResource : Core.Types.DownloadResource
+    {
+        [System.Obsolete("Use constructor with source parameter")]
+        public LocalDownloadResource(FindLocalPackagesResource localResource) { }
+
+        public LocalDownloadResource(string source, FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalDownloadResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalDownloadResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class LocalFolderUtility
+    {
+        public static void EnsurePackageFileExists(string packagePath, System.Collections.Generic.IEnumerable<string> matchingPackagePaths) { }
+
+        public static void GenerateNupkgMetadataFile(string nupkgPath, string installPath, string hashPath, string nupkgMetadataPath) { }
+
+        public static System.IO.DirectoryInfo GetAndVerifyRootDirectory(string root) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetDistinctPackages(System.Collections.Generic.IEnumerable<LocalPackageInfo> packages) { throw null; }
+
+        public static Packaging.Core.PackageIdentity GetIdentityFromNupkgPath(System.IO.FileInfo file, string id) { throw null; }
+
+        public static FeedType GetLocalFeedType(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.IO.FileInfo> GetNupkgsFromFlatFolder(string root, string id, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackage(System.Uri path, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackagesConfigFolderPackage(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackagesConfigFolderPackage(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesConfigFolderPackages(string root, string id, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV2(string root, string id, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, Common.ILogger log) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, string id, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LocalPackageInfo> GetPackagesV3(string root, string id, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, string id, Versioning.NuGetVersion version, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static LocalPackageInfo GetPackageV2(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV3(string root, Packaging.Core.PackageIdentity identity, Common.ILogger log) { throw null; }
+
+        public static LocalPackageInfo GetPackageV3(string root, string id, Versioning.NuGetVersion version, Common.ILogger log) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionFromFileName(string fileName, string id, string extension) { throw null; }
+
+        public static bool IsPossiblePackageMatch(System.IO.FileInfo file, Packaging.Core.PackageIdentity identity) { throw null; }
+
+        public static bool IsPossiblePackageMatch(System.IO.FileInfo file, string id) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> ResolvePackageFromPath(string packagePath, bool isSnupkg = false) { throw null; }
+    }
+
+    public partial class LocalMetadataResource : Core.Types.MetadataResource
+    {
+        public LocalMetadataResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalMetadataResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalMetadataResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class LocalPackageArchiveDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public LocalPackageArchiveDownloader(string source, string packageFilePath, Packaging.Core.PackageIdentity packageIdentity, Common.ILogger logger) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class LocalPackageFileCache
+    {
+        public LocalPackageFileCache() { }
+
+        public virtual System.Lazy<System.Collections.Generic.IReadOnlyList<string>> GetOrAddFiles(string expandedPath) { throw null; }
+
+        public virtual System.Lazy<Packaging.NuspecReader> GetOrAddNuspec(string manifestPath, string expandedPath) { throw null; }
+
+        public virtual System.Lazy<RuntimeModel.RuntimeGraph> GetOrAddRuntimeGraph(string expandedPath) { throw null; }
+
+        public virtual System.Lazy<string> GetOrAddSha512(string sha512Path) { throw null; }
+
+        public virtual bool Sha512Exists(string sha512Path) { throw null; }
+
+        public void UpdateLastAccessTime(string nupkgMetadataPath) { }
+    }
+
+    public partial class LocalPackageInfo
+    {
+        protected LocalPackageInfo() { }
+
+        public LocalPackageInfo(Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<Packaging.NuspecReader> nuspec, bool useFolder) { }
+
+        [System.Obsolete("use other constructor")]
+        public LocalPackageInfo(Packaging.Core.PackageIdentity identity, string path, System.DateTime lastWriteTimeUtc, System.Lazy<Packaging.NuspecReader> nuspec, System.Func<Packaging.PackageReaderBase> getPackageReader) { }
+
+        public virtual Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public virtual bool IsNupkg { get { throw null; } }
+
+        public virtual System.DateTime LastWriteTimeUtc { get { throw null; } }
+
+        public virtual Packaging.NuspecReader Nuspec { get { throw null; } }
+
+        public virtual string Path { get { throw null; } }
+
+        public virtual Packaging.PackageReaderBase GetReader() { throw null; }
+    }
+
+    public partial class LocalPackageListResource : Core.Types.ListResource
+    {
+        public LocalPackageListResource(Core.Types.PackageSearchResource localPackageSearchResource, string baseAddress) { }
+
+        public override string Source { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<Common.IEnumerableAsync<Core.Types.IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageMetadataResource : Core.Types.PackageMetadataResource
+    {
+        public LocalPackageMetadataResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageMetadataResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageMetadataResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageSearchMetadata : Core.Types.IPackageSearchMetadata
+    {
+        public LocalPackageSearchMetadata(LocalPackageInfo package) { }
+
+        public string Authors { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public string Owners { get { throw null; } }
+
+        public System.Uri PackageDetailsUrl { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public System.Func<Packaging.PackageReaderBase> PackageReader { get { throw null; } }
+
+        public bool PrefixReserved { get { throw null; } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        public System.Uri ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+
+        public string LoadFileAsText(string path) { throw null; }
+    }
+
+    public partial class LocalPackageSearchResource : Core.Types.PackageSearchResource
+    {
+        public LocalPackageSearchResource(FindLocalPackagesResource localResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalPackageSearchResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageSearchResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalV2FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public LocalV2FindPackageByIdResource(Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalV2FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalV2FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class LocalV3FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public LocalV3FindPackageByIdResource(Configuration.PackageSource packageSource) { }
+
+        public bool IsFallbackFolder { get { throw null; } set { } }
+
+        public LocalPackageFileCache PackageFileCache { get { throw null; } set { } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalV3FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalV3FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataFieldConverter : Newtonsoft.Json.JsonConverter
+    {
+        public MetadataFieldConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class MetadataReferenceCache
+    {
+        public MetadataReferenceCache() { }
+
+        public T GetObject<T>(T input) { throw null; }
+
+        public string GetString(string s) { throw null; }
+
+        public Versioning.NuGetVersion GetVersion(string s) { throw null; }
+    }
+
+    public partial class MetadataResourceV2Feed : Core.Types.MetadataResource
+    {
+        public MetadataResourceV2Feed(V2FeedParser feedParser, Core.Types.SourceRepository source) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public MetadataResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV3 : Core.Types.MetadataResource
+    {
+        public MetadataResourceV3(RegistrationResourceV3 regResource) { }
+
+        public override System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class MetadataResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public MetadataResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class NuGetVersionConverter : Newtonsoft.Json.JsonConverter
+    {
+        public NuGetVersionConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class NullThrottle : IThrottle
+    {
+        public NullThrottle() { }
+
+        public static NullThrottle Instance { get { throw null; } }
+
+        public void Release() { }
+
+        public System.Threading.Tasks.Task WaitAsync() { throw null; }
+    }
+
+    public partial class ODataServiceDocumentResourceV2 : Core.Types.INuGetResource
+    {
+        public ODataServiceDocumentResourceV2(string baseAddress, System.DateTime requestTime) { }
+
+        public string BaseAddress { get { throw null; } }
+
+        public virtual System.DateTime RequestTime { get { throw null; } }
+    }
+
+    public partial class ODataServiceDocumentResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public ODataServiceDocumentResourceV2Provider() : base(default!) { }
+
+        public System.TimeSpan MaxCacheDuration { get { throw null; } protected set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+
+        protected partial class ODataServiceDocumentCacheInfo
+        {
+            public ODataServiceDocumentCacheInfo() { }
+
+            public System.DateTime CachedTime { get { throw null; } set { } }
+
+            public ODataServiceDocumentResourceV2 ServiceDocument { get { throw null; } set { } }
+        }
+    }
+
+    public partial class PackageDependencyGroupConverter : Newtonsoft.Json.JsonConverter
+    {
+        public PackageDependencyGroupConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class PackageDeprecationMetadata
+    {
+        public PackageDeprecationMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "alternatePackage")]
+        public AlternatePackageMetadata AlternatePackage { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        public string Message { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "reasons")]
+        public System.Collections.Generic.IEnumerable<string> Reasons { get { throw null; } }
+    }
+
+    public partial class PackageDetailsUriResourceV3 : Core.Types.INuGetResource
+    {
+        public static PackageDetailsUriResourceV3 CreateOrNull(string uriTemplate) { throw null; }
+
+        public System.Uri GetUri(string id, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class PackageDetailsUriResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageDetailsUriResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV2Feed : Core.Types.PackageMetadataResource
+    {
+        public PackageMetadataResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public PackageMetadataResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV3 : Core.Types.PackageMetadataResource
+    {
+        public PackageMetadataResourceV3(HttpSource client, RegistrationResourceV3 regResource, ReportAbuseResourceV3 reportAbuseResource, PackageDetailsUriResourceV3 packageDetailsUriResource) { }
+
+        public override System.Threading.Tasks.Task<Core.Types.IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageMetadataResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageMetadataResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageNotFoundProtocolException : InvalidCacheProtocolException
+    {
+        public PackageNotFoundProtocolException(Packaging.Core.PackageIdentity package, System.Exception innerException) : base(default!) { }
+
+        public PackageNotFoundProtocolException(Packaging.Core.PackageIdentity package) : base(default!) { }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadata : Core.Types.IPackageSearchMetadata
+    {
+        public PackageSearchMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "authors")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Authors { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "dependencyGroups", ItemConverterType = typeof(PackageDependencyGroupConverter))]
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySetsInternal { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "deprecation")]
+        public PackageDeprecationMetadata DeprecationMetadata { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "description")]
+        public string Description { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "totalDownloads")]
+        public long? DownloadCount { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "iconUrl")]
+        public System.Uri IconUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "listed")]
+        public bool IsListed { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseExpression")]
+        public string LicenseExpression { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseExpressionVersion")]
+        public string LicenseExpressionVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "licenseUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "owners")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Owners { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Uri PackageDetailsUrl { get { throw null; } set { } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "versions")]
+        public Core.Types.VersionInfo[] ParsedVersions { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "verified")]
+        public bool PrefixReserved { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "projectUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "published")]
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "readmeUrl")]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeUriConverter))]
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonIgnore]
+        public System.Uri ReportAbuseUrl { get { throw null; } set { } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "requireLicenseAcceptance", DefaultValueHandling = Newtonsoft.Json.DefaultValueHandling.Populate)]
+        [System.ComponentModel.DefaultValue(false)]
+        [Newtonsoft.Json.JsonConverter(typeof(SafeBoolConverter))]
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "summary")]
+        public string Summary { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "tags")]
+        [Newtonsoft.Json.JsonConverter(typeof(MetadataFieldConverter))]
+        public string Tags { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "title")]
+        public string Title { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "version")]
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "vulnerabilities")]
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+    }
+
+    public partial class PackageSearchMetadataRegistration : PackageSearchMetadata
+    {
+        public PackageSearchMetadataRegistration() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "@id")]
+        public System.Uri CatalogUri { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadataV2Feed : Core.Types.IPackageSearchMetadata
+    {
+        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package, MetadataReferenceCache metadataCache) { }
+
+        public PackageSearchMetadataV2Feed(V2FeedPackageInfo package) { }
+
+        public string Authors { get { throw null; } }
+
+        public System.DateTimeOffset? Created { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public PackageDeprecationMetadata DeprecationMetadata { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public System.Uri IconUrl { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public System.DateTimeOffset? LastEdited { get { throw null; } }
+
+        public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } }
+
+        public System.Uri LicenseUrl { get { throw null; } }
+
+        public string Owners { get { throw null; } }
+
+        public System.Uri PackageDetailsUrl { get { throw null; } }
+
+        public string PackageId { get { throw null; } }
+
+        public bool PrefixReserved { get { throw null; } }
+
+        public System.Uri ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public System.Uri ReadmeUrl { get { throw null; } }
+
+        public System.Uri ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } }
+
+        public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.VersionInfo>> GetVersionsAsync() { throw null; }
+    }
+
+    public partial class PackageSearchResourceV2Feed : Core.Types.PackageSearchResource
+    {
+        public PackageSearchResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV2FeedProvider : Core.Types.ResourceProvider
+    {
+        public PackageSearchResourceV2FeedProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV3 : Core.Types.PackageSearchResource
+    {
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public PackageSearchResourceV3(RawSearchResourceV3 searchResource) { }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Core.Types.IPackageSearchMetadata>> SearchAsync(string searchTerm, Core.Types.SearchFilter filter, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class PackageSearchResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageSearchResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageUpdateResourceV2Provider : Core.Types.ResourceProvider
+    {
+        public PackageUpdateResourceV2Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageUpdateResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public PackageUpdateResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class PackageVulnerabilityMetadata
+    {
+        public PackageVulnerabilityMetadata() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "advisoryUrl", ItemConverterType = typeof(SafeUriConverter))]
+        public System.Uri AdvisoryUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "severity")]
+        public int Severity { get { throw null; } }
+    }
+
+    public sealed partial class PluginFindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public PluginFindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public static partial class ProtocolConstants
+    {
+        public static readonly string ApiKeyHeader;
+        public static readonly string ServerWarningHeader;
+        public static readonly string SessionId;
+    }
+
+    public partial class ProxyAuthenticationHandler : System.Net.Http.DelegatingHandler
+    {
+        public static readonly int MaxAuthRetries;
+        public ProxyAuthenticationHandler(System.Net.Http.HttpClientHandler clientHandler, Configuration.ICredentialService credentialService, Configuration.IProxyCredentialCache credentialCache) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+    public partial class RawSearchResourceV3 : Core.Types.INuGetResource
+    {
+        public RawSearchResourceV3(HttpSource client, System.Collections.Generic.IEnumerable<System.Uri> searchEndpoints) { }
+
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> Search(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+        public virtual System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> SearchPage(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    [System.Obsolete("Use PackageSearchResource instead (via SourceRepository.GetResourceAsync<PackageSearchResource>")]
+    public partial class RawSearchResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public RawSearchResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RegistrationResourceV3 : Core.Types.INuGetResource
+    {
+        public RegistrationResourceV3(HttpSource client, System.Uri baseUrl) { }
+
+        public System.Uri BaseUri { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageEntries(string packageId, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<Newtonsoft.Json.Linq.JObject> GetPackageMetadata(Packaging.Core.PackageIdentity identity, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageMetadata(string packageId, Versioning.VersionRange range, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Uri GetUri(Packaging.Core.PackageIdentity package) { throw null; }
+
+        public virtual System.Uri GetUri(string id, Versioning.NuGetVersion version) { throw null; }
+
+        public virtual System.Uri GetUri(string packageId) { throw null; }
+    }
+
+    public partial class RegistrationResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public RegistrationResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class RegistrationUtility
+    {
+        public static Versioning.VersionRange CreateVersionRange(string stringToParse) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Newtonsoft.Json.Linq.JObject>> LoadRanges(HttpSource httpSource, System.Uri registrationUri, string packageId, Versioning.VersionRange range, Core.Types.SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class RemotePackageArchiveDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public RemotePackageArchiveDownloader(string source, Core.Types.FindPackageByIdResource resource, Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public partial class RemoteV2FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public RemoteV2FindPackageByIdResource(Configuration.PackageSource packageSource, HttpSource httpSource) { }
+
+        public Configuration.PackageSource PackageSource { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteV2FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public RemoteV2FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RemoteV3FindPackageByIdResource : Core.Types.FindPackageByIdResource
+    {
+        public RemoteV3FindPackageByIdResource(Core.Types.SourceRepository sourceRepository, HttpSource httpSource) { }
+
+        public Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Core.Types.FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteV3FindPackageByIdResourceProvider : Core.Types.ResourceProvider
+    {
+        public RemoteV3FindPackageByIdResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository sourceRepository, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class ReportAbuseResourceV3 : Core.Types.INuGetResource
+    {
+        public ReportAbuseResourceV3(string uriTemplate) { }
+
+        public System.Uri GetReportAbuseUrl(string id, Versioning.NuGetVersion version) { throw null; }
+    }
+
+    public partial class ReportAbuseResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public ReportAbuseResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RepositoryCertificateInfo : Packaging.Core.IRepositoryCertificateInfo
+    {
+        public RepositoryCertificateInfo() { }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "contentUrl")]
+        public string ContentUrl { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "fingerprints")]
+        public Packaging.Core.Fingerprints Fingerprints { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "issuer")]
+        public string Issuer { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "notAfter")]
+        public System.DateTimeOffset NotAfter { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "notBefore")]
+        public System.DateTimeOffset NotBefore { get { throw null; } }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "subject")]
+        public string Subject { get { throw null; } }
+    }
+
+    public partial class RepositorySignatureResource : Core.Types.INuGetResource
+    {
+        public RepositorySignatureResource(Newtonsoft.Json.Linq.JObject repoSignInformationContent, Core.Types.SourceRepository source) { }
+
+        public RepositorySignatureResource(bool allRepositorySigned, System.Collections.Generic.IEnumerable<Packaging.Core.IRepositoryCertificateInfo> repositoryCertInfos) { }
+
+        public bool AllRepositorySigned { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.Core.IRepositoryCertificateInfo> RepositoryCertificateInfos { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public void UpdateRepositorySignatureInfo() { }
+    }
+
+    public partial class RepositorySignatureResourceProvider : Core.Types.ResourceProvider
+    {
+        public RepositorySignatureResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SafeBoolConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SafeBoolConverter() { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class SafeUriConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SafeUriConverter() { }
+
+        public override bool CanRead { get { throw null; } }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public sealed partial class SemanticVersionConverter : Newtonsoft.Json.JsonConverter
+    {
+        public SemanticVersionConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class SemaphoreSlimThrottle : IThrottle
+    {
+        public SemaphoreSlimThrottle(System.Threading.SemaphoreSlim semaphore) { }
+
+        public int CurrentCount { get { throw null; } }
+
+        public static SemaphoreSlimThrottle CreateBinarySemaphore() { throw null; }
+
+        public static SemaphoreSlimThrottle CreateSemaphoreThrottle(int initialCount) { throw null; }
+
+        public void Release() { }
+
+        public System.Threading.Tasks.Task WaitAsync() { throw null; }
+    }
+
+    public partial class ServerWarningLogHandler : System.Net.Http.DelegatingHandler
+    {
+        public ServerWarningLogHandler(System.Net.Http.HttpClientHandler clientHandler) { }
+
+        protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class ServiceIndexEntry
+    {
+        public ServiceIndexEntry(System.Uri serviceUri, string serviceType, Versioning.SemanticVersion clientVersion) { }
+
+        public Versioning.SemanticVersion ClientVersion { get { throw null; } }
+
+        public string Type { get { throw null; } }
+
+        public System.Uri Uri { get { throw null; } }
+    }
+
+    public partial class ServiceIndexResourceV3 : Core.Types.INuGetResource
+    {
+        public ServiceIndexResourceV3(Newtonsoft.Json.Linq.JObject index, System.DateTime requestTime) { }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> Entries { get { throw null; } }
+
+        public virtual string Json { get { throw null; } }
+
+        public virtual System.DateTime RequestTime { get { throw null; } }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> GetServiceEntries(Versioning.NuGetVersion clientVersion, params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<ServiceIndexEntry> GetServiceEntries(params string[] orderedTypes) { throw null; }
+
+        public virtual System.Uri GetServiceEntryUri(params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<System.Uri> GetServiceEntryUris(Versioning.NuGetVersion clientVersion, params string[] orderedTypes) { throw null; }
+
+        public virtual System.Collections.Generic.IReadOnlyList<System.Uri> GetServiceEntryUris(params string[] orderedTypes) { throw null; }
+    }
+
+    public partial class ServiceIndexResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public ServiceIndexResourceV3Provider() : base(default!) { }
+
+        public System.TimeSpan MaxCacheDuration { get { throw null; } protected set { } }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+
+        protected partial class ServiceIndexCacheInfo
+        {
+            public ServiceIndexCacheInfo() { }
+
+            public System.DateTime CachedTime { get { throw null; } set { } }
+
+            public ServiceIndexResourceV3 Index { get { throw null; } set { } }
+        }
+    }
+
+    public static partial class ServiceTypes
+    {
+        public static readonly string[] LegacyGallery;
+        public static readonly string[] PackageBaseAddress;
+        public static readonly string[] PackageDetailsUriTemplate;
+        public static readonly string[] PackagePublish;
+        public static readonly string[] RegistrationsBaseUrl;
+        public static readonly string[] ReportAbuse;
+        public static readonly string[] RepositorySignatures;
+        public static readonly string[] SearchAutocompleteService;
+        public static readonly string[] SearchQueryService;
+        public static readonly string[] SymbolPackagePublish;
+        public static readonly string Version200;
+        public static readonly string Version300;
+        public static readonly string Version300beta;
+        public static readonly string Version340;
+        public static readonly string Version470;
+        public static readonly string Version490;
+        public static readonly string Version500;
+        public static readonly string Version510;
+        public static readonly string Versioned;
+    }
+
+    public static partial class StreamExtensions
+    {
+        public static readonly int BufferSize;
+        public static System.Threading.Tasks.Task CopyToAsync(this System.IO.Stream stream, System.IO.Stream destination, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SymbolPackageUpdateResourceV3Provider : Core.Types.ResourceProvider
+    {
+        public SymbolPackageUpdateResourceV3Provider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public static partial class TimeoutUtility
+    {
+        public static System.Threading.Tasks.Task StartWithTimeout(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> getTask, System.TimeSpan timeout, string timeoutMessage, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<T> StartWithTimeout<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> getTask, System.TimeSpan timeout, string timeoutMessage, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class TokenStore
+    {
+        public TokenStore() { }
+
+        public static TokenStore Instance { get { throw null; } }
+
+        public System.Guid Version { get { throw null; } }
+
+        public void AddToken(System.Uri sourceUri, string token) { }
+
+        public string GetToken(System.Uri sourceUri) { throw null; }
+    }
+
+    public partial class V2FeedListResource : Core.Types.ListResource
+    {
+        public V2FeedListResource(IV2FeedParser feedParser, Core.Types.ILegacyFeedCapabilityResource feedCapabilities, string baseAddress) { }
+
+        public override string Source { get { throw null; } }
+
+        public override System.Threading.Tasks.Task<Common.IEnumerableAsync<Core.Types.IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedListResourceProvider : Core.Types.ResourceProvider
+    {
+        public V2FeedListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedPackageInfo : Packaging.Core.PackageIdentity
+    {
+        public V2FeedPackageInfo(Packaging.Core.PackageIdentity identity, string title, string summary, string description, System.Collections.Generic.IEnumerable<string> authors, System.Collections.Generic.IEnumerable<string> owners, string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl, string galleryDetailsUrl, string tags, System.DateTimeOffset? created, System.DateTimeOffset? lastEdited, System.DateTimeOffset? published, string dependencies, bool requireLicenseAccept, string downloadUrl, string downloadCount, string packageHash, string packageHashAlgorithm, Versioning.NuGetVersion minClientVersion) : base(default!, default!) { }
+
+        public System.Collections.Generic.IEnumerable<string> Authors { get { throw null; } }
+
+        public System.DateTimeOffset? Created { get { throw null; } }
+
+        public string Dependencies { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } }
+
+        public string Description { get { throw null; } }
+
+        public string DownloadCount { get { throw null; } }
+
+        public int DownloadCountAsInt { get { throw null; } }
+
+        public string DownloadUrl { get { throw null; } }
+
+        public string GalleryDetailsUrl { get { throw null; } }
+
+        public string IconUrl { get { throw null; } }
+
+        public bool IsListed { get { throw null; } }
+
+        public System.DateTimeOffset? LastEdited { get { throw null; } }
+
+        public string LicenseUrl { get { throw null; } }
+
+        public Versioning.NuGetVersion MinClientVersion { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } }
+
+        public string PackageHash { get { throw null; } }
+
+        public string PackageHashAlgorithm { get { throw null; } }
+
+        public string ProjectUrl { get { throw null; } }
+
+        public System.DateTimeOffset? Published { get { throw null; } }
+
+        public string ReportAbuseUrl { get { throw null; } }
+
+        public bool RequireLicenseAcceptance { get { throw null; } }
+
+        public string Summary { get { throw null; } }
+
+        public string Tags { get { throw null; } }
+
+        public string Title { get { throw null; } }
+    }
+
+    public partial class V2FeedPage
+    {
+        public V2FeedPage(System.Collections.Generic.List<V2FeedPackageInfo> items, string nextUri) { }
+
+        public System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo> Items { get { throw null; } }
+
+        public string NextUri { get { throw null; } }
+    }
+
+    public sealed partial class V2FeedParser : IV2FeedParser
+    {
+        public V2FeedParser(HttpSource httpSource, string baseAddress, string source) { }
+
+        public V2FeedParser(HttpSource httpSource, string baseAddress) { }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> DownloadFromIdentity(Packaging.Core.PackageIdentity package, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<Core.Types.DownloadResourceResult> DownloadFromUrl(Packaging.Core.PackageIdentity package, System.Uri downloadUri, Core.Types.PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> FindPackagesByIdAsync(string id, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> FindPackagesByIdAsync(string id, bool includeUnlisted, bool includePrerelease, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPackageInfo> GetPackage(Packaging.Core.PackageIdentity package, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> GetPackagesPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> GetSearchPageAsync(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<V2FeedPage> QueryV2FeedAsync(string relativeUri, string id, int max, bool ignoreNotFounds, Core.Types.SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<V2FeedPackageInfo>> Search(string searchTerm, Core.Types.SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class V2FeedQueryBuilder
+    {
+        public V2FeedQueryBuilder() { }
+
+        public string BuildFindPackagesByIdUri(string id) { throw null; }
+
+        public string BuildGetPackagesUri(string searchTerm, Core.Types.SearchFilter filters, int? skip, int? take) { throw null; }
+
+        public string BuildGetPackageUri(Packaging.Core.PackageIdentity package) { throw null; }
+
+        public string BuildSearchUri(string searchTerm, Core.Types.SearchFilter filters, int skip, int take) { throw null; }
+    }
+
+    public static partial class V2FeedUtilities
+    {
+        public static Core.Types.IPackageSearchMetadata CreatePackageSearchResult(V2FeedPackageInfo package, MetadataReferenceCache metadataCache, Core.Types.SearchFilter filter, V2FeedParser feedParser, Common.ILogger log, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class V3FeedListResourceProvider : Core.Types.ResourceProvider
+    {
+        public V3FeedListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class VersionInfoConverter : Newtonsoft.Json.JsonConverter
+    {
+        public VersionInfoConverter() { }
+
+        public override bool CanWrite { get { throw null; } }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+
+    public partial class VersionRangeConverter : Newtonsoft.Json.JsonConverter
+    {
+        public VersionRangeConverter() { }
+
+        public override bool CanConvert(System.Type objectType) { throw null; }
+
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+}
+
+namespace NuGet.Protocol.Core.Types
+{
+    public abstract partial class AutoCompleteResource : INuGetResource
+    {
+        protected AutoCompleteResource() { }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> IdStartsWith(string packageIdPrefix, bool includePrerelease, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> VersionStartsWith(string packageId, string versionPrefix, bool includePrerelease, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class DependencyInfoResource : INuGetResource
+    {
+        protected DependencyInfoResource() { }
+
+        public abstract System.Threading.Tasks.Task<SourcePackageDependencyInfo> ResolvePackage(Packaging.Core.PackageIdentity package, Frameworks.NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, Frameworks.NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId, SourceCacheContext cacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public abstract partial class DownloadResource : INuGetResource
+    {
+        protected DownloadResource() { }
+
+        public abstract System.Threading.Tasks.Task<DownloadResourceResult> GetDownloadResourceResultAsync(Packaging.Core.PackageIdentity identity, PackageDownloadContext downloadContext, string globalPackagesFolder, Common.ILogger logger, System.Threading.CancellationToken token);
+    }
+
+    public sealed partial class DownloadResourceResult : System.IDisposable
+    {
+        public DownloadResourceResult(Packaging.PackageReaderBase packageReader, string source) { }
+
+        public DownloadResourceResult(DownloadResourceResultStatus status) { }
+
+        public DownloadResourceResult(System.IO.Stream stream, Packaging.PackageReaderBase packageReader, string source) { }
+
+        public DownloadResourceResult(System.IO.Stream stream, string source) { }
+
+        public Packaging.PackageReaderBase PackageReader { get { throw null; } }
+
+        public string PackageSource { get { throw null; } }
+
+        public System.IO.Stream PackageStream { get { throw null; } }
+
+        public bool SignatureVerified { get { throw null; } set { } }
+
+        public DownloadResourceResultStatus Status { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public enum DownloadResourceResultStatus
+    {
+        Available = 0,
+        AvailableWithoutStream = 1,
+        NotFound = 2,
+        Cancelled = 3
+    }
+
+    public partial class FatalProtocolException : NuGetProtocolException
+    {
+        public FatalProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public FatalProtocolException(string message) : base(default!) { }
+    }
+
+    public partial class FindPackageByIdDependencyInfo
+    {
+        public FindPackageByIdDependencyInfo(Packaging.Core.PackageIdentity packageIdentity, System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> dependencyGroups, System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> frameworkReferenceGroups) { }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.FrameworkSpecificGroup> FrameworkReferenceGroups { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+    }
+
+    public abstract partial class FindPackageByIdResource : INuGetResource
+    {
+        protected FindPackageByIdResource() { }
+
+        public abstract System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        protected static FindPackageByIdDependencyInfo GetDependencyInfo(Packaging.NuspecReader reader) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public abstract partial class HttpHandlerResource : INuGetResource
+    {
+        protected HttpHandlerResource() { }
+
+        public abstract System.Net.Http.HttpClientHandler ClientHandler { get; }
+        public abstract System.Net.Http.HttpMessageHandler MessageHandler { get; }
+    }
+
+    public partial class HttpSourceCacheContext
+    {
+        public bool DirectDownload { get { throw null; } }
+
+        public System.TimeSpan MaxAge { get { throw null; } }
+
+        public string RootTempFolder { get { throw null; } }
+
+        public SourceCacheContext SourceCacheContext { get { throw null; } }
+
+        public static HttpSourceCacheContext Create(SourceCacheContext cacheContext, bool isFirstAttempt) { throw null; }
+
+        public static HttpSourceCacheContext Create(SourceCacheContext cacheContext, int retryCount) { throw null; }
+    }
+
+    public partial interface ILegacyFeedCapabilityResource
+    {
+        System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public partial interface INuGetResource
+    {
+    }
+
+    public partial interface INuGetResourceProvider
+    {
+        System.Collections.Generic.IEnumerable<string> After { get; }
+
+        System.Collections.Generic.IEnumerable<string> Before { get; }
+
+        string Name { get; }
+
+        System.Type ResourceType { get; }
+
+        System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken token);
+    }
+
+    public partial interface IPackageSearchMetadata
+    {
+        string Authors { get; }
+
+        System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get; }
+
+        string Description { get; }
+
+        long? DownloadCount { get; }
+
+        System.Uri IconUrl { get; }
+
+        Packaging.Core.PackageIdentity Identity { get; }
+
+        bool IsListed { get; }
+
+        Packaging.LicenseMetadata LicenseMetadata { get; }
+
+        System.Uri LicenseUrl { get; }
+
+        string Owners { get; }
+
+        System.Uri PackageDetailsUrl { get; }
+
+        bool PrefixReserved { get; }
+
+        System.Uri ProjectUrl { get; }
+
+        System.DateTimeOffset? Published { get; }
+
+        System.Uri ReadmeUrl { get; }
+
+        System.Uri ReportAbuseUrl { get; }
+
+        bool RequireLicenseAcceptance { get; }
+
+        string Summary { get; }
+
+        string Tags { get; }
+
+        string Title { get; }
+
+        System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; }
+
+        System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync();
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>> GetVersionsAsync();
+    }
+
+    public partial interface ISourceRepositoryProvider
+    {
+        Configuration.IPackageSourceProvider PackageSourceProvider { get; }
+
+        SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type);
+        SourceRepository CreateRepository(Configuration.PackageSource source);
+        System.Collections.Generic.IEnumerable<SourceRepository> GetRepositories();
+    }
+
+    public abstract partial class LegacyFeedCapabilityResource : INuGetResource, ILegacyFeedCapabilityResource
+    {
+        protected LegacyFeedCapabilityResource() { }
+
+        public abstract System.Threading.Tasks.Task<bool> SupportsIsAbsoluteLatestVersionAsync(Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<bool> SupportsSearchAsync(Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class ListResource : INuGetResource
+    {
+        protected ListResource() { }
+
+        public abstract string Source { get; }
+
+        public abstract System.Threading.Tasks.Task<Common.IEnumerableAsync<IPackageSearchMetadata>> ListAsync(string searchTerm, bool prerelease, bool allVersions, bool includeDelisted, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class MetadataResource : INuGetResource
+    {
+        protected MetadataResource() { }
+
+        public System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> Exists(Packaging.Core.PackageIdentity identity, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<bool> Exists(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<Versioning.NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Versioning.NuGetVersion>>> GetLatestVersions(System.Collections.Generic.IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public abstract partial class NuGetProtocolException : System.Exception
+    {
+        public NuGetProtocolException(string message, System.Exception innerException) { }
+
+        public NuGetProtocolException(string message) { }
+    }
+
+    public sealed partial class NuGetResourceProviderPositions
+    {
+        public const string First = "First";
+        public const string Last = "Last";
+        public NuGetResourceProviderPositions() { }
+    }
+
+    public static partial class NuGetTestMode
+    {
+        public const string NuGetTestClientName = "NuGet Test Client";
+        public static bool Enabled { get { throw null; } }
+
+        public static T InvokeTestFunctionAgainstTestMode<T>(System.Func<T> function, bool testModeEnabled) { throw null; }
+    }
+
+    public partial class NullSourceCacheContext : SourceCacheContext
+    {
+        public NullSourceCacheContext() { }
+
+        public override string GeneratedTempFolder { get { throw null; } }
+
+        public static SourceCacheContext Instance { get { throw null; } }
+
+        public override SourceCacheContext Clone() { throw null; }
+
+        public override SourceCacheContext WithRefreshCacheTrue() { throw null; }
+    }
+
+    public partial class OfflineFeedAddContext
+    {
+        public OfflineFeedAddContext(string packagePath, string source, Common.ILogger logger, bool throwIfSourcePackageIsInvalid, bool throwIfPackageExistsAndInvalid, bool throwIfPackageExists, Packaging.PackageExtractionContext extractionContext) { }
+
+        public Packaging.PackageExtractionContext ExtractionContext { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public bool ThrowIfPackageExists { get { throw null; } }
+
+        public bool ThrowIfPackageExistsAndInvalid { get { throw null; } }
+
+        public bool ThrowIfSourcePackageIsInvalid { get { throw null; } }
+    }
+
+    public static partial class OfflineFeedUtility
+    {
+        public static System.Threading.Tasks.Task AddPackageToSource(OfflineFeedAddContext offlineFeedAddContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static string GetPackageDirectory(Packaging.Core.PackageIdentity packageIdentity, string offlineFeed) { throw null; }
+
+        public static bool PackageExists(Packaging.Core.PackageIdentity packageIdentity, string offlineFeed, out bool isValidPackage) { throw null; }
+
+        public static void ThrowIfInvalid(string path) { }
+
+        public static void ThrowIfInvalidOrNotFound(string path, bool isDirectory, string resourceString) { }
+    }
+
+    public partial class PackageDownloadContext
+    {
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory, bool directDownload, Configuration.PackageSourceMapping packageSourceMappingConfiguration) { }
+
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory, bool directDownload) { }
+
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext) { }
+
+        public Packaging.Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } set { } }
+
+        public bool DirectDownload { get { throw null; } }
+
+        public string DirectDownloadDirectory { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public SourceCacheContext SourceCacheContext { get { throw null; } }
+    }
+
+    public abstract partial class PackageMetadataResource : INuGetResource
+    {
+        protected PackageMetadataResource() { }
+
+        public abstract System.Threading.Tasks.Task<IPackageSearchMetadata> GetMetadataAsync(Packaging.Core.PackageIdentity package, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, System.Threading.CancellationToken token);
+    }
+
+    public partial class PackageProgressEventArgs : System.EventArgs
+    {
+        public PackageProgressEventArgs(Packaging.Core.PackageIdentity identity, Configuration.PackageSource source, double complete) { }
+
+        public double Complete { get { throw null; } }
+
+        public bool HasPackageSource { get { throw null; } }
+
+        public bool IsComplete { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity PackageIdentity { get { throw null; } }
+
+        public Configuration.PackageSource PackageSource { get { throw null; } }
+    }
+
+    public partial class PackageSearchMetadataBuilder
+    {
+        public IPackageSearchMetadata Build() { throw null; }
+
+        public static PackageSearchMetadataBuilder FromIdentity(Packaging.Core.PackageIdentity identity) { throw null; }
+
+        public static PackageSearchMetadataBuilder FromMetadata(IPackageSearchMetadata metadata) { throw null; }
+
+        public PackageSearchMetadataBuilder WithDeprecation(Common.AsyncLazy<PackageDeprecationMetadata> lazyDeprecationFactory) { throw null; }
+
+        public PackageSearchMetadataBuilder WithVersions(Common.AsyncLazy<System.Collections.Generic.IEnumerable<VersionInfo>> lazyVersionsFactory) { throw null; }
+
+        public partial class ClonedPackageSearchMetadata : IPackageSearchMetadata
+        {
+            public ClonedPackageSearchMetadata() { }
+
+            public string Authors { get { throw null; } set { } }
+
+            public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencySets { get { throw null; } set { } }
+
+            public string Description { get { throw null; } set { } }
+
+            public long? DownloadCount { get { throw null; } set { } }
+
+            public System.Uri IconUrl { get { throw null; } set { } }
+
+            public Packaging.Core.PackageIdentity Identity { get { throw null; } set { } }
+
+            public bool IsListed { get { throw null; } set { } }
+
+            public Packaging.LicenseMetadata LicenseMetadata { get { throw null; } set { } }
+
+            public System.Uri LicenseUrl { get { throw null; } set { } }
+
+            public string Owners { get { throw null; } set { } }
+
+            public System.Uri PackageDetailsUrl { get { throw null; } set { } }
+
+            public string PackagePath { get { throw null; } set { } }
+
+            [System.Obsolete("PackagePath is recommended in place of PackageReader")]
+            public System.Func<Packaging.PackageReaderBase> PackageReader { get { throw null; } set { } }
+
+            public bool PrefixReserved { get { throw null; } set { } }
+
+            public System.Uri ProjectUrl { get { throw null; } set { } }
+
+            public System.DateTimeOffset? Published { get { throw null; } set { } }
+
+            public System.Uri ReadmeUrl { get { throw null; } set { } }
+
+            public System.Uri ReportAbuseUrl { get { throw null; } set { } }
+
+            public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+            public string Summary { get { throw null; } set { } }
+
+            public string Tags { get { throw null; } set { } }
+
+            public string Title { get { throw null; } set { } }
+
+            public System.Collections.Generic.IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get { throw null; } set { } }
+
+            public System.Threading.Tasks.Task<PackageDeprecationMetadata> GetDeprecationMetadataAsync() { throw null; }
+
+            public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>> GetVersionsAsync() { throw null; }
+        }
+    }
+
+    public static partial class PackageSearchMetadataExtensions
+    {
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Collections.Generic.IEnumerable<VersionInfo> versions) { throw null; }
+
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Func<System.Collections.Generic.IEnumerable<VersionInfo>> valueFactory) { throw null; }
+
+        public static IPackageSearchMetadata WithVersions(this IPackageSearchMetadata metadata, System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<VersionInfo>>> asyncValueFactory) { throw null; }
+    }
+
+    public abstract partial class PackageSearchResource : INuGetResource
+    {
+        protected PackageSearchResource() { }
+
+        public abstract System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filters, int skip, int take, Common.ILogger log, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial class PackageUpdateResource : INuGetResource
+    {
+        public PackageUpdateResource(string source, HttpSource httpSource) { }
+
+        public Configuration.ISettings Settings { get { throw null; } set { } }
+
+        public System.Uri SourceUri { get { throw null; } }
+
+        public System.Threading.Tasks.Task Delete(string packageId, string packageVersion, System.Func<string, string> getApiKey, System.Func<string, bool> confirm, bool noServiceEndpoint, Common.ILogger log) { throw null; }
+
+        public static void ForceDeleteDirectory(string path) { }
+
+        public System.Threading.Tasks.Task Push(System.Collections.Generic.IList<string> packagePaths, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, Common.ILogger log) { throw null; }
+
+        [System.Obsolete("Consolidating to one PackageUpdateResource.Push method which has all parameters defined.")]
+        public System.Threading.Tasks.Task Push(string packagePath, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, Common.ILogger log) { throw null; }
+
+        [System.Obsolete("Use Push method which takes multiple package paths.")]
+        public System.Threading.Tasks.Task Push(string packagePath, string symbolSource, int timeoutInSecond, bool disableBuffering, System.Func<string, string> getApiKey, System.Func<string, string> getSymbolApiKey, bool noServiceEndpoint, bool skipDuplicate, SymbolPackageUpdateResourceV3 symbolPackageUpdateResource, Common.ILogger log) { throw null; }
+    }
+
+    public sealed partial class PluginFindPackageByIdResource : FindPackageByIdResource
+    {
+        public PluginFindPackageByIdResource(Plugins.IPlugin plugin, Plugins.IPluginMulticlientUtilities utilities, Configuration.PackageSource packageSource) { }
+
+        public override System.Threading.Tasks.Task<bool> CopyNupkgToStreamAsync(string id, Versioning.NuGetVersion version, System.IO.Stream destination, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> DoesPackageExistAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, Versioning.NuGetVersion version, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginResource : INuGetResource
+    {
+        public PluginResource(System.Collections.Generic.IEnumerable<Plugins.PluginCreationResult> pluginCreationResults, Configuration.PackageSource packageSource, Configuration.ICredentialService credentialService) { }
+
+        public System.Threading.Tasks.Task<GetPluginResult> GetPluginAsync(Plugins.OperationClaim requiredClaim, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public sealed partial class GetPluginResult
+        {
+            public Plugins.IPlugin Plugin { get { throw null; } }
+
+            public Plugins.IPluginMulticlientUtilities PluginMulticlientUtilities { get { throw null; } }
+        }
+    }
+
+    public partial class PluginResourceProvider : ResourceProvider
+    {
+        public PluginResourceProvider() : base(default!) { }
+
+        public PluginResourceProvider(Plugins.IPluginManager pluginManager) : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class RemoteSourceDependencyInfo : System.IEquatable<RemoteSourceDependencyInfo>
+    {
+        public RemoteSourceDependencyInfo(Packaging.Core.PackageIdentity identity, bool listed, System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> dependencyGroups, string contentUri) { }
+
+        public string ContentUri { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> DependencyGroups { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Identity { get { throw null; } }
+
+        public bool Listed { get { throw null; } }
+
+        public bool Equals(RemoteSourceDependencyInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class Repository
+    {
+        public static RepositoryFactory Factory { get { throw null; } }
+
+        public static ProviderFactory Provider { get { throw null; } set { } }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public static ISourceRepositoryProvider CreateProvider(System.Collections.Generic.IEnumerable<INuGetResourceProvider> resourceProviders, string rootPath) { throw null; }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public static ISourceRepositoryProvider CreateProvider(System.Collections.Generic.IEnumerable<INuGetResourceProvider> resourceProviders) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, Configuration.PackageSource source) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, string sourceUrl, FeedType type) { throw null; }
+
+        public static SourceRepository CreateSource(System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders, string sourceUrl) { throw null; }
+
+        public partial class ProviderFactory
+        {
+            public ProviderFactory() { }
+
+            public virtual System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> GetCoreV3() { throw null; }
+        }
+
+        public partial class RepositoryFactory
+        {
+            public RepositoryFactory() { }
+        }
+    }
+
+    public abstract partial class ResourceProvider : INuGetResourceProvider
+    {
+        public ResourceProvider(System.Type resourceType, string name, System.Collections.Generic.IEnumerable<string> before, System.Collections.Generic.IEnumerable<string> after) { }
+
+        public ResourceProvider(System.Type resourceType, string name, string before) { }
+
+        public ResourceProvider(System.Type resourceType, string name) { }
+
+        public ResourceProvider(System.Type resourceType) { }
+
+        public virtual System.Collections.Generic.IEnumerable<string> After { get { throw null; } }
+
+        public virtual System.Collections.Generic.IEnumerable<string> Before { get { throw null; } }
+
+        public virtual string Name { get { throw null; } }
+
+        public virtual System.Type ResourceType { get { throw null; } }
+
+        public abstract System.Threading.Tasks.Task<System.Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, System.Threading.CancellationToken token);
+    }
+
+    public partial class RetriableProtocolException : NuGetProtocolException
+    {
+        public RetriableProtocolException(string message, System.Exception innerException) : base(default!) { }
+
+        public RetriableProtocolException(string message) : base(default!) { }
+    }
+
+    public partial class SearchFilter
+    {
+        public SearchFilter(bool includePrerelease, SearchFilterType? filter) { }
+
+        public SearchFilter(bool includePrerelease) { }
+
+        public SearchFilterType? Filter { get { throw null; } }
+
+        public bool IncludeDelisted { get { throw null; } set { } }
+
+        public bool IncludePrerelease { get { throw null; } }
+
+        public SearchOrderBy? OrderBy { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> PackageTypes { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> SupportedFrameworks { get { throw null; } set { } }
+    }
+
+    public enum SearchFilterType
+    {
+        IsLatestVersion = 0,
+        IsAbsoluteLatestVersion = 1
+    }
+
+    public enum SearchOrderBy
+    {
+        Id = 0
+    }
+
+    public partial class SourceCacheContext : System.IDisposable
+    {
+        public SourceCacheContext() { }
+
+        public bool DirectDownload { get { throw null; } set { } }
+
+        public virtual string GeneratedTempFolder { get { throw null; } set { } }
+
+        public bool IgnoreFailedSources { get { throw null; } set { } }
+
+        public System.DateTimeOffset? MaxAge { get { throw null; } set { } }
+
+        public System.TimeSpan MaxAgeTimeSpan { get { throw null; } }
+
+        public bool NoCache { get { throw null; } set { } }
+
+        public bool RefreshMemoryCache { get { throw null; } set { } }
+
+        public System.Guid SessionId { get { throw null; } set { } }
+
+        public virtual SourceCacheContext Clone() { throw null; }
+
+        public void Dispose() { }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        public virtual SourceCacheContext WithRefreshCacheTrue() { throw null; }
+    }
+
+    public partial class SourcePackageDependencyInfo : Packaging.Core.PackageDependencyInfo
+    {
+        public SourcePackageDependencyInfo(Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source, System.Uri downloadUri, string packageHash) : base(identity, dependencies) { }
+
+        public SourcePackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source, System.Uri downloadUri, string packageHash) : base(id, version) { }
+
+        public SourcePackageDependencyInfo(string id, Versioning.NuGetVersion version, System.Collections.Generic.IEnumerable<Packaging.Core.PackageDependency> dependencies, bool listed, SourceRepository source) : base(id, version) { }
+
+        public System.Uri DownloadUri { get { throw null; } }
+
+        public bool Listed { get { throw null; } }
+
+        public string PackageHash { get { throw null; } }
+
+        public SourceRepository Source { get { throw null; } }
+    }
+
+    public partial class SourceRepository
+    {
+        protected SourceRepository() { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<INuGetResourceProvider> providers) { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> providers, FeedType feedTypeOverride) { }
+
+        public SourceRepository(Configuration.PackageSource source, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> providers) { }
+
+        public FeedType FeedTypeOverride { get { throw null; } }
+
+        public virtual Configuration.PackageSource PackageSource { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task<FeedType> GetFeedType(System.Threading.CancellationToken token) { throw null; }
+
+        public virtual T GetResource<T>()
+            where T : class, INuGetResource { throw null; }
+
+        public virtual T GetResource<T>(System.Threading.CancellationToken token)
+            where T : class, INuGetResource { throw null; }
+
+        public virtual System.Threading.Tasks.Task<T> GetResourceAsync<T>()
+            where T : class, INuGetResource { throw null; }
+
+        public virtual System.Threading.Tasks.Task<T> GetResourceAsync<T>(System.Threading.CancellationToken token)
+            where T : class, INuGetResource { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class SourceRepositoryProvider : ISourceRepositoryProvider
+    {
+        public SourceRepositoryProvider(Configuration.IPackageSourceProvider packageSourceProvider, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders) { }
+
+        [System.Obsolete("https://github.com/NuGet/Home/issues/8479")]
+        public SourceRepositoryProvider(Configuration.ISettings settings, System.Collections.Generic.IEnumerable<System.Lazy<INuGetResourceProvider>> resourceProviders) { }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider { get { throw null; } }
+
+        public SourceRepository CreateRepository(Configuration.PackageSource source, FeedType type) { throw null; }
+
+        public SourceRepository CreateRepository(Configuration.PackageSource source) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<SourceRepository> GetRepositories() { throw null; }
+    }
+
+    public partial class SymbolPackageUpdateResourceV3 : INuGetResource
+    {
+        public SymbolPackageUpdateResourceV3(string source, HttpSource httpSource) { }
+
+        public System.Uri SourceUri { get { throw null; } }
+    }
+
+    public static partial class UserAgent
+    {
+        public static string UserAgentString { get { throw null; } }
+
+        public static void SetUserAgent(System.Net.Http.HttpClient client) { }
+
+        public static void SetUserAgentString(UserAgentStringBuilder builder) { }
+    }
+
+    public partial class UserAgentStringBuilder
+    {
+        public static readonly string DefaultNuGetClientName;
+        public UserAgentStringBuilder() { }
+
+        public UserAgentStringBuilder(string clientName) { }
+
+        public string NuGetClientVersion { get { throw null; } }
+
+        public string Build() { throw null; }
+
+        public UserAgentStringBuilder WithOSDescription(string osInfo) { throw null; }
+
+        public UserAgentStringBuilder WithVisualStudioSKU(string vsInfo) { throw null; }
+    }
+
+    public partial class VersionInfo
+    {
+        public VersionInfo(Versioning.NuGetVersion version, long? downloadCount) { }
+
+        public VersionInfo(Versioning.NuGetVersion version, string downloadCount) { }
+
+        public VersionInfo(Versioning.NuGetVersion version) { }
+
+        public long? DownloadCount { get { throw null; } }
+
+        public IPackageSearchMetadata PackageSearchMetadata { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+    }
+}
+
+namespace NuGet.Protocol.Events
+{
+    public sealed partial class ProtocolDiagnosticHttpEvent : ProtocolDiagnosticHttpEventBase
+    {
+        internal ProtocolDiagnosticHttpEvent() : base(default!) { }
+
+        public long Bytes { get { throw null; } }
+
+        public System.TimeSpan EventDuration { get { throw null; } }
+
+        public bool IsSuccess { get { throw null; } }
+
+        public System.DateTime Timestamp { get { throw null; } }
+    }
+
+    public abstract partial class ProtocolDiagnosticHttpEventBase
+    {
+        protected ProtocolDiagnosticHttpEventBase(ProtocolDiagnosticHttpEventBase other) { }
+
+        protected ProtocolDiagnosticHttpEventBase(string source, System.Uri url, System.TimeSpan? headerDuration, int? httpStatusCode, bool isRetry, bool isCancelled, bool isLastAttempt) { }
+
+        public System.TimeSpan? HeaderDuration { get { throw null; } }
+
+        public int? HttpStatusCode { get { throw null; } }
+
+        public bool IsCancelled { get { throw null; } }
+
+        public bool IsLastAttempt { get { throw null; } }
+
+        public bool IsRetry { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Uri Url { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolDiagnosticNupkgCopiedEvent
+    {
+        public ProtocolDiagnosticNupkgCopiedEvent(string source, long fileSize) { }
+
+        public long FileSize { get { throw null; } }
+
+        public string Source { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolDiagnosticResourceEvent
+    {
+        public ProtocolDiagnosticResourceEvent(string source, string resourceType, string type, string method, System.TimeSpan duration) { }
+
+        public System.TimeSpan Duration { get { throw null; } }
+
+        public string Method { get { throw null; } }
+
+        public string ResourceType { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public string Type { get { throw null; } }
+    }
+
+    public static partial class ProtocolDiagnostics
+    {
+        public static event ProtocolDiagnosticHttpEventHandler HttpEvent { add { } remove { } }
+
+        public static event ProtocolDiagnosticsNupkgCopiedEventHandler NupkgCopiedEvent { add { } remove { } }
+
+        public static event ProtocolDiagnosticResourceEventHandler ResourceEvent { add { } remove { } }
+
+        public delegate void ProtocolDiagnosticHttpEventHandler(ProtocolDiagnosticHttpEvent pdEvent);
+        public delegate void ProtocolDiagnosticResourceEventHandler(ProtocolDiagnosticResourceEvent pdrEvent);
+        public delegate void ProtocolDiagnosticsNupkgCopiedEventHandler(ProtocolDiagnosticNupkgCopiedEvent ncEvent);
+    }
+}
+
+namespace NuGet.Protocol.LocalRepositories
+{
+    public partial class LocalPackageListResourceProvider : Core.Types.ResourceProvider
+    {
+        public LocalPackageListResourceProvider() : base(default!) { }
+
+        public override System.Threading.Tasks.Task<System.Tuple<bool, Core.Types.INuGetResource>> TryCreate(Core.Types.SourceRepository source, System.Threading.CancellationToken token) { throw null; }
+    }
+}
+
+namespace NuGet.Protocol.Plugins
+{
+    public sealed partial class AutomaticProgressReporter : System.IDisposable
+    {
+        public static AutomaticProgressReporter Create(IConnection connection, Message request, System.TimeSpan interval, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class CloseRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public CloseRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class Connection : IConnection, System.IDisposable
+    {
+        public Connection(IMessageDispatcher dispatcher, ISender sender, IReceiver receiver, ConnectionOptions options) { }
+
+        public IMessageDispatcher MessageDispatcher { get { throw null; } }
+
+        public ConnectionOptions Options { get { throw null; } }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        public ConnectionState State { get { throw null; } }
+
+        public event System.EventHandler<ProtocolErrorEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<MessageEventArgs> MessageReceived { add { } remove { } }
+
+        public void Close() { }
+
+        public System.Threading.Tasks.Task ConnectAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class { throw null; }
+    }
+
+    public sealed partial class ConnectionOptions
+    {
+        public ConnectionOptions(Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion, System.TimeSpan handshakeTimeout, System.TimeSpan requestTimeout) { }
+
+        public System.TimeSpan HandshakeTimeout { get { throw null; } }
+
+        public Versioning.SemanticVersion MinimumProtocolVersion { get { throw null; } }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        public System.TimeSpan RequestTimeout { get { throw null; } }
+
+        public static ConnectionOptions CreateDefault(Common.IEnvironmentVariableReader reader = null) { throw null; }
+
+        public void SetRequestTimeout(System.TimeSpan requestTimeout) { }
+    }
+
+    public enum ConnectionState
+    {
+        FailedToHandshake = 0,
+        Closing = 1,
+        Closed = 2,
+        ReadyToConnect = 3,
+        Connecting = 4,
+        Handshaking = 5,
+        Connected = 6
+    }
+
+    public sealed partial class CopyFilesInPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion, System.Collections.Generic.IEnumerable<string> filesInPackage, string destinationFolderPath) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string DestinationFolderPath { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Collections.Generic.IEnumerable<string> FilesInPackage { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class CopyFilesInPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyFilesInPackageResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> copiedFiles) { }
+
+        public System.Collections.Generic.IEnumerable<string> CopiedFiles { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class CopyNupkgFileRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyNupkgFileRequest(string packageSourceRepository, string packageId, string packageVersion, string destinationFilePath) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string DestinationFilePath { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class CopyNupkgFileResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public CopyNupkgFileResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public abstract partial class EmbeddedSignatureVerifier
+    {
+        protected EmbeddedSignatureVerifier() { }
+
+        public static EmbeddedSignatureVerifier Create() { throw null; }
+
+        public abstract bool IsValid(string filePath);
+    }
+
+    public sealed partial class FallbackEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public FallbackEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+
+    public sealed partial class Fault
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Fault(string message) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Message { get { throw null; } }
+    }
+
+    public sealed partial class FaultedPluginEventArgs : System.EventArgs
+    {
+        public FaultedPluginEventArgs(IPlugin plugin, System.Exception exception) { }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public IPlugin Plugin { get { throw null; } }
+    }
+
+    public sealed partial class GetAuthenticationCredentialsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetAuthenticationCredentialsRequest(System.Uri uri, bool isRetry, bool isNonInteractive, bool canShowDialog) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool CanShowDialog { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool IsNonInteractive { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public bool IsRetry { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Uri Uri { get { throw null; } }
+    }
+
+    public sealed partial class GetAuthenticationCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetAuthenticationCredentialsResponse(string username, string password, string message, System.Collections.Generic.IList<string> authenticationTypes, MessageResponseCode responseCode) { }
+
+        public System.Collections.Generic.IList<string> AuthenticationTypes { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public string Username { get { throw null; } }
+
+        public bool IsValid() { throw null; }
+    }
+
+    public sealed partial class GetCredentialsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetCredentialsRequest(string packageSourceRepository, System.Net.HttpStatusCode statusCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Net.HttpStatusCode StatusCode { get { throw null; } }
+    }
+
+    public sealed partial class GetCredentialsRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public GetCredentialsRequestHandler(IPlugin plugin, System.Net.IWebProxy proxy, Configuration.ICredentialService credentialService) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void AddOrUpdateSourceRepository(Core.Types.SourceRepository sourceRepository) { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class GetCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetCredentialsResponse(MessageResponseCode responseCode, string username, string password, System.Collections.Generic.IReadOnlyList<string> authenticationTypes = null) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> AuthenticationTypes { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public string Username { get { throw null; } }
+    }
+
+    public sealed partial class GetFilesInPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetFilesInPackageRequest(string packageSourceRepository, string packageId, string packageVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class GetFilesInPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetFilesInPackageResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> files) { }
+
+        public System.Collections.Generic.IEnumerable<string> Files { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class GetOperationClaimsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetOperationClaimsRequest(string packageSourceRepository, Newtonsoft.Json.Linq.JObject serviceIndex) { }
+
+        public string PackageSourceRepository { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject ServiceIndex { get { throw null; } }
+    }
+
+    public sealed partial class GetOperationClaimsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetOperationClaimsResponse(System.Collections.Generic.IEnumerable<OperationClaim> claims) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> Claims { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageHashRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageHashRequest(string packageSourceRepository, string packageId, string packageVersion, string hashAlgorithm) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string HashAlgorithm { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageHashResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageHashResponse(MessageResponseCode responseCode, string hash) { }
+
+        public string Hash { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageVersionsRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageVersionsRequest(string packageSourceRepository, string packageId) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+    }
+
+    public sealed partial class GetPackageVersionsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetPackageVersionsResponse(MessageResponseCode responseCode, System.Collections.Generic.IEnumerable<string> versions) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> Versions { get { throw null; } }
+    }
+
+    public sealed partial class GetServiceIndexRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetServiceIndexRequest(string packageSourceRepository) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+    }
+
+    public sealed partial class GetServiceIndexRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public GetServiceIndexRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void AddOrUpdateSourceRepository(Core.Types.SourceRepository sourceRepository) { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class GetServiceIndexResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public GetServiceIndexResponse(MessageResponseCode responseCode, Newtonsoft.Json.Linq.JObject serviceIndex) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject ServiceIndex { get { throw null; } }
+    }
+
+    public sealed partial class HandshakeRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public HandshakeRequest(Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Versioning.SemanticVersion MinimumProtocolVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+    }
+
+    public sealed partial class HandshakeResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public HandshakeResponse(MessageResponseCode responseCode, Versioning.SemanticVersion protocolVersion) { }
+
+        public Versioning.SemanticVersion ProtocolVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public partial interface IConnection : System.IDisposable
+    {
+        IMessageDispatcher MessageDispatcher { get; }
+
+        ConnectionOptions Options { get; }
+
+        Versioning.SemanticVersion ProtocolVersion { get; }
+
+        event System.EventHandler<ProtocolErrorEventArgs> Faulted;
+        event System.EventHandler<MessageEventArgs> MessageReceived;
+        void Close();
+        System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<TInbound> SendRequestAndReceiveResponseAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class;
+    }
+
+    public partial interface IIdGenerator
+    {
+        string GenerateUniqueId();
+    }
+
+    public partial interface IMessageDispatcher : System.IDisposable
+    {
+        IRequestHandlers RequestHandlers { get; }
+
+        void Close();
+        Message CreateMessage(MessageType type, MessageMethod method);
+        Message CreateMessage<TPayload>(MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class;
+        System.Threading.Tasks.Task DispatchCancelAsync(Message request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task DispatchFaultAsync(Message request, Fault fault, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task DispatchProgressAsync(Message request, Progress progress, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class;
+        System.Threading.Tasks.Task DispatchResponseAsync<TOutbound>(Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class;
+        void SetConnection(IConnection connection);
+    }
+
+    public sealed partial class InboundRequestContext : System.IDisposable
+    {
+        public InboundRequestContext(IConnection connection, string requestId, System.Threading.CancellationToken cancellationToken) { }
+
+        public string RequestId { get { throw null; } }
+
+        public void BeginFaultAsync(Message request, System.Exception exception) { }
+
+        public void BeginResponseAsync(Message request, IRequestHandler requestHandler, IResponseHandler responseHandler) { }
+
+        public void Cancel() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class InitializeRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public InitializeRequest(string clientVersion, string culture, System.TimeSpan requestTimeout) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string ClientVersion { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Culture { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public System.TimeSpan RequestTimeout { get { throw null; } }
+    }
+
+    public sealed partial class InitializeResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public InitializeResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public partial interface IPlugin : System.IDisposable
+    {
+        IConnection Connection { get; }
+
+        string FilePath { get; }
+
+        string Id { get; }
+
+        string Name { get; }
+
+        event System.EventHandler BeforeClose;
+        event System.EventHandler Closed;
+        void Close();
+    }
+
+    public partial interface IPluginDiscoverer : System.IDisposable
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> DiscoverAsync(System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginFactory : System.IDisposable
+    {
+        System.Threading.Tasks.Task<IPlugin> GetOrCreateAsync(string filePath, System.Collections.Generic.IEnumerable<string> arguments, IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken);
+    }
+
+    public partial interface IPluginManager
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginCreationResult>> CreatePluginsAsync(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginMulticlientUtilities
+    {
+        System.Threading.Tasks.Task DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IPluginProcess : System.IDisposable
+    {
+        int? ExitCode { get; }
+
+        int? Id { get; }
+
+        event System.EventHandler<IPluginProcess> Exited;
+        event System.EventHandler<LineReadEventArgs> LineRead;
+        void BeginReadLine();
+        void CancelRead();
+        void Kill();
+    }
+
+    public partial interface IReceiver : System.IDisposable
+    {
+        event System.EventHandler<ProtocolErrorEventArgs> Faulted;
+        event System.EventHandler<MessageEventArgs> MessageReceived;
+        void Close();
+        void Connect();
+    }
+
+    public partial interface IRequestHandler
+    {
+        System.Threading.CancellationToken CancellationToken { get; }
+
+        System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IRequestHandlers
+    {
+        void AddOrUpdate(MessageMethod method, System.Func<IRequestHandler> addHandlerFunc, System.Func<IRequestHandler, IRequestHandler> updateHandlerFunc);
+        bool TryAdd(MessageMethod method, IRequestHandler handler);
+        bool TryGet(MessageMethod method, out IRequestHandler handler);
+        bool TryRemove(MessageMethod method);
+    }
+
+    public partial interface IResponseHandler
+    {
+        System.Threading.Tasks.Task SendResponseAsync<TPayload>(Message request, TPayload payload, System.Threading.CancellationToken cancellationToken)
+            where TPayload : class;
+    }
+
+    public partial interface ISender : System.IDisposable
+    {
+        void Close();
+        void Connect();
+        System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public static partial class JsonSerializationUtilities
+    {
+        public static Newtonsoft.Json.JsonSerializer Serializer { get { throw null; } }
+
+        public static T Deserialize<T>(string json)
+            where T : class { throw null; }
+
+        public static Newtonsoft.Json.Linq.JObject FromObject(object value) { throw null; }
+
+        public static void Serialize(Newtonsoft.Json.JsonWriter writer, object value) { }
+
+        public static T ToObject<T>(Newtonsoft.Json.Linq.JObject jObject) { throw null; }
+    }
+
+    public sealed partial class LineReadEventArgs : System.EventArgs
+    {
+        public LineReadEventArgs(string line) { }
+
+        public string Line { get { throw null; } }
+    }
+
+    public sealed partial class LogRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public LogRequest(Common.LogLevel logLevel, string message) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Common.LogLevel LogLevel { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string Message { get { throw null; } }
+    }
+
+    public sealed partial class LogRequestHandler : IRequestHandler
+    {
+        public LogRequestHandler(Common.ILogger logger) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public static Common.LogLevel GetLogLevel(Common.ILogger logger) { throw null; }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetLogger(Common.ILogger logger) { }
+    }
+
+    public sealed partial class LogResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public LogResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class Message
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Message(string requestId, MessageType type, MessageMethod method, Newtonsoft.Json.Linq.JObject payload = null) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageMethod Method { get { throw null; } }
+
+        public Newtonsoft.Json.Linq.JObject Payload { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string RequestId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageType Type { get { throw null; } }
+    }
+
+    public sealed partial class MessageDispatcher : IMessageDispatcher, System.IDisposable, IResponseHandler
+    {
+        public MessageDispatcher(IRequestHandlers requestHandlers, IIdGenerator idGenerator) { }
+
+        public IRequestHandlers RequestHandlers { get { throw null; } }
+
+        public void Close() { }
+
+        public Message CreateMessage(MessageType type, MessageMethod method) { throw null; }
+
+        public Message CreateMessage<TPayload>(MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class { throw null; }
+
+        public System.Threading.Tasks.Task DispatchCancelAsync(Message request, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task DispatchFaultAsync(Message request, Fault fault, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task DispatchProgressAsync(Message request, Progress progress, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<TInbound> DispatchRequestAsync<TOutbound, TInbound>(MessageMethod method, TOutbound payload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class where TInbound : class { throw null; }
+
+        public System.Threading.Tasks.Task DispatchResponseAsync<TOutbound>(Message request, TOutbound responsePayload, System.Threading.CancellationToken cancellationToken)
+            where TOutbound : class { throw null; }
+
+        public void Dispose() { }
+
+        System.Threading.Tasks.Task IResponseHandler.SendResponseAsync<TPayload>(Message request, TPayload payload, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetConnection(IConnection connection) { }
+    }
+
+    public sealed partial class MessageEventArgs : System.EventArgs
+    {
+        public MessageEventArgs(Message message) { }
+
+        public Message Message { get { throw null; } }
+    }
+
+    public enum MessageMethod
+    {
+        None = 0,
+        Close = 1,
+        CopyFilesInPackage = 2,
+        CopyNupkgFile = 3,
+        GetCredentials = 4,
+        GetFilesInPackage = 5,
+        GetOperationClaims = 6,
+        GetPackageHash = 7,
+        GetPackageVersions = 8,
+        GetServiceIndex = 9,
+        Handshake = 10,
+        Initialize = 11,
+        Log = 12,
+        MonitorNuGetProcessExit = 13,
+        PrefetchPackage = 14,
+        SetCredentials = 15,
+        SetLogLevel = 16,
+        GetAuthenticationCredentials = 17
+    }
+
+    public enum MessageResponseCode
+    {
+        Success = 0,
+        Error = 1,
+        NotFound = 2
+    }
+
+    public enum MessageType
+    {
+        Cancel = 0,
+        Fault = 1,
+        Progress = 2,
+        Request = 3,
+        Response = 4
+    }
+
+    public static partial class MessageUtilities
+    {
+        public static Message Create(string requestId, MessageType type, MessageMethod method) { throw null; }
+
+        public static Message Create<TPayload>(string requestId, MessageType type, MessageMethod method, TPayload payload)
+            where TPayload : class { throw null; }
+
+        public static TPayload DeserializePayload<TPayload>(Message message) { throw null; }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public MonitorNuGetProcessExitRequest(int processId) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public int ProcessId { get { throw null; } }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitRequestHandler : IRequestHandler, System.IDisposable
+    {
+        public MonitorNuGetProcessExitRequestHandler(IPlugin plugin) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class MonitorNuGetProcessExitResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public MonitorNuGetProcessExitResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class NoOpDisposePlugin : IPlugin, System.IDisposable
+    {
+        public NoOpDisposePlugin(IPlugin plugin) { }
+
+        public IConnection Connection { get { throw null; } }
+
+        public string FilePath { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public event System.EventHandler BeforeClose { add { } remove { } }
+
+        public event System.EventHandler Closed { add { } remove { } }
+
+        public void Close() { }
+
+        public void Dispose() { }
+    }
+
+    public enum OperationClaim
+    {
+        DownloadPackage = 0,
+        Authentication = 1
+    }
+
+    public abstract partial class OutboundRequestContext : System.IDisposable
+    {
+        protected OutboundRequestContext() { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } protected set { } }
+
+        public string RequestId { get { throw null; } protected set { } }
+
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract void HandleCancelResponse();
+        public abstract void HandleFault(Message fault);
+        public abstract void HandleProgress(Message progress);
+        public abstract void HandleResponse(Message response);
+    }
+
+    public sealed partial class OutboundRequestContext<TResult> : OutboundRequestContext
+    {
+        public OutboundRequestContext(IConnection connection, Message request, System.TimeSpan? timeout, bool isKeepAlive, System.Threading.CancellationToken cancellationToken) { }
+
+        public System.Threading.Tasks.Task<TResult> CompletionTask { get { throw null; } }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override void HandleCancelResponse() { }
+
+        public override void HandleFault(Message fault) { }
+
+        public override void HandleProgress(Message progress) { }
+
+        public override void HandleResponse(Message response) { }
+    }
+
+    public sealed partial class Plugin : IPlugin, System.IDisposable
+    {
+        public Plugin(string filePath, IConnection connection, IPluginProcess process, bool isOwnProcess, System.TimeSpan idleTimeout) { }
+
+        public IConnection Connection { get { throw null; } }
+
+        public string FilePath { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public event System.EventHandler BeforeClose { add { } remove { } }
+
+        public event System.EventHandler Closed { add { } remove { } }
+
+        public event System.EventHandler<PluginEventArgs> Exited { add { } remove { } }
+
+        public event System.EventHandler<FaultedPluginEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<PluginEventArgs> Idle { add { } remove { } }
+
+        public void Close() { }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class PluginCacheEntry
+    {
+        public PluginCacheEntry(string rootCacheFolder, string pluginFilePath, string requestKey) { }
+
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> OperationClaims { get { throw null; } set { } }
+
+        public void LoadFromFile() { }
+
+        public System.Threading.Tasks.Task UpdateCacheFileAsync() { throw null; }
+    }
+
+    public static partial class PluginConstants
+    {
+        public static readonly System.TimeSpan CloseTimeout;
+        public static readonly System.TimeSpan IdleTimeout;
+        public static readonly System.Collections.Generic.IEnumerable<string> PluginArguments;
+        public static readonly System.TimeSpan ProgressInterval;
+        public static readonly System.TimeSpan RequestTimeout;
+    }
+
+    public sealed partial class PluginCreationResult
+    {
+        public PluginCreationResult(IPlugin plugin, IPluginMulticlientUtilities utilities, System.Collections.Generic.IReadOnlyList<OperationClaim> claims) { }
+
+        public PluginCreationResult(string message, System.Exception exception) { }
+
+        public PluginCreationResult(string message) { }
+
+        public System.Collections.Generic.IReadOnlyList<OperationClaim> Claims { get { throw null; } }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public string Message { get { throw null; } }
+
+        public IPlugin Plugin { get { throw null; } }
+
+        public IPluginMulticlientUtilities PluginMulticlientUtilities { get { throw null; } }
+    }
+
+    public sealed partial class PluginDiscoverer : IPluginDiscoverer, System.IDisposable
+    {
+        public PluginDiscoverer(string rawPluginPaths, EmbeddedSignatureVerifier verifier) { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> DiscoverAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+    }
+
+    public sealed partial class PluginDiscoveryResult
+    {
+        public PluginDiscoveryResult(PluginFile pluginFile) { }
+
+        public string Message { get { throw null; } }
+
+        public PluginFile PluginFile { get { throw null; } }
+    }
+
+    public static partial class PluginDiscoveryUtility
+    {
+        public static System.Lazy<string> InternalPluginDiscoveryRoot { get { throw null; } set { } }
+
+        public static System.Collections.Generic.IEnumerable<string> GetConventionBasedPlugins(System.Collections.Generic.IEnumerable<string> directories) { throw null; }
+
+        public static string GetNuGetHomePluginsPath() { throw null; }
+
+        public static string GetNuGetPluginsDirectoryRelativeToNuGetAssembly(string nugetAssemblyPath) { throw null; }
+    }
+
+    public sealed partial class PluginEventArgs : System.EventArgs
+    {
+        public PluginEventArgs(IPlugin plugin) { }
+
+        public IPlugin Plugin { get { throw null; } }
+    }
+
+    public sealed partial class PluginException : System.Exception
+    {
+        public PluginException(string message, System.Exception innerException) { }
+
+        public PluginException(string message) { }
+    }
+
+    public sealed partial class PluginFactory : IPluginFactory, System.IDisposable
+    {
+        public PluginFactory(System.TimeSpan pluginIdleTimeout) { }
+
+        public static System.Threading.Tasks.Task<IPlugin> CreateFromCurrentProcessAsync(IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<IPlugin> GetOrCreateAsync(string filePath, System.Collections.Generic.IEnumerable<string> arguments, IRequestHandlers requestHandlers, ConnectionOptions options, System.Threading.CancellationToken sessionCancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginFile
+    {
+        public PluginFile(string filePath, System.Lazy<PluginFileState> state) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Lazy<PluginFileState> State { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum PluginFileState
+    {
+        Valid = 0,
+        NotFound = 1,
+        InvalidFilePath = 2,
+        InvalidEmbeddedSignature = 3
+    }
+
+    public sealed partial class PluginManager : IPluginManager, System.IDisposable
+    {
+        public PluginManager(Common.IEnvironmentVariableReader reader, System.Lazy<IPluginDiscoverer> pluginDiscoverer, System.Func<System.TimeSpan, IPluginFactory> pluginFactoryCreator, System.Lazy<string> pluginsCacheDirectoryPath) { }
+
+        public Common.IEnvironmentVariableReader EnvironmentVariableReader { get { throw null; } }
+
+        public static IPluginManager Instance { get { throw null; } }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginCreationResult>> CreatePluginsAsync(Core.Types.SourceRepository source, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<PluginDiscoveryResult>> FindAvailablePluginsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Tuple<bool, PluginCreationResult>> TryGetSourceAgnosticPluginAsync(PluginDiscoveryResult pluginDiscoveryResult, OperationClaim requestedOperationClaim, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginMulticlientUtilities : IPluginMulticlientUtilities
+    {
+        public PluginMulticlientUtilities() { }
+
+        public System.Threading.Tasks.Task DoOncePerPluginLifetimeAsync(string key, System.Func<System.Threading.Tasks.Task> taskFunc, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class PluginPackageDownloader : Packaging.IPackageDownloader, System.IDisposable
+    {
+        public PluginPackageDownloader(IPlugin plugin, Packaging.Core.PackageIdentity packageIdentity, PluginPackageReader packageReader, string packageSourceRepository) { }
+
+        public Packaging.IAsyncPackageContentReader ContentReader { get { throw null; } }
+
+        public Packaging.Core.IAsyncPackageCoreReader CoreReader { get { throw null; } }
+
+        public Packaging.Signing.ISignedPackageReader SignedPackageReader { get { throw null; } }
+
+        public string Source { get { throw null; } }
+
+        public System.Threading.Tasks.Task<bool> CopyNupkgFileToAsync(string destinationFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task<string> GetPackageHashAsync(string hashAlgorithm, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public void SetExceptionHandler(System.Func<System.Exception, System.Threading.Tasks.Task<bool>> handleExceptionAsync) { }
+
+        public void SetThrottle(System.Threading.SemaphoreSlim throttle) { }
+    }
+
+    public sealed partial class PluginPackageReader : Packaging.PackageReaderBase
+    {
+        public PluginPackageReader(IPlugin plugin, Packaging.Core.PackageIdentity packageIdentity, string packageSourceRepository) : base(default!) { }
+
+        public override Packaging.NuspecReader NuspecReader { get { throw null; } }
+
+        public override bool CanVerifySignedPackages(Packaging.Signing.SignedPackageVerifierSettings verifierSettings) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> CopyFiles(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Packaging.Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> CopyFilesAsync(string destination, System.Collections.Generic.IEnumerable<string> packageFiles, Packaging.Core.ExtractPackageFileDelegate extractFile, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<string> CopyNupkgAsync(string nupkgFilePath, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        protected override void Dispose(bool disposing) { }
+
+        public override System.Threading.Tasks.Task<byte[]> GetArchiveHashAsync(Common.HashAlgorithmName hashAlgorithm, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetBuildItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetBuildItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override string GetContentHash(System.Threading.CancellationToken token, System.Func<string> GetUnsignedPackageHash = null) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetContentItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetContentItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override bool GetDevelopmentDependency() { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> GetDevelopmentDependencyAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles() { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<string> GetFiles(string folder) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(string folder, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<string>> GetFilesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetFrameworkItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetFrameworkItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override Packaging.Core.PackageIdentity GetIdentity() { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.Core.PackageIdentity> GetIdentityAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetItems(string folderName) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetItemsAsync(string folderName, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetLibItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetLibItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override Versioning.NuGetVersion GetMinClientVersion() { throw null; }
+
+        public override System.Threading.Tasks.Task<Versioning.NuGetVersion> GetMinClientVersionAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.IO.Stream GetNuspec() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.IO.Stream> GetNuspecAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override string GetNuspecFile() { throw null; }
+
+        public override System.Threading.Tasks.Task<string> GetNuspecFileAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.NuspecReader> GetNuspecReaderAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup> GetPackageDependencies() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.PackageDependencyGroup>> GetPackageDependenciesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> GetPackageTypes() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType>> GetPackageTypesAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<Packaging.Signing.PrimarySignature> GetPrimarySignatureAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetReferenceItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetReferenceItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.IO.Stream GetStream(string path) { throw null; }
+
+        public override System.Threading.Tasks.Task<System.IO.Stream> GetStreamAsync(string path, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetSupportedFrameworks() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework>> GetSupportedFrameworksAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup> GetToolItems() { throw null; }
+
+        public override System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Packaging.FrameworkSpecificGroup>> GetToolItemsAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override bool IsServiceable() { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsServiceableAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public override System.Threading.Tasks.Task<bool> IsSignedAsync(System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Threading.Tasks.Task ValidateIntegrityAsync(Packaging.Signing.SignatureContent signatureContent, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public sealed partial class PluginProcess : IPluginProcess, System.IDisposable
+    {
+        public PluginProcess() { }
+
+        public PluginProcess(System.Diagnostics.ProcessStartInfo startInfo) { }
+
+        public int? ExitCode { get { throw null; } }
+
+        public int? Id { get { throw null; } }
+
+        public event System.EventHandler<IPluginProcess> Exited { add { } remove { } }
+
+        public event System.EventHandler<LineReadEventArgs> LineRead { add { } remove { } }
+
+        public void BeginReadLine() { }
+
+        public void CancelRead() { }
+
+        public void Dispose() { }
+
+        public void Kill() { }
+
+        public void Start() { }
+    }
+
+    public sealed partial class PrefetchPackageRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public PrefetchPackageRequest(string packageSourceRepository, string packageId, string packageVersion) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageId { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageVersion { get { throw null; } }
+    }
+
+    public sealed partial class PrefetchPackageResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public PrefetchPackageResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class Progress
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public Progress(double? percentage = null) { }
+
+        public double? Percentage { get { throw null; } }
+    }
+
+    public static partial class ProtocolConstants
+    {
+        public static readonly Versioning.SemanticVersion CurrentVersion;
+        public static readonly System.TimeSpan HandshakeTimeout;
+        public static readonly System.TimeSpan MaxTimeout;
+        public static readonly System.TimeSpan MinTimeout;
+        public static readonly System.TimeSpan RequestTimeout;
+        public static readonly Versioning.SemanticVersion Version100;
+    }
+
+    public sealed partial class ProtocolErrorEventArgs : System.EventArgs
+    {
+        public ProtocolErrorEventArgs(System.Exception exception, Message message) { }
+
+        public ProtocolErrorEventArgs(System.Exception exception) { }
+
+        public System.Exception Exception { get { throw null; } }
+
+        public Message Message { get { throw null; } }
+    }
+
+    public sealed partial class ProtocolException : System.Exception
+    {
+        public ProtocolException(string message, System.Exception innerException) { }
+
+        public ProtocolException(string message) { }
+    }
+
+    public abstract partial class Receiver : IReceiver, System.IDisposable
+    {
+        protected Receiver() { }
+
+        protected bool IsClosed { get { throw null; } }
+
+        protected bool IsDisposed { get { throw null; } set { } }
+
+        public event System.EventHandler<ProtocolErrorEventArgs> Faulted { add { } remove { } }
+
+        public event System.EventHandler<MessageEventArgs> MessageReceived { add { } remove { } }
+
+        public virtual void Close() { }
+
+        public abstract void Connect();
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        protected void FireFaultEvent(System.Exception exception, Message message) { }
+
+        protected void FireMessageReceivedEvent(Message message) { }
+
+        protected void ThrowIfClosed() { }
+
+        protected void ThrowIfDisposed() { }
+    }
+
+    public sealed partial class RequestHandlers : IRequestHandlers
+    {
+        public RequestHandlers() { }
+
+        public void AddOrUpdate(MessageMethod method, System.Func<IRequestHandler> addHandlerFunc, System.Func<IRequestHandler, IRequestHandler> updateHandlerFunc) { }
+
+        public bool TryAdd(MessageMethod method, IRequestHandler handler) { throw null; }
+
+        public bool TryGet(MessageMethod method, out IRequestHandler handler) { throw null; }
+
+        public bool TryRemove(MessageMethod method) { throw null; }
+    }
+
+    public sealed partial class RequestIdGenerator : IIdGenerator
+    {
+        public RequestIdGenerator() { }
+
+        public string GenerateUniqueId() { throw null; }
+    }
+
+    public sealed partial class Sender : ISender, System.IDisposable
+    {
+        public Sender(System.IO.TextWriter writer) { }
+
+        public void Close() { }
+
+        public void Connect() { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task SendAsync(Message message, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public sealed partial class SetCredentialsRequest
+    {
+        public SetCredentialsRequest(string packageSourceRepository, string proxyUsername, string proxyPassword, string username, string password) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public string PackageSourceRepository { get { throw null; } }
+
+        public string Password { get { throw null; } }
+
+        public string ProxyPassword { get { throw null; } }
+
+        public string ProxyUsername { get { throw null; } }
+
+        public string Username { get { throw null; } }
+    }
+
+    public sealed partial class SetCredentialsResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetCredentialsResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class SetLogLevelRequest
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetLogLevelRequest(Common.LogLevel logLevel) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public Common.LogLevel LogLevel { get { throw null; } }
+    }
+
+    public sealed partial class SetLogLevelResponse
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public SetLogLevelResponse(MessageResponseCode responseCode) { }
+
+        [Newtonsoft.Json.JsonRequired]
+        public MessageResponseCode ResponseCode { get { throw null; } }
+    }
+
+    public sealed partial class StandardInputReceiver : Receiver
+    {
+        public StandardInputReceiver(System.IO.TextReader reader) { }
+
+        public override void Connect() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class StandardOutputReceiver : Receiver
+    {
+        public StandardOutputReceiver(IPluginProcess process) { }
+
+        public override void Close() { }
+
+        public override void Connect() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    public sealed partial class SymmetricHandshake : IRequestHandler, System.IDisposable
+    {
+        public SymmetricHandshake(IConnection connection, System.TimeSpan handshakeTimeout, Versioning.SemanticVersion protocolVersion, Versioning.SemanticVersion minimumProtocolVersion) { }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.Task HandleResponseAsync(IConnection connection, Message request, IResponseHandler responseHandler, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Versioning.SemanticVersion> HandshakeAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public static partial class TimeoutUtilities
+    {
+        public static System.TimeSpan GetTimeout(string timeoutInSeconds, System.TimeSpan fallbackTimeout) { throw null; }
+
+        public static bool IsValid(System.TimeSpan timeout) { throw null; }
+    }
+
+    public partial class UnixAndMonoPlatformsEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public UnixAndMonoPlatformsEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+
+    public sealed partial class WindowsEmbeddedSignatureVerifier : EmbeddedSignatureVerifier
+    {
+        public WindowsEmbeddedSignatureVerifier() { }
+
+        public override bool IsValid(string filePath) { throw null; }
+    }
+}
+
+namespace NuGet.Protocol.VisualStudio
+{
+    public static partial class FactoryExtensionsVS
+    {
+        public static System.Collections.Generic.IEnumerable<System.Lazy<Core.Types.INuGetResourceProvider>> GetVisualStudio(this Core.Types.Repository.ProviderFactory factory) { throw null; }
+
+        public static Core.Types.SourceRepository GetVisualStudio(this Core.Types.Repository.RepositoryFactory factory, Configuration.PackageSource source) { throw null; }
+
+        public static Core.Types.SourceRepository GetVisualStudio(this Core.Types.Repository.RepositoryFactory factory, string source) { throw null; }
+    }
+}
+
+namespace NuGet.Repositories
+{
+    public partial class LocalPackageInfo
+    {
+        public LocalPackageInfo(string packageId, Versioning.NuGetVersion version, string path, string manifestPath, string zipPath, string sha512Path, System.Lazy<Packaging.NuspecReader> nuspec, System.Lazy<System.Collections.Generic.IReadOnlyList<string>> files, System.Lazy<string> sha512, System.Lazy<RuntimeModel.RuntimeGraph> runtimeGraph) { }
+
+        public string ExpandedPath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Files { get { throw null; } }
+
+        public string Id { get { throw null; } }
+
+        public string ManifestPath { get { throw null; } }
+
+        public Packaging.NuspecReader Nuspec { get { throw null; } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } }
+
+        public string Sha512 { get { throw null; } }
+
+        public string Sha512Path { get { throw null; } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } }
+
+        public string ZipPath { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LocalPackageSourceInfo
+    {
+        public LocalPackageSourceInfo(NuGetv3LocalRepository repository, LocalPackageInfo package) { }
+
+        public LocalPackageInfo Package { get { throw null; } }
+
+        public NuGetv3LocalRepository Repository { get { throw null; } }
+    }
+
+    public partial class NuGetv3LocalRepository
+    {
+        public NuGetv3LocalRepository(string path, Protocol.LocalPackageFileCache packageFileCache, bool isFallbackFolder, bool updateLastAccessTime) { }
+
+        public NuGetv3LocalRepository(string path, Protocol.LocalPackageFileCache packageFileCache, bool isFallbackFolder) { }
+
+        public NuGetv3LocalRepository(string path) { }
+
+        public Packaging.VersionFolderPathResolver PathResolver { get { throw null; } }
+
+        public string RepositoryRoot { get { throw null; } }
+
+        public void ClearCacheForIds(System.Collections.Generic.IEnumerable<string> packageIds) { }
+
+        public bool Exists(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public LocalPackageInfo FindPackage(string packageId, Versioning.NuGetVersion version) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<LocalPackageInfo> FindPackagesById(string packageId) { throw null; }
+    }
+
+    public static partial class NuGetv3LocalRepositoryUtility
+    {
+        public static LocalPackageSourceInfo GetPackage(System.Collections.Generic.IReadOnlyList<NuGetv3LocalRepository> repositories, string id, Versioning.NuGetVersion version) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.protocol/6.2.2/nuget.protocol.nuspec
+++ b/src/referencePackages/src/nuget.protocol/6.2.2/nuget.protocol.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Protocol</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's implementation for interacting with feeds. Contains functionality for all feed types.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget protocol</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.Packaging" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Packaging" version="6.2.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+    </frameworkAssemblies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.versioning/6.2.2/NuGet.Versioning.6.2.2.csproj
+++ b/src/referencePackages/src/nuget.versioning/6.2.2/NuGet.Versioning.6.2.2.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Versioning</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.versioning/6.2.2/lib/netstandard2.0/NuGet.Versioning.cs
+++ b/src/referencePackages/src/nuget.versioning/6.2.2/lib/netstandard2.0/NuGet.Versioning.cs
@@ -1,0 +1,405 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's implementation of Semantic Versioning.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.2.2.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.2.2+027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d.027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Versioning")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.2.2.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Versioning
+{
+    public partial class FloatRange : System.IEquatable<FloatRange>
+    {
+        public FloatRange(NuGetVersionFloatBehavior floatBehavior, NuGetVersion minVersion, string releasePrefix) { }
+
+        public FloatRange(NuGetVersionFloatBehavior floatBehavior, NuGetVersion minVersion) { }
+
+        public FloatRange(NuGetVersionFloatBehavior floatBehavior) { }
+
+        public NuGetVersionFloatBehavior FloatBehavior { get { throw null; } }
+
+        public bool HasMinVersion { get { throw null; } }
+
+        public NuGetVersion MinVersion { get { throw null; } }
+
+        public string OriginalReleasePrefix { get { throw null; } }
+
+        public bool Equals(FloatRange other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static FloatRange Parse(string versionString) { throw null; }
+
+        public bool Satisfies(NuGetVersion version) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static bool TryParse(string versionString, out FloatRange range) { throw null; }
+    }
+
+    public partial interface INuGetVersionable
+    {
+        NuGetVersion Version { get; }
+    }
+
+    public partial interface IVersionComparer : System.Collections.Generic.IEqualityComparer<SemanticVersion>, System.Collections.Generic.IComparer<SemanticVersion>
+    {
+    }
+
+    public partial interface IVersionRangeComparer : System.Collections.Generic.IEqualityComparer<VersionRangeBase>
+    {
+    }
+
+    public partial class NuGetVersion : SemanticVersion
+    {
+        public NuGetVersion(NuGetVersion version) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, int revision, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, int revision, string releaseLabel, string metadata) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, int revision) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, string releaseLabel, string metadata) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch, string releaseLabel) : base(default!) { }
+
+        public NuGetVersion(int major, int minor, int patch) : base(default!) { }
+
+        public NuGetVersion(string version) : base(default!) { }
+
+        public NuGetVersion(System.Version version, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata, string originalVersion) : base(default!) { }
+
+        public NuGetVersion(System.Version version, string releaseLabel = null, string metadata = null) : base(default!) { }
+
+        public virtual bool IsLegacyVersion { get { throw null; } }
+
+        public bool IsSemVer2 { get { throw null; } }
+
+        public string OriginalVersion { get { throw null; } }
+
+        public int Revision { get { throw null; } }
+
+        public System.Version Version { get { throw null; } }
+
+        public new static NuGetVersion Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static bool TryParse(string value, out NuGetVersion version) { throw null; }
+
+        public static bool TryParseStrict(string value, out NuGetVersion version) { throw null; }
+    }
+
+    public enum NuGetVersionFloatBehavior
+    {
+        None = 0,
+        Prerelease = 1,
+        Revision = 2,
+        Patch = 3,
+        Minor = 4,
+        Major = 5,
+        AbsoluteLatest = 6,
+        PrereleaseRevision = 7,
+        PrereleasePatch = 8,
+        PrereleaseMinor = 9,
+        PrereleaseMajor = 10
+    }
+
+    public partial class SemanticVersion : System.IFormattable, System.IComparable, System.IComparable<SemanticVersion>, System.IEquatable<SemanticVersion>
+    {
+        public SemanticVersion(SemanticVersion version) { }
+
+        public SemanticVersion(int major, int minor, int patch, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata) { }
+
+        protected SemanticVersion(int major, int minor, int patch, int revision, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata) { }
+
+        protected SemanticVersion(int major, int minor, int patch, int revision, string releaseLabel, string metadata) { }
+
+        public SemanticVersion(int major, int minor, int patch, string releaseLabel, string metadata) { }
+
+        public SemanticVersion(int major, int minor, int patch, string releaseLabel) { }
+
+        public SemanticVersion(int major, int minor, int patch) { }
+
+        protected SemanticVersion(System.Version version, System.Collections.Generic.IEnumerable<string> releaseLabels, string metadata) { }
+
+        protected SemanticVersion(System.Version version, string releaseLabel = null, string metadata = null) { }
+
+        public virtual bool HasMetadata { get { throw null; } }
+
+        public virtual bool IsPrerelease { get { throw null; } }
+
+        public int Major { get { throw null; } }
+
+        public virtual string Metadata { get { throw null; } }
+
+        public int Minor { get { throw null; } }
+
+        public int Patch { get { throw null; } }
+
+        public string Release { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<string> ReleaseLabels { get { throw null; } }
+
+        public virtual int CompareTo(SemanticVersion other, VersionComparison versionComparison) { throw null; }
+
+        public virtual int CompareTo(SemanticVersion other) { throw null; }
+
+        public virtual int CompareTo(object obj) { throw null; }
+
+        public virtual bool Equals(SemanticVersion other, VersionComparison versionComparison) { throw null; }
+
+        public virtual bool Equals(SemanticVersion other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static bool operator >(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static bool operator >=(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static bool operator !=(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static bool operator <(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static bool operator <=(SemanticVersion version1, SemanticVersion version2) { throw null; }
+
+        public static SemanticVersion Parse(string value) { throw null; }
+
+        public virtual string ToFullString() { throw null; }
+
+        public virtual string ToNormalizedString() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public virtual string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+
+        protected bool TryFormatter(string format, System.IFormatProvider formatProvider, out string formattedString) { throw null; }
+
+        public static bool TryParse(string value, out SemanticVersion version) { throw null; }
+    }
+
+    public partial class SemanticVersionConverter : System.ComponentModel.TypeConverter
+    {
+        public SemanticVersionConverter() { }
+
+        public override bool CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) { throw null; }
+
+        public override bool CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) { throw null; }
+
+        public override object ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) { throw null; }
+
+        public override object ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) { throw null; }
+    }
+
+    public sealed partial class VersionComparer : IVersionComparer, System.Collections.Generic.IEqualityComparer<SemanticVersion>, System.Collections.Generic.IComparer<SemanticVersion>
+    {
+        public static readonly IVersionComparer Default;
+        public static readonly IVersionComparer Version;
+        public static readonly IVersionComparer VersionRelease;
+        public static readonly IVersionComparer VersionReleaseMetadata;
+        public VersionComparer() { }
+
+        public VersionComparer(VersionComparison versionComparison) { }
+
+        public static int Compare(SemanticVersion version1, SemanticVersion version2, VersionComparison versionComparison) { throw null; }
+
+        public int Compare(SemanticVersion x, SemanticVersion y) { throw null; }
+
+        public bool Equals(SemanticVersion x, SemanticVersion y) { throw null; }
+
+        public int GetHashCode(SemanticVersion version) { throw null; }
+    }
+
+    public enum VersionComparison
+    {
+        Default = 0,
+        Version = 1,
+        VersionRelease = 2,
+        VersionReleaseMetadata = 3
+    }
+
+    public static partial class VersionExtensions
+    {
+        public static INuGetVersionable FindBestMatch(this System.Collections.Generic.IEnumerable<INuGetVersionable> items, VersionRange ideal) { throw null; }
+
+        public static T FindBestMatch<T>(this System.Collections.Generic.IEnumerable<T> items, VersionRange ideal, System.Func<T, NuGetVersion> selector)
+            where T : class { throw null; }
+    }
+
+    public partial class VersionFormatter : System.IFormatProvider, System.ICustomFormatter
+    {
+        public static readonly VersionFormatter Instance;
+        public VersionFormatter() { }
+
+        public string Format(string format, object arg, System.IFormatProvider formatProvider) { throw null; }
+
+        public object GetFormat(System.Type formatType) { throw null; }
+    }
+
+    public partial class VersionRange : VersionRangeBase, System.IFormattable
+    {
+        public static readonly VersionRange All;
+        [System.Obsolete("Consider not using this VersionRange. The lack of a proper normalized version means that it is not round trippable in an assets file.")]
+        public static readonly VersionRange AllFloating;
+        public static readonly VersionRange AllStable;
+        [System.Obsolete("Consider not using this VersionRange. The lack of a proper normalized version means that it is not round trippable in an assets file.")]
+        public static readonly VersionRange AllStableFloating;
+        public static readonly VersionRange None;
+        public VersionRange(NuGetVersion minVersion, FloatRange floatRange) : base(default!, default, default!, default) { }
+
+        public VersionRange(NuGetVersion minVersion = null, bool includeMinVersion = true, NuGetVersion maxVersion = null, bool includeMaxVersion = false, FloatRange floatRange = null, string originalString = null) : base(default!, default, default!, default) { }
+
+        public VersionRange(NuGetVersion minVersion) : base(default!, default, default!, default) { }
+
+        public VersionRange(VersionRange range, FloatRange floatRange) : base(default!, default, default!, default) { }
+
+        public FloatRange Float { get { throw null; } }
+
+        public bool IsFloating { get { throw null; } }
+
+        public string OriginalString { get { throw null; } }
+
+        public static VersionRange Combine(System.Collections.Generic.IEnumerable<NuGetVersion> versions, IVersionComparer comparer) { throw null; }
+
+        public static VersionRange Combine(System.Collections.Generic.IEnumerable<NuGetVersion> versions) { throw null; }
+
+        public static VersionRange Combine(System.Collections.Generic.IEnumerable<VersionRange> ranges, IVersionComparer comparer) { throw null; }
+
+        public static VersionRange Combine(System.Collections.Generic.IEnumerable<VersionRange> ranges) { throw null; }
+
+        public static VersionRange CommonSubSet(System.Collections.Generic.IEnumerable<VersionRange> ranges, IVersionComparer comparer) { throw null; }
+
+        public static VersionRange CommonSubSet(System.Collections.Generic.IEnumerable<VersionRange> ranges) { throw null; }
+
+        public bool Equals(VersionRange other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public NuGetVersion FindBestMatch(System.Collections.Generic.IEnumerable<NuGetVersion> versions) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool IsBetter(NuGetVersion current, NuGetVersion considering) { throw null; }
+
+        public static VersionRange Parse(string value, bool allowFloating) { throw null; }
+
+        public static VersionRange Parse(string value) { throw null; }
+
+        public string PrettyPrint() { throw null; }
+
+        public virtual string ToLegacyShortString() { throw null; }
+
+        public virtual string ToLegacyString() { throw null; }
+
+        public VersionRange ToNonSnapshotRange() { throw null; }
+
+        public virtual string ToNormalizedString() { throw null; }
+
+        public virtual string ToShortString() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public string ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+
+        protected bool TryFormatter(string format, System.IFormatProvider formatProvider, out string formattedString) { throw null; }
+
+        public static bool TryParse(string value, out VersionRange versionRange) { throw null; }
+
+        public static bool TryParse(string value, bool allowFloating, out VersionRange versionRange) { throw null; }
+    }
+
+    public abstract partial class VersionRangeBase : System.IEquatable<VersionRangeBase>
+    {
+        public VersionRangeBase(NuGetVersion minVersion = null, bool includeMinVersion = true, NuGetVersion maxVersion = null, bool includeMaxVersion = false) { }
+
+        public bool HasLowerAndUpperBounds { get { throw null; } }
+
+        public bool HasLowerBound { get { throw null; } }
+
+        protected bool HasPrereleaseBounds { get { throw null; } }
+
+        public bool HasUpperBound { get { throw null; } }
+
+        public bool IsMaxInclusive { get { throw null; } }
+
+        public bool IsMinInclusive { get { throw null; } }
+
+        public NuGetVersion MaxVersion { get { throw null; } }
+
+        public NuGetVersion MinVersion { get { throw null; } }
+
+        public bool Equals(VersionRangeBase other, IVersionComparer versionComparer) { throw null; }
+
+        public bool Equals(VersionRangeBase other, IVersionRangeComparer comparer) { throw null; }
+
+        public bool Equals(VersionRangeBase other, VersionComparison versionComparison) { throw null; }
+
+        public bool Equals(VersionRangeBase other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool IsSubSetOrEqualTo(VersionRangeBase possibleSuperSet, IVersionComparer comparer) { throw null; }
+
+        public bool IsSubSetOrEqualTo(VersionRangeBase possibleSuperSet) { throw null; }
+
+        public bool Satisfies(NuGetVersion version, IVersionComparer comparer) { throw null; }
+
+        public bool Satisfies(NuGetVersion version, VersionComparison versionComparison) { throw null; }
+
+        public bool Satisfies(NuGetVersion version) { throw null; }
+    }
+
+    public partial class VersionRangeComparer : IVersionRangeComparer, System.Collections.Generic.IEqualityComparer<VersionRangeBase>
+    {
+        public VersionRangeComparer() { }
+
+        public VersionRangeComparer(IVersionComparer versionComparer) { }
+
+        public VersionRangeComparer(VersionComparison versionComparison) { }
+
+        public static IVersionRangeComparer Default { get { throw null; } }
+
+        public static IVersionRangeComparer VersionRelease { get { throw null; } }
+
+        public bool Equals(VersionRangeBase x, VersionRangeBase y) { throw null; }
+
+        public int GetHashCode(VersionRangeBase obj) { throw null; }
+    }
+
+    public partial class VersionRangeFormatter : System.IFormatProvider, System.ICustomFormatter
+    {
+        public static readonly VersionRangeFormatter Instance;
+        public VersionRangeFormatter() { }
+
+        public string Format(string format, object arg, System.IFormatProvider formatProvider) { throw null; }
+
+        public object GetFormat(System.Type formatType) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.versioning/6.2.2/nuget.versioning.nuspec
+++ b/src/referencePackages/src/nuget.versioning/6.2.2/nuget.versioning.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Versioning</id>
+    <version>6.2.2</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's implementation of Semantic Versioning.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>semver semantic versioning</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="027ca8b8ef4b4dc94995f87b9c441d2bcf742c1d" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
This reverts commit a74fb65cdadc946a9d493af8a8390ce831acd96f.

Based on work completed by Viktor and referenced in https://github.com/dotnet/source-build-reference-packages/pull/673#issuecomment-1569508658, Arcade is no longer packaging `Nuget.ProjectModel` and now can utilize SBRP.

Reverted the commit removing `6.2.2` + tested it in the VMR with repo PvP flow