### PR TITLE
Update licenseUrl to MIT license for reference-packages

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/RewriteNuspec.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 {
     public partial class RewriteNuspec : Task
     {
+        private const string MicrosoftMitLicenseUrl = "https://microsoft.mit-license.org/";
+
         [Required]
         public string? NuspecPath { get; set; }
 
@@ -81,6 +83,9 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
 
             // Ensure that the nuspec's line endings match the current environment
             nuspecContent = nuspecContent.ReplaceLineEndings();
+
+            nuspecContent = nuspecContent.Replace("http://go.microsoft.com/fwlink/?LinkId=529443", MicrosoftMitLicenseUrl);
+            nuspecContent = nuspecContent.Replace("http://go.microsoft.com/fwlink/?LinkId=329770", MicrosoftMitLicenseUrl);
 
             File.WriteAllText(TargetPath!, nuspecContent);
             return true;

--- a/src/referencePackages/src/microsoft.build.framework/15.1.1012/microsoft.build.framework.nuspec
+++ b/src/referencePackages/src/microsoft.build.framework/15.1.1012/microsoft.build.framework.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
     <description>This package contains the Microsoft.Build.Framework assembly which is a common assembly used by other MSBuild assemblies.</description>

--- a/src/referencePackages/src/microsoft.build.framework/16.0.461/microsoft.build.framework.nuspec
+++ b/src/referencePackages/src/microsoft.build.framework/16.0.461/microsoft.build.framework.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
     <description>This package contains the Microsoft.Build.Framework assembly which is a common assembly used by other MSBuild assemblies.</description>

--- a/src/referencePackages/src/microsoft.build.utilities.core/15.1.1012/microsoft.build.utilities.core.nuspec
+++ b/src/referencePackages/src/microsoft.build.utilities.core/15.1.1012/microsoft.build.utilities.core.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
     <description>This package contains the Microsoft.Build.Utilities.Core assembly which is used to implement custom MSBuild tasks.</description>

--- a/src/referencePackages/src/microsoft.build.utilities.core/16.0.461/microsoft.build.utilities.core.nuspec
+++ b/src/referencePackages/src/microsoft.build.utilities.core/16.0.461/microsoft.build.utilities.core.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</projectUrl>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=825694</iconUrl>
     <description>This package contains the Microsoft.Build.Utilities assembly which is used to implement custom MSBuild tasks.</description>

--- a/src/referencePackages/src/microsoft.codeanalysis.common/2.9.0/microsoft.codeanalysis.common.nuspec
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/2.9.0/microsoft.codeanalysis.common.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529443</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://github.com/dotnet/roslyn</projectUrl>
     <description>A shared package used by the Microsoft .NET Compiler Platform ("Roslyn").
       Do not install this package manually, it will be added as a prerequisite by other packages that require it.

--- a/src/referencePackages/src/microsoft.codeanalysis.csharp/2.9.0/microsoft.codeanalysis.csharp.nuspec
+++ b/src/referencePackages/src/microsoft.codeanalysis.csharp/2.9.0/microsoft.codeanalysis.csharp.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=529443</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://github.com/dotnet/roslyn</projectUrl>
     <description>.NET Compiler Platform ("Roslyn") support for C#, Microsoft.CodeAnalysis.CSharp.dll.
 

--- a/src/referencePackages/src/system.composition.attributedmodel/1.0.31/system.composition.attributedmodel.nuspec
+++ b/src/referencePackages/src/system.composition.attributedmodel/1.0.31/system.composition.attributedmodel.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides common attributes used by System.Composition types.

--- a/src/referencePackages/src/system.composition.convention/1.0.31/system.composition.convention.nuspec
+++ b/src/referencePackages/src/system.composition.convention/1.0.31/system.composition.convention.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides types that support using Managed Extensibility Framework with a convention-based configuration model.

--- a/src/referencePackages/src/system.composition.hosting/1.0.31/system.composition.hosting.nuspec
+++ b/src/referencePackages/src/system.composition.hosting/1.0.31/system.composition.hosting.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.

--- a/src/referencePackages/src/system.composition.runtime/1.0.31/system.composition.runtime.nuspec
+++ b/src/referencePackages/src/system.composition.runtime/1.0.31/system.composition.runtime.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Contains runtime components of the Managed Extensibility Framework.

--- a/src/referencePackages/src/system.composition.typedparts/1.0.31/system.composition.typedparts.nuspec
+++ b/src/referencePackages/src/system.composition.typedparts/1.0.31/system.composition.typedparts.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides some extension methods for the Managed Extensibility Framework.

--- a/src/referencePackages/src/system.diagnostics.stacktrace/4.3.0/system.diagnostics.stacktrace.nuspec
+++ b/src/referencePackages/src/system.diagnostics.stacktrace/4.3.0/system.diagnostics.stacktrace.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the System.Diagnostics.StackTrace class, which allows interaction with local and remote processes.

--- a/src/referencePackages/src/system.runtime.extensions/4.3.1/system.runtime.extensions.nuspec
+++ b/src/referencePackages/src/system.runtime.extensions/4.3.1/system.runtime.extensions.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides commonly-used classes for performing mathematical functions, conversions, string comparisons and querying environment information.

--- a/src/referencePackages/src/system.runtime/4.3.1/system.runtime.nuspec
+++ b/src/referencePackages/src/system.runtime/4.3.1/system.runtime.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the fundamental primitives, classes and base classes that define commonly-used value and reference data types, events and event handlers, interfaces, attributes, and exceptions. This packages represents the core package, and provides the minimal set of types required to build a managed application.

--- a/src/referencePackages/src/system.text.encoding.codepages/4.3.0/system.text.encoding.codepages.nuspec
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.3.0/system.text.encoding.codepages.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.

--- a/src/referencePackages/src/system.text.regularexpressions/4.3.1/system.text.regularexpressions.nuspec
+++ b/src/referencePackages/src/system.text.regularexpressions/4.3.1/system.text.regularexpressions.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the System.Text.RegularExpressions.Regex class, an implementation of a regular expression engine.

--- a/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/system.threading.tasks.parallel.nuspec
+++ b/src/referencePackages/src/system.threading.tasks.parallel/4.3.0/system.threading.tasks.parallel.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the System.Threading.Tasks.Parallel class, which adds support for running loops and iterators in parallel.

--- a/src/referencePackages/src/system.valuetuple/4.3.0/system.valuetuple.nuspec
+++ b/src/referencePackages/src/system.valuetuple/4.3.0/system.valuetuple.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the System.ValueTuple structs, which implement the underlying types for C# 7 tuples.

--- a/src/referencePackages/src/system.xml.xpath.xdocument/4.3.0/system.xml.xpath.xdocument.nuspec
+++ b/src/referencePackages/src/system.xml.xpath.xdocument/4.3.0/system.xml.xpath.xdocument.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides extension methods that add System.Xml.XPath support to the System.Xml.XDocument package.

--- a/src/referencePackages/src/system.xml.xpath/4.3.0/system.xml.xpath.nuspec
+++ b/src/referencePackages/src/system.xml.xpath/4.3.0/system.xml.xpath.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>Provides the classes that define a cursor model for navigating and editing Extensible Markup Language (XML) information items as instances of the XQuery 1.0 and XPath 2.0 Data Model.

--- a/src/targetPacks/ILsrc/netstandard.library/1.6.1/netstandard.library.nuspec
+++ b/src/targetPacks/ILsrc/netstandard.library/1.6.1/netstandard.library.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft,dotnetframework</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <licenseUrl>https://microsoft.mit-license.org/</licenseUrl>
     <projectUrl>https://dot.net/</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <description>A set of standard .NET APIs that are prescribed to be used and supported together. This includes all of the APIs in the NETStandard.Platform package plus additional libraries that are core to .NET but built on top of NETStandard.Platform. 


### PR DESCRIPTION
Per agreement reached in the past, the reference packages should have an MIT license.