### PR TITLE
Add regenerate support

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -83,7 +83,7 @@
                             EndGeneratePackageSource;
                             InvokePackageDependencies" />
 
-  <!-- Emit a log message that indicates the start of the package source generation. -->
+  <!-- Initialize the package source generation. -->
   <Target Name="BeginGeneratePackageSource">
     <PropertyGroup>
       <PackageTargetFrameworksMessage Condition="'$(PackageTargetFrameworks)' != ''">, TFMs: $(PackageTargetFrameworks)</PackageTargetFrameworksMessage>
@@ -91,6 +91,9 @@
 
     <Message Text="%0D%0A$(MSBuildProjectName) -> Generating package source for $(PackageName) (v$(PackageVersion)$(PackageTargetFrameworksMessage))..."
              Importance="high" />
+
+    <!-- Remove the target directory to support regenerate scenario in case existing files are removed. -->
+    <RemoveDir Directories="$(PackageTargetDirectory)" />
   </Target>
 
   <!-- Retrieve compile items, placeholder files, package dependencies and framework references with their target framework. -->


### PR DESCRIPTION
In regenerate scenarios, existing files should be deleted to support scenarios when generator has changed and not all of the previous files are generated.  The canonical scenario for this is TFM support has been removed.