### PR TITLE
Regenerate System.Xml.ReaderWriter 4.0.11

### DIFF
--- a/docs/known_generator_issues.md
+++ b/docs/known_generator_issues.md
@@ -7,3 +7,16 @@ error CS8138: Cannot reference 'System.Runtime.CompilerServices.TupleElementName
 ```
 
 Workaround: update the declaration using tuple syntax to define tuple names. Or comment/remove this attribute.
+
+## Circular dependency between reference package and targeting pack
+
+```text
+error NU1108: Cycle detected.
+error NU1108:   <Reference project> -> NETStandard.Library x.y.z -> <Reference project>
+```
+
+Workaround: add the following property to the project.
+
+```xml
+<DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+```

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <IsPackable>true</IsPackable>
     <!--
       Arcade defaults Serviceable to 'true'. Reset it, to use the value in the nuspec. Improves

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,11 @@
 
   <Import Project="..\Directory.Build.targets" />
 
+  <!-- Setting that are dependent on the project template version. -->
+  <PropertyGroup>
+    <DisableImplicitFrameworkReferences Condition="'$(ProjectTemplateVersion)' != '2'">true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <!--
     Disable Arcade util that populates PackTask properties. For these projects, the nuspec already
     contains everything. It's generated when the package is initially deconstructed and tends to be

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -6,7 +6,7 @@
   <Choose>
     <When Condition="'$(ProjectTemplateVersion)' == '2'">
       <PropertyGroup>
-        <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+        <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">false</DisableImplicitFrameworkReferences>
       </PropertyGroup>
 
       <ItemGroup>

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/System.Xml.ReaderWriter.4.0.11.csproj
@@ -1,42 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.xml.readerwriter/4.0.11/system.xml.readerwriter.nuspec</NuspecFile>
-   </PropertyGroup>
+    <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
 
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.xml.readerwriter/4.0.11/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.xml.readerwriter/4.0.11</IntermediateOutputPath>
+    <!-- Required to avoid circular dependency with targeting pack -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.IO" Version="4.1.0" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="System.IO" Version="4.1.0" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-        <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <PackageReference Include="System.Collections" Version="4.0.11" />
-        <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
-        <PackageReference Include="System.Globalization" Version="4.0.11" />
-        <PackageReference Include="System.IO" Version="4.1.0" />
-        <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
-        <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.0.1" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-        <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0" />
-        <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
-        <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.0.0" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Collections" Version="4.0.11" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
+    <PackageReference Include="System.Globalization" Version="4.0.11" />
+    <PackageReference Include="System.IO" Version="4.1.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.0.1" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.1.0" />
+    <PackageReference Include="System.Text.Encoding" Version="4.0.11" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.1.0" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.0.0" />
+  </ItemGroup>
 
-  
 </Project>

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/ref/netstandard1.0/System.Xml.ReaderWriter.cs
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/ref/netstandard1.0/System.Xml.ReaderWriter.cs
@@ -4,515 +4,807 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Xml.ReaderWriter")]
-[assembly: AssemblyDescription("System.Xml.ReaderWriter")]
-[assembly: AssemblyDefaultAlias("System.Xml.ReaderWriter")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.0.30319.17929")]
-[assembly: AssemblyInformationalVersion("4.0.30319.17929 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.0.0")]
-
-
-
-
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Xml.ReaderWriter.dll")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyTitle("System.Xml.ReaderWriter.dll")]
+[assembly: System.Reflection.AssemblyDescription("System.Xml.ReaderWriter.dll")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.0.30319.17929")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.0.30319.17929")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Xml
 {
     public enum ConformanceLevel
     {
         Auto = 0,
-        Document = 2,
         Fragment = 1,
+        Document = 2
     }
+
     public enum DtdProcessing
     {
-        Ignore = 1,
         Prohibit = 0,
+        Ignore = 1
     }
+
     public partial interface IXmlLineInfo
     {
         int LineNumber { get; }
+
         int LinePosition { get; }
+
         bool HasLineInfo();
     }
+
     public partial interface IXmlNamespaceResolver
     {
-        System.Collections.Generic.IDictionary<string, string> GetNamespacesInScope(System.Xml.XmlNamespaceScope scope);
+        Collections.Generic.IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope);
         string LookupNamespace(string prefix);
         string LookupPrefix(string namespaceName);
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum NamespaceHandling
     {
         Default = 0,
-        OmitDuplicates = 1,
+        OmitDuplicates = 1
     }
-    public partial class NameTable : System.Xml.XmlNameTable
+
+    public partial class NameTable : XmlNameTable
     {
-        public NameTable() { }
         public override string Add(char[] key, int start, int len) { throw null; }
+
         public override string Add(string key) { throw null; }
+
         public override string Get(char[] key, int start, int len) { throw null; }
+
         public override string Get(string value) { throw null; }
     }
+
     public enum NewLineHandling
     {
-        Entitize = 1,
-        None = 2,
         Replace = 0,
+        Entitize = 1,
+        None = 2
     }
+
     public enum ReadState
     {
-        Closed = 4,
-        EndOfFile = 3,
-        Error = 2,
         Initial = 0,
         Interactive = 1,
+        Error = 2,
+        EndOfFile = 3,
+        Closed = 4
     }
+
     public enum WriteState
     {
-        Attribute = 3,
-        Closed = 5,
-        Content = 4,
-        Element = 2,
-        Error = 6,
-        Prolog = 1,
         Start = 0,
+        Prolog = 1,
+        Element = 2,
+        Attribute = 3,
+        Content = 4,
+        Closed = 5,
+        Error = 6
     }
+
     public static partial class XmlConvert
     {
         public static string DecodeName(string name) { throw null; }
+
         public static string EncodeLocalName(string name) { throw null; }
+
         public static string EncodeName(string name) { throw null; }
+
         public static string EncodeNmToken(string name) { throw null; }
+
         public static bool ToBoolean(string s) { throw null; }
+
         public static byte ToByte(string s) { throw null; }
+
         public static char ToChar(string s) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s, string format) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s, string[] formats) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s, string format) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s, string[] formats) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s) { throw null; }
+
         public static decimal ToDecimal(string s) { throw null; }
+
         public static double ToDouble(string s) { throw null; }
-        public static System.Guid ToGuid(string s) { throw null; }
+
+        public static Guid ToGuid(string s) { throw null; }
+
         public static short ToInt16(string s) { throw null; }
+
         public static int ToInt32(string s) { throw null; }
+
         public static long ToInt64(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static sbyte ToSByte(string s) { throw null; }
+
         public static float ToSingle(string s) { throw null; }
+
         public static string ToString(bool value) { throw null; }
+
         public static string ToString(char value) { throw null; }
-        public static string ToString(System.DateTimeOffset value) { throw null; }
-        public static string ToString(System.DateTimeOffset value, string format) { throw null; }
+
+        public static string ToString(DateTimeOffset value, string format) { throw null; }
+
+        public static string ToString(DateTimeOffset value) { throw null; }
+
         public static string ToString(decimal value) { throw null; }
+
         public static string ToString(double value) { throw null; }
-        public static string ToString(System.Guid value) { throw null; }
+
+        public static string ToString(Guid value) { throw null; }
+
         public static string ToString(short value) { throw null; }
+
         public static string ToString(int value) { throw null; }
+
         public static string ToString(long value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static string ToString(sbyte value) { throw null; }
+
         public static string ToString(float value) { throw null; }
-        public static string ToString(System.TimeSpan value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        public static string ToString(TimeSpan value) { throw null; }
+
+        [CLSCompliant(false)]
         public static string ToString(uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static string ToString(ulong value) { throw null; }
-        public static System.TimeSpan ToTimeSpan(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        public static TimeSpan ToTimeSpan(string s) { throw null; }
+
+        [CLSCompliant(false)]
         public static ushort ToUInt16(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static uint ToUInt32(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static ulong ToUInt64(string s) { throw null; }
+
         public static string VerifyName(string name) { throw null; }
+
         public static string VerifyNCName(string name) { throw null; }
+
         public static string VerifyNMTOKEN(string name) { throw null; }
+
         public static string VerifyPublicId(string publicId) { throw null; }
+
         public static string VerifyWhitespace(string content) { throw null; }
+
         public static string VerifyXmlChars(string content) { throw null; }
     }
-    public partial class XmlException : System.Exception
+
+    public partial class XmlException : Exception
     {
         public XmlException() { }
+
+        public XmlException(string message, Exception innerException, int lineNumber, int linePosition) { }
+
+        public XmlException(string message, Exception innerException) { }
+
         public XmlException(string message) { }
-        public XmlException(string message, System.Exception innerException) { }
-        public XmlException(string message, System.Exception innerException, int lineNumber, int linePosition) { }
+
         public int LineNumber { get { throw null; } }
+
         public int LinePosition { get { throw null; } }
+
         public override string Message { get { throw null; } }
     }
-    public partial class XmlNamespaceManager : System.Collections.IEnumerable, System.Xml.IXmlNamespaceResolver
+
+    public partial class XmlNamespaceManager : Collections.IEnumerable, IXmlNamespaceResolver
     {
-        public XmlNamespaceManager(System.Xml.XmlNameTable nameTable) { }
+        public XmlNamespaceManager(XmlNameTable nameTable) { }
+
         public virtual string DefaultNamespace { get { throw null; } }
-        public virtual System.Xml.XmlNameTable NameTable { get { throw null; } }
+
+        public virtual XmlNameTable NameTable { get { throw null; } }
+
         public virtual void AddNamespace(string prefix, string uri) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.IDictionary<string, string> GetNamespacesInScope(System.Xml.XmlNamespaceScope scope) { throw null; }
+
+        public virtual Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public virtual Collections.Generic.IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) { throw null; }
+
         public virtual bool HasNamespace(string prefix) { throw null; }
+
         public virtual string LookupNamespace(string prefix) { throw null; }
+
         public virtual string LookupPrefix(string uri) { throw null; }
+
         public virtual bool PopScope() { throw null; }
+
         public virtual void PushScope() { }
+
         public virtual void RemoveNamespace(string prefix, string uri) { }
     }
+
     public enum XmlNamespaceScope
     {
         All = 0,
         ExcludeXml = 1,
-        Local = 2,
+        Local = 2
     }
+
     public abstract partial class XmlNameTable
     {
-        protected XmlNameTable() { }
         public abstract string Add(char[] array, int offset, int length);
         public abstract string Add(string array);
         public abstract string Get(char[] array, int offset, int length);
         public abstract string Get(string array);
     }
+
     public enum XmlNodeType
     {
+        None = 0,
+        Element = 1,
         Attribute = 2,
+        Text = 3,
         CDATA = 4,
+        EntityReference = 5,
+        Entity = 6,
+        ProcessingInstruction = 7,
         Comment = 8,
         Document = 9,
-        DocumentFragment = 11,
         DocumentType = 10,
-        Element = 1,
+        DocumentFragment = 11,
+        Notation = 12,
+        Whitespace = 13,
+        SignificantWhitespace = 14,
         EndElement = 15,
         EndEntity = 16,
-        Entity = 6,
-        EntityReference = 5,
-        None = 0,
-        Notation = 12,
-        ProcessingInstruction = 7,
-        SignificantWhitespace = 14,
-        Text = 3,
-        Whitespace = 13,
-        XmlDeclaration = 17,
+        XmlDeclaration = 17
     }
+
     public partial class XmlParserContext
     {
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, System.Xml.XmlSpace xmlSpace) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, System.Xml.XmlSpace xmlSpace, System.Text.Encoding enc) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string xmlLang, System.Xml.XmlSpace xmlSpace) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string xmlLang, System.Xml.XmlSpace xmlSpace, System.Text.Encoding enc) { }
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, XmlSpace xmlSpace, Text.Encoding enc) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, XmlSpace xmlSpace) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string xmlLang, XmlSpace xmlSpace, Text.Encoding enc) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string xmlLang, XmlSpace xmlSpace) { }
+
         public string BaseURI { get { throw null; } set { } }
+
         public string DocTypeName { get { throw null; } set { } }
-        public System.Text.Encoding Encoding { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
         public string InternalSubset { get { throw null; } set { } }
-        public System.Xml.XmlNamespaceManager NamespaceManager { get { throw null; } set { } }
-        public System.Xml.XmlNameTable NameTable { get { throw null; } set { } }
+
+        public XmlNamespaceManager NamespaceManager { get { throw null; } set { } }
+
+        public XmlNameTable NameTable { get { throw null; } set { } }
+
         public string PublicId { get { throw null; } set { } }
+
         public string SystemId { get { throw null; } set { } }
+
         public string XmlLang { get { throw null; } set { } }
-        public System.Xml.XmlSpace XmlSpace { get { throw null; } set { } }
+
+        public XmlSpace XmlSpace { get { throw null; } set { } }
     }
+
     public partial class XmlQualifiedName
     {
-        public static readonly System.Xml.XmlQualifiedName Empty;
+        public static readonly XmlQualifiedName Empty;
         public XmlQualifiedName() { }
-        public XmlQualifiedName(string name) { }
+
         public XmlQualifiedName(string name, string ns) { }
+
+        public XmlQualifiedName(string name) { }
+
         public bool IsEmpty { get { throw null; } }
+
         public string Name { get { throw null; } }
+
         public string Namespace { get { throw null; } }
+
         public override bool Equals(object other) { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Xml.XmlQualifiedName a, System.Xml.XmlQualifiedName b) { throw null; }
-        public static bool operator !=(System.Xml.XmlQualifiedName a, System.Xml.XmlQualifiedName b) { throw null; }
+
+        public static bool operator ==(XmlQualifiedName a, XmlQualifiedName b) { throw null; }
+
+        public static bool operator !=(XmlQualifiedName a, XmlQualifiedName b) { throw null; }
+
         public override string ToString() { throw null; }
+
         public static string ToString(string name, string ns) { throw null; }
     }
-    public abstract partial class XmlReader : System.IDisposable
+
+    public abstract partial class XmlReader : IDisposable
     {
-        protected XmlReader() { }
         public abstract int AttributeCount { get; }
         public abstract string BaseURI { get; }
+
         public virtual bool CanReadBinaryContent { get { throw null; } }
+
         public virtual bool CanReadValueChunk { get { throw null; } }
+
         public virtual bool CanResolveEntity { get { throw null; } }
+
         public abstract int Depth { get; }
         public abstract bool EOF { get; }
+
         public virtual bool HasAttributes { get { throw null; } }
+
         public virtual bool HasValue { get { throw null; } }
+
         public virtual bool IsDefault { get { throw null; } }
+
         public abstract bool IsEmptyElement { get; }
+
         public virtual string this[int i] { get { throw null; } }
-        public virtual string this[string name] { get { throw null; } }
+
         public virtual string this[string name, string namespaceURI] { get { throw null; } }
+
+        public virtual string this[string name] { get { throw null; } }
+
         public abstract string LocalName { get; }
+
         public virtual string Name { get { throw null; } }
+
         public abstract string NamespaceURI { get; }
-        public abstract System.Xml.XmlNameTable NameTable { get; }
-        public abstract System.Xml.XmlNodeType NodeType { get; }
+        public abstract XmlNameTable NameTable { get; }
+        public abstract XmlNodeType NodeType { get; }
         public abstract string Prefix { get; }
-        public abstract System.Xml.ReadState ReadState { get; }
-        public virtual System.Xml.XmlReaderSettings Settings { get { throw null; } }
+        public abstract ReadState ReadState { get; }
+
+        public virtual XmlReaderSettings Settings { get { throw null; } }
+
         public abstract string Value { get; }
-        public virtual System.Type ValueType { get { throw null; } }
+
+        public virtual Type ValueType { get { throw null; } }
+
         public virtual string XmlLang { get { throw null; } }
-        public virtual System.Xml.XmlSpace XmlSpace { get { throw null; } }
-        public static System.Xml.XmlReader Create(System.IO.Stream input) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.Stream input, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.Stream input, System.Xml.XmlReaderSettings settings, System.Xml.XmlParserContext inputContext) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input, System.Xml.XmlReaderSettings settings, System.Xml.XmlParserContext inputContext) { throw null; }
-        public static System.Xml.XmlReader Create(string inputUri) { throw null; }
-        public static System.Xml.XmlReader Create(string inputUri, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.Xml.XmlReader reader, System.Xml.XmlReaderSettings settings) { throw null; }
+
+        public virtual XmlSpace XmlSpace { get { throw null; } }
+
+        public static XmlReader Create(IO.Stream input, XmlReaderSettings settings, XmlParserContext inputContext) { throw null; }
+
+        public static XmlReader Create(IO.Stream input, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(IO.Stream input) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input, XmlReaderSettings settings, XmlParserContext inputContext) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input) { throw null; }
+
+        public static XmlReader Create(string inputUri, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(string inputUri) { throw null; }
+
+        public static XmlReader Create(XmlReader reader, XmlReaderSettings settings) { throw null; }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
+
         public abstract string GetAttribute(int i);
-        public abstract string GetAttribute(string name);
         public abstract string GetAttribute(string name, string namespaceURI);
-        public virtual System.Threading.Tasks.Task<string> GetValueAsync() { throw null; }
+        public abstract string GetAttribute(string name);
+        public virtual Threading.Tasks.Task<string> GetValueAsync() { throw null; }
+
         public static bool IsName(string str) { throw null; }
+
         public static bool IsNameToken(string str) { throw null; }
+
         public virtual bool IsStartElement() { throw null; }
-        public virtual bool IsStartElement(string name) { throw null; }
+
         public virtual bool IsStartElement(string localname, string ns) { throw null; }
+
+        public virtual bool IsStartElement(string name) { throw null; }
+
         public abstract string LookupNamespace(string prefix);
         public virtual void MoveToAttribute(int i) { }
-        public abstract bool MoveToAttribute(string name);
+
         public abstract bool MoveToAttribute(string name, string ns);
-        public virtual System.Xml.XmlNodeType MoveToContent() { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Xml.XmlNodeType> MoveToContentAsync() { throw null; }
+        public abstract bool MoveToAttribute(string name);
+        public virtual XmlNodeType MoveToContent() { throw null; }
+
+        public virtual Threading.Tasks.Task<XmlNodeType> MoveToContentAsync() { throw null; }
+
         public abstract bool MoveToElement();
         public abstract bool MoveToFirstAttribute();
         public abstract bool MoveToNextAttribute();
         public abstract bool Read();
-        public virtual System.Threading.Tasks.Task<bool> ReadAsync() { throw null; }
+        public virtual Threading.Tasks.Task<bool> ReadAsync() { throw null; }
+
         public abstract bool ReadAttributeValue();
-        public virtual object ReadContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadContentAsAsync(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
+        public virtual object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
         public virtual int ReadContentAsBase64(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual int ReadContentAsBinHex(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public virtual bool ReadContentAsBoolean() { throw null; }
-        public virtual System.DateTimeOffset ReadContentAsDateTimeOffset() { throw null; }
+
+        public virtual DateTimeOffset ReadContentAsDateTimeOffset() { throw null; }
+
         public virtual decimal ReadContentAsDecimal() { throw null; }
+
         public virtual double ReadContentAsDouble() { throw null; }
+
         public virtual float ReadContentAsFloat() { throw null; }
+
         public virtual int ReadContentAsInt() { throw null; }
+
         public virtual long ReadContentAsLong() { throw null; }
+
         public virtual object ReadContentAsObject() { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadContentAsObjectAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadContentAsObjectAsync() { throw null; }
+
         public virtual string ReadContentAsString() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadContentAsStringAsync() { throw null; }
-        public virtual object ReadElementContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
-        public virtual object ReadElementContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver, string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadElementContentAsAsync(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadContentAsStringAsync() { throw null; }
+
+        public virtual object ReadElementContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver, string localName, string namespaceURI) { throw null; }
+
+        public virtual object ReadElementContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadElementContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
         public virtual int ReadElementContentAsBase64(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual int ReadElementContentAsBinHex(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public virtual bool ReadElementContentAsBoolean() { throw null; }
+
         public virtual bool ReadElementContentAsBoolean(string localName, string namespaceURI) { throw null; }
+
         public virtual decimal ReadElementContentAsDecimal() { throw null; }
+
         public virtual decimal ReadElementContentAsDecimal(string localName, string namespaceURI) { throw null; }
+
         public virtual double ReadElementContentAsDouble() { throw null; }
+
         public virtual double ReadElementContentAsDouble(string localName, string namespaceURI) { throw null; }
+
         public virtual float ReadElementContentAsFloat() { throw null; }
+
         public virtual float ReadElementContentAsFloat(string localName, string namespaceURI) { throw null; }
+
         public virtual int ReadElementContentAsInt() { throw null; }
+
         public virtual int ReadElementContentAsInt(string localName, string namespaceURI) { throw null; }
+
         public virtual long ReadElementContentAsLong() { throw null; }
+
         public virtual long ReadElementContentAsLong(string localName, string namespaceURI) { throw null; }
+
         public virtual object ReadElementContentAsObject() { throw null; }
+
         public virtual object ReadElementContentAsObject(string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadElementContentAsObjectAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadElementContentAsObjectAsync() { throw null; }
+
         public virtual string ReadElementContentAsString() { throw null; }
+
         public virtual string ReadElementContentAsString(string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadElementContentAsStringAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadElementContentAsStringAsync() { throw null; }
+
         public virtual void ReadEndElement() { }
+
         public virtual string ReadInnerXml() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadInnerXmlAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadInnerXmlAsync() { throw null; }
+
         public virtual string ReadOuterXml() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadOuterXmlAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadOuterXmlAsync() { throw null; }
+
         public virtual void ReadStartElement() { }
-        public virtual void ReadStartElement(string name) { }
+
         public virtual void ReadStartElement(string localname, string ns) { }
-        public virtual System.Xml.XmlReader ReadSubtree() { throw null; }
-        public virtual bool ReadToDescendant(string name) { throw null; }
+
+        public virtual void ReadStartElement(string name) { }
+
+        public virtual XmlReader ReadSubtree() { throw null; }
+
         public virtual bool ReadToDescendant(string localName, string namespaceURI) { throw null; }
-        public virtual bool ReadToFollowing(string name) { throw null; }
+
+        public virtual bool ReadToDescendant(string name) { throw null; }
+
         public virtual bool ReadToFollowing(string localName, string namespaceURI) { throw null; }
-        public virtual bool ReadToNextSibling(string name) { throw null; }
+
+        public virtual bool ReadToFollowing(string name) { throw null; }
+
         public virtual bool ReadToNextSibling(string localName, string namespaceURI) { throw null; }
+
+        public virtual bool ReadToNextSibling(string name) { throw null; }
+
         public virtual int ReadValueChunk(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadValueChunkAsync(char[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadValueChunkAsync(char[] buffer, int index, int count) { throw null; }
+
         public abstract void ResolveEntity();
         public virtual void Skip() { }
-        public virtual System.Threading.Tasks.Task SkipAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task SkipAsync() { throw null; }
     }
+
     public sealed partial class XmlReaderSettings
     {
-        public XmlReaderSettings() { }
         public bool Async { get { throw null; } set { } }
+
         public bool CheckCharacters { get { throw null; } set { } }
+
         public bool CloseInput { get { throw null; } set { } }
-        public System.Xml.ConformanceLevel ConformanceLevel { get { throw null; } set { } }
-        public System.Xml.DtdProcessing DtdProcessing { get { throw null; } set { } }
+
+        public ConformanceLevel ConformanceLevel { get { throw null; } set { } }
+
+        public DtdProcessing DtdProcessing { get { throw null; } set { } }
+
         public bool IgnoreComments { get { throw null; } set { } }
+
         public bool IgnoreProcessingInstructions { get { throw null; } set { } }
+
         public bool IgnoreWhitespace { get { throw null; } set { } }
+
         public int LineNumberOffset { get { throw null; } set { } }
+
         public int LinePositionOffset { get { throw null; } set { } }
+
         public long MaxCharactersFromEntities { get { throw null; } set { } }
+
         public long MaxCharactersInDocument { get { throw null; } set { } }
-        public System.Xml.XmlNameTable NameTable { get { throw null; } set { } }
-        public System.Xml.XmlReaderSettings Clone() { throw null; }
+
+        public XmlNameTable NameTable { get { throw null; } set { } }
+
+        public XmlReaderSettings Clone() { throw null; }
+
         public void Reset() { }
     }
+
     public enum XmlSpace
     {
-        Default = 1,
         None = 0,
-        Preserve = 2,
+        Default = 1,
+        Preserve = 2
     }
-    public abstract partial class XmlWriter : System.IDisposable
+
+    public abstract partial class XmlWriter : IDisposable
     {
-        protected XmlWriter() { }
-        public virtual System.Xml.XmlWriterSettings Settings { get { throw null; } }
-        public abstract System.Xml.WriteState WriteState { get; }
+        public virtual XmlWriterSettings Settings { get { throw null; } }
+
+        public abstract WriteState WriteState { get; }
+
         public virtual string XmlLang { get { throw null; } }
-        public virtual System.Xml.XmlSpace XmlSpace { get { throw null; } }
-        public static System.Xml.XmlWriter Create(System.IO.Stream output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.Stream output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.TextWriter output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.TextWriter output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Text.StringBuilder output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Text.StringBuilder output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Xml.XmlWriter output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Xml.XmlWriter output, System.Xml.XmlWriterSettings settings) { throw null; }
+
+        public virtual XmlSpace XmlSpace { get { throw null; } }
+
+        public static XmlWriter Create(IO.Stream output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(IO.Stream output) { throw null; }
+
+        public static XmlWriter Create(IO.TextWriter output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(IO.TextWriter output) { throw null; }
+
+        public static XmlWriter Create(Text.StringBuilder output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(Text.StringBuilder output) { throw null; }
+
+        public static XmlWriter Create(XmlWriter output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(XmlWriter output) { throw null; }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
+
         public abstract void Flush();
-        public virtual System.Threading.Tasks.Task FlushAsync() { throw null; }
+        public virtual Threading.Tasks.Task FlushAsync() { throw null; }
+
         public abstract string LookupPrefix(string ns);
-        public virtual void WriteAttributes(System.Xml.XmlReader reader, bool defattr) { }
-        public virtual System.Threading.Tasks.Task WriteAttributesAsync(System.Xml.XmlReader reader, bool defattr) { throw null; }
-        public void WriteAttributeString(string localName, string value) { }
-        public void WriteAttributeString(string localName, string ns, string value) { }
+        public virtual void WriteAttributes(XmlReader reader, bool defattr) { }
+
+        public virtual Threading.Tasks.Task WriteAttributesAsync(XmlReader reader, bool defattr) { throw null; }
+
         public void WriteAttributeString(string prefix, string localName, string ns, string value) { }
-        public System.Threading.Tasks.Task WriteAttributeStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
+        public void WriteAttributeString(string localName, string ns, string value) { }
+
+        public void WriteAttributeString(string localName, string value) { }
+
+        public Threading.Tasks.Task WriteAttributeStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
         public abstract void WriteBase64(byte[] buffer, int index, int count);
-        public virtual System.Threading.Tasks.Task WriteBase64Async(byte[] buffer, int index, int count) { throw null; }
+        public virtual Threading.Tasks.Task WriteBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual void WriteBinHex(byte[] buffer, int index, int count) { }
-        public virtual System.Threading.Tasks.Task WriteBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public abstract void WriteCData(string text);
-        public virtual System.Threading.Tasks.Task WriteCDataAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteCDataAsync(string text) { throw null; }
+
         public abstract void WriteCharEntity(char ch);
-        public virtual System.Threading.Tasks.Task WriteCharEntityAsync(char ch) { throw null; }
+        public virtual Threading.Tasks.Task WriteCharEntityAsync(char ch) { throw null; }
+
         public abstract void WriteChars(char[] buffer, int index, int count);
-        public virtual System.Threading.Tasks.Task WriteCharsAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual Threading.Tasks.Task WriteCharsAsync(char[] buffer, int index, int count) { throw null; }
+
         public abstract void WriteComment(string text);
-        public virtual System.Threading.Tasks.Task WriteCommentAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteCommentAsync(string text) { throw null; }
+
         public abstract void WriteDocType(string name, string pubid, string sysid, string subset);
-        public virtual System.Threading.Tasks.Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset) { throw null; }
-        public void WriteElementString(string localName, string value) { }
-        public void WriteElementString(string localName, string ns, string value) { }
+        public virtual Threading.Tasks.Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset) { throw null; }
+
         public void WriteElementString(string prefix, string localName, string ns, string value) { }
-        public System.Threading.Tasks.Task WriteElementStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
+        public void WriteElementString(string localName, string ns, string value) { }
+
+        public void WriteElementString(string localName, string value) { }
+
+        public Threading.Tasks.Task WriteElementStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
         public abstract void WriteEndAttribute();
-        protected internal virtual System.Threading.Tasks.Task WriteEndAttributeAsync() { throw null; }
+        protected internal virtual Threading.Tasks.Task WriteEndAttributeAsync() { throw null; }
+
         public abstract void WriteEndDocument();
-        public virtual System.Threading.Tasks.Task WriteEndDocumentAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteEndDocumentAsync() { throw null; }
+
         public abstract void WriteEndElement();
-        public virtual System.Threading.Tasks.Task WriteEndElementAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteEndElementAsync() { throw null; }
+
         public abstract void WriteEntityRef(string name);
-        public virtual System.Threading.Tasks.Task WriteEntityRefAsync(string name) { throw null; }
+        public virtual Threading.Tasks.Task WriteEntityRefAsync(string name) { throw null; }
+
         public abstract void WriteFullEndElement();
-        public virtual System.Threading.Tasks.Task WriteFullEndElementAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteFullEndElementAsync() { throw null; }
+
         public virtual void WriteName(string name) { }
-        public virtual System.Threading.Tasks.Task WriteNameAsync(string name) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteNameAsync(string name) { throw null; }
+
         public virtual void WriteNmToken(string name) { }
-        public virtual System.Threading.Tasks.Task WriteNmTokenAsync(string name) { throw null; }
-        public virtual void WriteNode(System.Xml.XmlReader reader, bool defattr) { }
-        public virtual System.Threading.Tasks.Task WriteNodeAsync(System.Xml.XmlReader reader, bool defattr) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteNmTokenAsync(string name) { throw null; }
+
+        public virtual void WriteNode(XmlReader reader, bool defattr) { }
+
+        public virtual Threading.Tasks.Task WriteNodeAsync(XmlReader reader, bool defattr) { throw null; }
+
         public abstract void WriteProcessingInstruction(string name, string text);
-        public virtual System.Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string text) { throw null; }
+
         public virtual void WriteQualifiedName(string localName, string ns) { }
-        public virtual System.Threading.Tasks.Task WriteQualifiedNameAsync(string localName, string ns) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteQualifiedNameAsync(string localName, string ns) { throw null; }
+
         public abstract void WriteRaw(char[] buffer, int index, int count);
         public abstract void WriteRaw(string data);
-        public virtual System.Threading.Tasks.Task WriteRawAsync(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task WriteRawAsync(string data) { throw null; }
-        public void WriteStartAttribute(string localName) { }
-        public void WriteStartAttribute(string localName, string ns) { }
+        public virtual Threading.Tasks.Task WriteRawAsync(char[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteRawAsync(string data) { throw null; }
+
         public abstract void WriteStartAttribute(string prefix, string localName, string ns);
-        protected internal virtual System.Threading.Tasks.Task WriteStartAttributeAsync(string prefix, string localName, string ns) { throw null; }
+        public void WriteStartAttribute(string localName, string ns) { }
+
+        public void WriteStartAttribute(string localName) { }
+
+        protected internal virtual Threading.Tasks.Task WriteStartAttributeAsync(string prefix, string localName, string ns) { throw null; }
+
         public abstract void WriteStartDocument();
         public abstract void WriteStartDocument(bool standalone);
-        public virtual System.Threading.Tasks.Task WriteStartDocumentAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task WriteStartDocumentAsync(bool standalone) { throw null; }
-        public void WriteStartElement(string localName) { }
-        public void WriteStartElement(string localName, string ns) { }
+        public virtual Threading.Tasks.Task WriteStartDocumentAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task WriteStartDocumentAsync(bool standalone) { throw null; }
+
         public abstract void WriteStartElement(string prefix, string localName, string ns);
-        public virtual System.Threading.Tasks.Task WriteStartElementAsync(string prefix, string localName, string ns) { throw null; }
+        public void WriteStartElement(string localName, string ns) { }
+
+        public void WriteStartElement(string localName) { }
+
+        public virtual Threading.Tasks.Task WriteStartElementAsync(string prefix, string localName, string ns) { throw null; }
+
         public abstract void WriteString(string text);
-        public virtual System.Threading.Tasks.Task WriteStringAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteStringAsync(string text) { throw null; }
+
         public abstract void WriteSurrogateCharEntity(char lowChar, char highChar);
-        public virtual System.Threading.Tasks.Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) { throw null; }
+        public virtual Threading.Tasks.Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) { throw null; }
+
         public virtual void WriteValue(bool value) { }
-        public virtual void WriteValue(System.DateTimeOffset value) { }
+
+        public virtual void WriteValue(DateTimeOffset value) { }
+
         public virtual void WriteValue(decimal value) { }
+
         public virtual void WriteValue(double value) { }
+
         public virtual void WriteValue(int value) { }
+
         public virtual void WriteValue(long value) { }
+
         public virtual void WriteValue(object value) { }
+
         public virtual void WriteValue(float value) { }
+
         public virtual void WriteValue(string value) { }
+
         public abstract void WriteWhitespace(string ws);
-        public virtual System.Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
+        public virtual Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
     }
+
     public sealed partial class XmlWriterSettings
     {
-        public XmlWriterSettings() { }
         public bool Async { get { throw null; } set { } }
+
         public bool CheckCharacters { get { throw null; } set { } }
+
         public bool CloseOutput { get { throw null; } set { } }
-        public System.Xml.ConformanceLevel ConformanceLevel { get { throw null; } set { } }
-        public System.Text.Encoding Encoding { get { throw null; } set { } }
+
+        public ConformanceLevel ConformanceLevel { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
         public bool Indent { get { throw null; } set { } }
+
         public string IndentChars { get { throw null; } set { } }
-        public System.Xml.NamespaceHandling NamespaceHandling { get { throw null; } set { } }
+
+        public NamespaceHandling NamespaceHandling { get { throw null; } set { } }
+
         public string NewLineChars { get { throw null; } set { } }
-        public System.Xml.NewLineHandling NewLineHandling { get { throw null; } set { } }
+
+        public NewLineHandling NewLineHandling { get { throw null; } set { } }
+
         public bool NewLineOnAttributes { get { throw null; } set { } }
+
         public bool OmitXmlDeclaration { get { throw null; } set { } }
+
         public bool WriteEndDocumentOnClose { get { throw null; } set { } }
-        public System.Xml.XmlWriterSettings Clone() { throw null; }
+
+        public XmlWriterSettings Clone() { throw null; }
+
         public void Reset() { }
     }
 }
+
 namespace System.Xml.Schema
 {
     public partial class XmlSchema
     {
         internal XmlSchema() { }
     }
+
     public enum XmlSchemaForm
     {
         None = 0,
         Qualified = 1,
-        Unqualified = 2,
+        Unqualified = 2
     }
 }

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/ref/netstandard1.3/System.Xml.ReaderWriter.cs
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/ref/netstandard1.3/System.Xml.ReaderWriter.cs
@@ -4,543 +4,847 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Xml.ReaderWriter")]
-[assembly: AssemblyDescription("System.Xml.ReaderWriter")]
-[assembly: AssemblyDefaultAlias("System.Xml.ReaderWriter")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.10.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Xml.ReaderWriter")]
+[assembly: System.Reflection.AssemblyDescription("System.Xml.ReaderWriter")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Xml.ReaderWriter")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.10.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Xml
 {
     public enum ConformanceLevel
     {
         Auto = 0,
-        Document = 2,
         Fragment = 1,
+        Document = 2
     }
+
     public enum DtdProcessing
     {
-        Ignore = 1,
         Prohibit = 0,
+        Ignore = 1
     }
+
     public partial interface IXmlLineInfo
     {
         int LineNumber { get; }
+
         int LinePosition { get; }
+
         bool HasLineInfo();
     }
+
     public partial interface IXmlNamespaceResolver
     {
-        System.Collections.Generic.IDictionary<string, string> GetNamespacesInScope(System.Xml.XmlNamespaceScope scope);
+        Collections.Generic.IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope);
         string LookupNamespace(string prefix);
         string LookupPrefix(string namespaceName);
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum NamespaceHandling
     {
         Default = 0,
-        OmitDuplicates = 1,
+        OmitDuplicates = 1
     }
-    public partial class NameTable : System.Xml.XmlNameTable
+
+    public partial class NameTable : XmlNameTable
     {
-        public NameTable() { }
         public override string Add(char[] key, int start, int len) { throw null; }
+
         public override string Add(string key) { throw null; }
+
         public override string Get(char[] key, int start, int len) { throw null; }
+
         public override string Get(string value) { throw null; }
     }
+
     public enum NewLineHandling
     {
-        Entitize = 1,
-        None = 2,
         Replace = 0,
+        Entitize = 1,
+        None = 2
     }
+
     public enum ReadState
     {
-        Closed = 4,
-        EndOfFile = 3,
-        Error = 2,
         Initial = 0,
         Interactive = 1,
+        Error = 2,
+        EndOfFile = 3,
+        Closed = 4
     }
+
     public enum WriteState
     {
-        Attribute = 3,
-        Closed = 5,
-        Content = 4,
-        Element = 2,
-        Error = 6,
-        Prolog = 1,
         Start = 0,
+        Prolog = 1,
+        Element = 2,
+        Attribute = 3,
+        Content = 4,
+        Closed = 5,
+        Error = 6
     }
+
     public static partial class XmlConvert
     {
         public static string DecodeName(string name) { throw null; }
+
         public static string EncodeLocalName(string name) { throw null; }
+
         public static string EncodeName(string name) { throw null; }
+
         public static string EncodeNmToken(string name) { throw null; }
+
         public static bool ToBoolean(string s) { throw null; }
+
         public static byte ToByte(string s) { throw null; }
+
         public static char ToChar(string s) { throw null; }
-        public static System.DateTime ToDateTime(string s, System.Xml.XmlDateTimeSerializationMode dateTimeOption) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s, string format) { throw null; }
-        public static System.DateTimeOffset ToDateTimeOffset(string s, string[] formats) { throw null; }
+
+        public static DateTime ToDateTime(string s, XmlDateTimeSerializationMode dateTimeOption) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s, string format) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s, string[] formats) { throw null; }
+
+        public static DateTimeOffset ToDateTimeOffset(string s) { throw null; }
+
         public static decimal ToDecimal(string s) { throw null; }
+
         public static double ToDouble(string s) { throw null; }
-        public static System.Guid ToGuid(string s) { throw null; }
+
+        public static Guid ToGuid(string s) { throw null; }
+
         public static short ToInt16(string s) { throw null; }
+
         public static int ToInt32(string s) { throw null; }
+
         public static long ToInt64(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static sbyte ToSByte(string s) { throw null; }
+
         public static float ToSingle(string s) { throw null; }
+
         public static string ToString(bool value) { throw null; }
+
         public static string ToString(byte value) { throw null; }
+
         public static string ToString(char value) { throw null; }
-        public static string ToString(System.DateTime value, System.Xml.XmlDateTimeSerializationMode dateTimeOption) { throw null; }
-        public static string ToString(System.DateTimeOffset value) { throw null; }
-        public static string ToString(System.DateTimeOffset value, string format) { throw null; }
+
+        public static string ToString(DateTime value, XmlDateTimeSerializationMode dateTimeOption) { throw null; }
+
+        public static string ToString(DateTimeOffset value, string format) { throw null; }
+
+        public static string ToString(DateTimeOffset value) { throw null; }
+
         public static string ToString(decimal value) { throw null; }
+
         public static string ToString(double value) { throw null; }
-        public static string ToString(System.Guid value) { throw null; }
+
+        public static string ToString(Guid value) { throw null; }
+
         public static string ToString(short value) { throw null; }
+
         public static string ToString(int value) { throw null; }
+
         public static string ToString(long value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static string ToString(sbyte value) { throw null; }
+
         public static string ToString(float value) { throw null; }
-        public static string ToString(System.TimeSpan value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        public static string ToString(TimeSpan value) { throw null; }
+
+        [CLSCompliant(false)]
         public static string ToString(ushort value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static string ToString(uint value) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static string ToString(ulong value) { throw null; }
-        public static System.TimeSpan ToTimeSpan(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        public static TimeSpan ToTimeSpan(string s) { throw null; }
+
+        [CLSCompliant(false)]
         public static ushort ToUInt16(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static uint ToUInt32(string s) { throw null; }
-        [System.CLSCompliantAttribute(false)]
+
+        [CLSCompliant(false)]
         public static ulong ToUInt64(string s) { throw null; }
+
         public static string VerifyName(string name) { throw null; }
+
         public static string VerifyNCName(string name) { throw null; }
+
         public static string VerifyNMTOKEN(string name) { throw null; }
+
         public static string VerifyPublicId(string publicId) { throw null; }
+
         public static string VerifyWhitespace(string content) { throw null; }
+
         public static string VerifyXmlChars(string content) { throw null; }
     }
+
     public enum XmlDateTimeSerializationMode
     {
         Local = 0,
-        RoundtripKind = 3,
-        Unspecified = 2,
         Utc = 1,
+        Unspecified = 2,
+        RoundtripKind = 3
     }
-    public partial class XmlException : System.Exception
+
+    public partial class XmlException : Exception
     {
         public XmlException() { }
+
+        public XmlException(string message, Exception innerException, int lineNumber, int linePosition) { }
+
+        public XmlException(string message, Exception innerException) { }
+
         public XmlException(string message) { }
-        public XmlException(string message, System.Exception innerException) { }
-        public XmlException(string message, System.Exception innerException, int lineNumber, int linePosition) { }
+
         public int LineNumber { get { throw null; } }
+
         public int LinePosition { get { throw null; } }
+
         public override string Message { get { throw null; } }
     }
-    public partial class XmlNamespaceManager : System.Collections.IEnumerable, System.Xml.IXmlNamespaceResolver
+
+    public partial class XmlNamespaceManager : Collections.IEnumerable, IXmlNamespaceResolver
     {
-        public XmlNamespaceManager(System.Xml.XmlNameTable nameTable) { }
+        public XmlNamespaceManager(XmlNameTable nameTable) { }
+
         public virtual string DefaultNamespace { get { throw null; } }
-        public virtual System.Xml.XmlNameTable NameTable { get { throw null; } }
+
+        public virtual XmlNameTable NameTable { get { throw null; } }
+
         public virtual void AddNamespace(string prefix, string uri) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.IDictionary<string, string> GetNamespacesInScope(System.Xml.XmlNamespaceScope scope) { throw null; }
+
+        public virtual Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public virtual Collections.Generic.IDictionary<string, string> GetNamespacesInScope(XmlNamespaceScope scope) { throw null; }
+
         public virtual bool HasNamespace(string prefix) { throw null; }
+
         public virtual string LookupNamespace(string prefix) { throw null; }
+
         public virtual string LookupPrefix(string uri) { throw null; }
+
         public virtual bool PopScope() { throw null; }
+
         public virtual void PushScope() { }
+
         public virtual void RemoveNamespace(string prefix, string uri) { }
     }
+
     public enum XmlNamespaceScope
     {
         All = 0,
         ExcludeXml = 1,
-        Local = 2,
+        Local = 2
     }
+
     public abstract partial class XmlNameTable
     {
-        protected XmlNameTable() { }
         public abstract string Add(char[] array, int offset, int length);
         public abstract string Add(string array);
         public abstract string Get(char[] array, int offset, int length);
         public abstract string Get(string array);
     }
+
     public enum XmlNodeType
     {
+        None = 0,
+        Element = 1,
         Attribute = 2,
+        Text = 3,
         CDATA = 4,
+        EntityReference = 5,
+        Entity = 6,
+        ProcessingInstruction = 7,
         Comment = 8,
         Document = 9,
-        DocumentFragment = 11,
         DocumentType = 10,
-        Element = 1,
+        DocumentFragment = 11,
+        Notation = 12,
+        Whitespace = 13,
+        SignificantWhitespace = 14,
         EndElement = 15,
         EndEntity = 16,
-        Entity = 6,
-        EntityReference = 5,
-        None = 0,
-        Notation = 12,
-        ProcessingInstruction = 7,
-        SignificantWhitespace = 14,
-        Text = 3,
-        Whitespace = 13,
-        XmlDeclaration = 17,
+        XmlDeclaration = 17
     }
+
     public partial class XmlParserContext
     {
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, System.Xml.XmlSpace xmlSpace) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, System.Xml.XmlSpace xmlSpace, System.Text.Encoding enc) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string xmlLang, System.Xml.XmlSpace xmlSpace) { }
-        public XmlParserContext(System.Xml.XmlNameTable nt, System.Xml.XmlNamespaceManager nsMgr, string xmlLang, System.Xml.XmlSpace xmlSpace, System.Text.Encoding enc) { }
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, XmlSpace xmlSpace, Text.Encoding enc) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string docTypeName, string pubId, string sysId, string internalSubset, string baseURI, string xmlLang, XmlSpace xmlSpace) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string xmlLang, XmlSpace xmlSpace, Text.Encoding enc) { }
+
+        public XmlParserContext(XmlNameTable nt, XmlNamespaceManager nsMgr, string xmlLang, XmlSpace xmlSpace) { }
+
         public string BaseURI { get { throw null; } set { } }
+
         public string DocTypeName { get { throw null; } set { } }
-        public System.Text.Encoding Encoding { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
         public string InternalSubset { get { throw null; } set { } }
-        public System.Xml.XmlNamespaceManager NamespaceManager { get { throw null; } set { } }
-        public System.Xml.XmlNameTable NameTable { get { throw null; } set { } }
+
+        public XmlNamespaceManager NamespaceManager { get { throw null; } set { } }
+
+        public XmlNameTable NameTable { get { throw null; } set { } }
+
         public string PublicId { get { throw null; } set { } }
+
         public string SystemId { get { throw null; } set { } }
+
         public string XmlLang { get { throw null; } set { } }
-        public System.Xml.XmlSpace XmlSpace { get { throw null; } set { } }
+
+        public XmlSpace XmlSpace { get { throw null; } set { } }
     }
+
     public partial class XmlQualifiedName
     {
-        public static readonly System.Xml.XmlQualifiedName Empty;
+        public static readonly XmlQualifiedName Empty;
         public XmlQualifiedName() { }
-        public XmlQualifiedName(string name) { }
+
         public XmlQualifiedName(string name, string ns) { }
+
+        public XmlQualifiedName(string name) { }
+
         public bool IsEmpty { get { throw null; } }
+
         public string Name { get { throw null; } }
+
         public string Namespace { get { throw null; } }
+
         public override bool Equals(object other) { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(System.Xml.XmlQualifiedName a, System.Xml.XmlQualifiedName b) { throw null; }
-        public static bool operator !=(System.Xml.XmlQualifiedName a, System.Xml.XmlQualifiedName b) { throw null; }
+
+        public static bool operator ==(XmlQualifiedName a, XmlQualifiedName b) { throw null; }
+
+        public static bool operator !=(XmlQualifiedName a, XmlQualifiedName b) { throw null; }
+
         public override string ToString() { throw null; }
+
         public static string ToString(string name, string ns) { throw null; }
     }
-    public abstract partial class XmlReader : System.IDisposable
+
+    public abstract partial class XmlReader : IDisposable
     {
-        protected XmlReader() { }
         public abstract int AttributeCount { get; }
         public abstract string BaseURI { get; }
+
         public virtual bool CanReadBinaryContent { get { throw null; } }
+
         public virtual bool CanReadValueChunk { get { throw null; } }
+
         public virtual bool CanResolveEntity { get { throw null; } }
+
         public abstract int Depth { get; }
         public abstract bool EOF { get; }
+
         public virtual bool HasAttributes { get { throw null; } }
+
         public virtual bool HasValue { get { throw null; } }
+
         public virtual bool IsDefault { get { throw null; } }
+
         public abstract bool IsEmptyElement { get; }
+
         public virtual string this[int i] { get { throw null; } }
-        public virtual string this[string name] { get { throw null; } }
+
         public virtual string this[string name, string namespaceURI] { get { throw null; } }
+
+        public virtual string this[string name] { get { throw null; } }
+
         public abstract string LocalName { get; }
+
         public virtual string Name { get { throw null; } }
+
         public abstract string NamespaceURI { get; }
-        public abstract System.Xml.XmlNameTable NameTable { get; }
-        public abstract System.Xml.XmlNodeType NodeType { get; }
+        public abstract XmlNameTable NameTable { get; }
+        public abstract XmlNodeType NodeType { get; }
         public abstract string Prefix { get; }
-        public abstract System.Xml.ReadState ReadState { get; }
-        public virtual System.Xml.XmlReaderSettings Settings { get { throw null; } }
+        public abstract ReadState ReadState { get; }
+
+        public virtual XmlReaderSettings Settings { get { throw null; } }
+
         public abstract string Value { get; }
-        public virtual System.Type ValueType { get { throw null; } }
+
+        public virtual Type ValueType { get { throw null; } }
+
         public virtual string XmlLang { get { throw null; } }
-        public virtual System.Xml.XmlSpace XmlSpace { get { throw null; } }
-        public static System.Xml.XmlReader Create(System.IO.Stream input) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.Stream input, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.Stream input, System.Xml.XmlReaderSettings settings, System.Xml.XmlParserContext inputContext) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.IO.TextReader input, System.Xml.XmlReaderSettings settings, System.Xml.XmlParserContext inputContext) { throw null; }
-        public static System.Xml.XmlReader Create(string inputUri) { throw null; }
-        public static System.Xml.XmlReader Create(string inputUri, System.Xml.XmlReaderSettings settings) { throw null; }
-        public static System.Xml.XmlReader Create(System.Xml.XmlReader reader, System.Xml.XmlReaderSettings settings) { throw null; }
+
+        public virtual XmlSpace XmlSpace { get { throw null; } }
+
+        public static XmlReader Create(IO.Stream input, XmlReaderSettings settings, XmlParserContext inputContext) { throw null; }
+
+        public static XmlReader Create(IO.Stream input, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(IO.Stream input) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input, XmlReaderSettings settings, XmlParserContext inputContext) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(IO.TextReader input) { throw null; }
+
+        public static XmlReader Create(string inputUri, XmlReaderSettings settings) { throw null; }
+
+        public static XmlReader Create(string inputUri) { throw null; }
+
+        public static XmlReader Create(XmlReader reader, XmlReaderSettings settings) { throw null; }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
+
         public abstract string GetAttribute(int i);
-        public abstract string GetAttribute(string name);
         public abstract string GetAttribute(string name, string namespaceURI);
-        public virtual System.Threading.Tasks.Task<string> GetValueAsync() { throw null; }
+        public abstract string GetAttribute(string name);
+        public virtual Threading.Tasks.Task<string> GetValueAsync() { throw null; }
+
         public static bool IsName(string str) { throw null; }
+
         public static bool IsNameToken(string str) { throw null; }
+
         public virtual bool IsStartElement() { throw null; }
-        public virtual bool IsStartElement(string name) { throw null; }
+
         public virtual bool IsStartElement(string localname, string ns) { throw null; }
+
+        public virtual bool IsStartElement(string name) { throw null; }
+
         public abstract string LookupNamespace(string prefix);
         public virtual void MoveToAttribute(int i) { }
-        public abstract bool MoveToAttribute(string name);
+
         public abstract bool MoveToAttribute(string name, string ns);
-        public virtual System.Xml.XmlNodeType MoveToContent() { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Xml.XmlNodeType> MoveToContentAsync() { throw null; }
+        public abstract bool MoveToAttribute(string name);
+        public virtual XmlNodeType MoveToContent() { throw null; }
+
+        public virtual Threading.Tasks.Task<XmlNodeType> MoveToContentAsync() { throw null; }
+
         public abstract bool MoveToElement();
         public abstract bool MoveToFirstAttribute();
         public abstract bool MoveToNextAttribute();
         public abstract bool Read();
-        public virtual System.Threading.Tasks.Task<bool> ReadAsync() { throw null; }
+        public virtual Threading.Tasks.Task<bool> ReadAsync() { throw null; }
+
         public abstract bool ReadAttributeValue();
-        public virtual object ReadContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadContentAsAsync(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
+        public virtual object ReadContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
         public virtual int ReadContentAsBase64(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual int ReadContentAsBinHex(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public virtual bool ReadContentAsBoolean() { throw null; }
-        public virtual System.DateTimeOffset ReadContentAsDateTimeOffset() { throw null; }
+
+        public virtual DateTimeOffset ReadContentAsDateTimeOffset() { throw null; }
+
         public virtual decimal ReadContentAsDecimal() { throw null; }
+
         public virtual double ReadContentAsDouble() { throw null; }
+
         public virtual float ReadContentAsFloat() { throw null; }
+
         public virtual int ReadContentAsInt() { throw null; }
+
         public virtual long ReadContentAsLong() { throw null; }
+
         public virtual object ReadContentAsObject() { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadContentAsObjectAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadContentAsObjectAsync() { throw null; }
+
         public virtual string ReadContentAsString() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadContentAsStringAsync() { throw null; }
-        public virtual object ReadElementContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
-        public virtual object ReadElementContentAs(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver, string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadElementContentAsAsync(System.Type returnType, System.Xml.IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadContentAsStringAsync() { throw null; }
+
+        public virtual object ReadElementContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver, string localName, string namespaceURI) { throw null; }
+
+        public virtual object ReadElementContentAs(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadElementContentAsAsync(Type returnType, IXmlNamespaceResolver namespaceResolver) { throw null; }
+
         public virtual int ReadElementContentAsBase64(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual int ReadElementContentAsBinHex(byte[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public virtual bool ReadElementContentAsBoolean() { throw null; }
+
         public virtual bool ReadElementContentAsBoolean(string localName, string namespaceURI) { throw null; }
+
         public virtual decimal ReadElementContentAsDecimal() { throw null; }
+
         public virtual decimal ReadElementContentAsDecimal(string localName, string namespaceURI) { throw null; }
+
         public virtual double ReadElementContentAsDouble() { throw null; }
+
         public virtual double ReadElementContentAsDouble(string localName, string namespaceURI) { throw null; }
+
         public virtual float ReadElementContentAsFloat() { throw null; }
+
         public virtual float ReadElementContentAsFloat(string localName, string namespaceURI) { throw null; }
+
         public virtual int ReadElementContentAsInt() { throw null; }
+
         public virtual int ReadElementContentAsInt(string localName, string namespaceURI) { throw null; }
+
         public virtual long ReadElementContentAsLong() { throw null; }
+
         public virtual long ReadElementContentAsLong(string localName, string namespaceURI) { throw null; }
+
         public virtual object ReadElementContentAsObject() { throw null; }
+
         public virtual object ReadElementContentAsObject(string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<object> ReadElementContentAsObjectAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<object> ReadElementContentAsObjectAsync() { throw null; }
+
         public virtual string ReadElementContentAsString() { throw null; }
+
         public virtual string ReadElementContentAsString(string localName, string namespaceURI) { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadElementContentAsStringAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadElementContentAsStringAsync() { throw null; }
+
         public virtual void ReadEndElement() { }
+
         public virtual string ReadInnerXml() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadInnerXmlAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadInnerXmlAsync() { throw null; }
+
         public virtual string ReadOuterXml() { throw null; }
-        public virtual System.Threading.Tasks.Task<string> ReadOuterXmlAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task<string> ReadOuterXmlAsync() { throw null; }
+
         public virtual void ReadStartElement() { }
-        public virtual void ReadStartElement(string name) { }
+
         public virtual void ReadStartElement(string localname, string ns) { }
-        public virtual System.Xml.XmlReader ReadSubtree() { throw null; }
-        public virtual bool ReadToDescendant(string name) { throw null; }
+
+        public virtual void ReadStartElement(string name) { }
+
+        public virtual XmlReader ReadSubtree() { throw null; }
+
         public virtual bool ReadToDescendant(string localName, string namespaceURI) { throw null; }
-        public virtual bool ReadToFollowing(string name) { throw null; }
+
+        public virtual bool ReadToDescendant(string name) { throw null; }
+
         public virtual bool ReadToFollowing(string localName, string namespaceURI) { throw null; }
-        public virtual bool ReadToNextSibling(string name) { throw null; }
+
+        public virtual bool ReadToFollowing(string name) { throw null; }
+
         public virtual bool ReadToNextSibling(string localName, string namespaceURI) { throw null; }
+
+        public virtual bool ReadToNextSibling(string name) { throw null; }
+
         public virtual int ReadValueChunk(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task<int> ReadValueChunkAsync(char[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task<int> ReadValueChunkAsync(char[] buffer, int index, int count) { throw null; }
+
         public abstract void ResolveEntity();
         public virtual void Skip() { }
-        public virtual System.Threading.Tasks.Task SkipAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task SkipAsync() { throw null; }
     }
+
     public sealed partial class XmlReaderSettings
     {
-        public XmlReaderSettings() { }
         public bool Async { get { throw null; } set { } }
+
         public bool CheckCharacters { get { throw null; } set { } }
+
         public bool CloseInput { get { throw null; } set { } }
-        public System.Xml.ConformanceLevel ConformanceLevel { get { throw null; } set { } }
-        public System.Xml.DtdProcessing DtdProcessing { get { throw null; } set { } }
+
+        public ConformanceLevel ConformanceLevel { get { throw null; } set { } }
+
+        public DtdProcessing DtdProcessing { get { throw null; } set { } }
+
         public bool IgnoreComments { get { throw null; } set { } }
+
         public bool IgnoreProcessingInstructions { get { throw null; } set { } }
+
         public bool IgnoreWhitespace { get { throw null; } set { } }
+
         public int LineNumberOffset { get { throw null; } set { } }
+
         public int LinePositionOffset { get { throw null; } set { } }
+
         public long MaxCharactersFromEntities { get { throw null; } set { } }
+
         public long MaxCharactersInDocument { get { throw null; } set { } }
-        public System.Xml.XmlNameTable NameTable { get { throw null; } set { } }
-        public System.Xml.XmlReaderSettings Clone() { throw null; }
+
+        public XmlNameTable NameTable { get { throw null; } set { } }
+
+        public XmlReaderSettings Clone() { throw null; }
+
         public void Reset() { }
     }
+
     public enum XmlSpace
     {
-        Default = 1,
         None = 0,
-        Preserve = 2,
+        Default = 1,
+        Preserve = 2
     }
-    public abstract partial class XmlWriter : System.IDisposable
+
+    public abstract partial class XmlWriter : IDisposable
     {
-        protected XmlWriter() { }
-        public virtual System.Xml.XmlWriterSettings Settings { get { throw null; } }
-        public abstract System.Xml.WriteState WriteState { get; }
+        public virtual XmlWriterSettings Settings { get { throw null; } }
+
+        public abstract WriteState WriteState { get; }
+
         public virtual string XmlLang { get { throw null; } }
-        public virtual System.Xml.XmlSpace XmlSpace { get { throw null; } }
-        public static System.Xml.XmlWriter Create(System.IO.Stream output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.Stream output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.TextWriter output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.IO.TextWriter output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Text.StringBuilder output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Text.StringBuilder output, System.Xml.XmlWriterSettings settings) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Xml.XmlWriter output) { throw null; }
-        public static System.Xml.XmlWriter Create(System.Xml.XmlWriter output, System.Xml.XmlWriterSettings settings) { throw null; }
+
+        public virtual XmlSpace XmlSpace { get { throw null; } }
+
+        public static XmlWriter Create(IO.Stream output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(IO.Stream output) { throw null; }
+
+        public static XmlWriter Create(IO.TextWriter output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(IO.TextWriter output) { throw null; }
+
+        public static XmlWriter Create(Text.StringBuilder output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(Text.StringBuilder output) { throw null; }
+
+        public static XmlWriter Create(XmlWriter output, XmlWriterSettings settings) { throw null; }
+
+        public static XmlWriter Create(XmlWriter output) { throw null; }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
+
         public abstract void Flush();
-        public virtual System.Threading.Tasks.Task FlushAsync() { throw null; }
+        public virtual Threading.Tasks.Task FlushAsync() { throw null; }
+
         public abstract string LookupPrefix(string ns);
-        public virtual void WriteAttributes(System.Xml.XmlReader reader, bool defattr) { }
-        public virtual System.Threading.Tasks.Task WriteAttributesAsync(System.Xml.XmlReader reader, bool defattr) { throw null; }
-        public void WriteAttributeString(string localName, string value) { }
-        public void WriteAttributeString(string localName, string ns, string value) { }
+        public virtual void WriteAttributes(XmlReader reader, bool defattr) { }
+
+        public virtual Threading.Tasks.Task WriteAttributesAsync(XmlReader reader, bool defattr) { throw null; }
+
         public void WriteAttributeString(string prefix, string localName, string ns, string value) { }
-        public System.Threading.Tasks.Task WriteAttributeStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
+        public void WriteAttributeString(string localName, string ns, string value) { }
+
+        public void WriteAttributeString(string localName, string value) { }
+
+        public Threading.Tasks.Task WriteAttributeStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
         public abstract void WriteBase64(byte[] buffer, int index, int count);
-        public virtual System.Threading.Tasks.Task WriteBase64Async(byte[] buffer, int index, int count) { throw null; }
+        public virtual Threading.Tasks.Task WriteBase64Async(byte[] buffer, int index, int count) { throw null; }
+
         public virtual void WriteBinHex(byte[] buffer, int index, int count) { }
-        public virtual System.Threading.Tasks.Task WriteBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteBinHexAsync(byte[] buffer, int index, int count) { throw null; }
+
         public abstract void WriteCData(string text);
-        public virtual System.Threading.Tasks.Task WriteCDataAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteCDataAsync(string text) { throw null; }
+
         public abstract void WriteCharEntity(char ch);
-        public virtual System.Threading.Tasks.Task WriteCharEntityAsync(char ch) { throw null; }
+        public virtual Threading.Tasks.Task WriteCharEntityAsync(char ch) { throw null; }
+
         public abstract void WriteChars(char[] buffer, int index, int count);
-        public virtual System.Threading.Tasks.Task WriteCharsAsync(char[] buffer, int index, int count) { throw null; }
+        public virtual Threading.Tasks.Task WriteCharsAsync(char[] buffer, int index, int count) { throw null; }
+
         public abstract void WriteComment(string text);
-        public virtual System.Threading.Tasks.Task WriteCommentAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteCommentAsync(string text) { throw null; }
+
         public abstract void WriteDocType(string name, string pubid, string sysid, string subset);
-        public virtual System.Threading.Tasks.Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset) { throw null; }
-        public void WriteElementString(string localName, string value) { }
-        public void WriteElementString(string localName, string ns, string value) { }
+        public virtual Threading.Tasks.Task WriteDocTypeAsync(string name, string pubid, string sysid, string subset) { throw null; }
+
         public void WriteElementString(string prefix, string localName, string ns, string value) { }
-        public System.Threading.Tasks.Task WriteElementStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
+        public void WriteElementString(string localName, string ns, string value) { }
+
+        public void WriteElementString(string localName, string value) { }
+
+        public Threading.Tasks.Task WriteElementStringAsync(string prefix, string localName, string ns, string value) { throw null; }
+
         public abstract void WriteEndAttribute();
-        protected internal virtual System.Threading.Tasks.Task WriteEndAttributeAsync() { throw null; }
+        protected internal virtual Threading.Tasks.Task WriteEndAttributeAsync() { throw null; }
+
         public abstract void WriteEndDocument();
-        public virtual System.Threading.Tasks.Task WriteEndDocumentAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteEndDocumentAsync() { throw null; }
+
         public abstract void WriteEndElement();
-        public virtual System.Threading.Tasks.Task WriteEndElementAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteEndElementAsync() { throw null; }
+
         public abstract void WriteEntityRef(string name);
-        public virtual System.Threading.Tasks.Task WriteEntityRefAsync(string name) { throw null; }
+        public virtual Threading.Tasks.Task WriteEntityRefAsync(string name) { throw null; }
+
         public abstract void WriteFullEndElement();
-        public virtual System.Threading.Tasks.Task WriteFullEndElementAsync() { throw null; }
+        public virtual Threading.Tasks.Task WriteFullEndElementAsync() { throw null; }
+
         public virtual void WriteName(string name) { }
-        public virtual System.Threading.Tasks.Task WriteNameAsync(string name) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteNameAsync(string name) { throw null; }
+
         public virtual void WriteNmToken(string name) { }
-        public virtual System.Threading.Tasks.Task WriteNmTokenAsync(string name) { throw null; }
-        public virtual void WriteNode(System.Xml.XmlReader reader, bool defattr) { }
-        public virtual System.Threading.Tasks.Task WriteNodeAsync(System.Xml.XmlReader reader, bool defattr) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteNmTokenAsync(string name) { throw null; }
+
+        public virtual void WriteNode(XmlReader reader, bool defattr) { }
+
+        public virtual Threading.Tasks.Task WriteNodeAsync(XmlReader reader, bool defattr) { throw null; }
+
         public abstract void WriteProcessingInstruction(string name, string text);
-        public virtual System.Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteProcessingInstructionAsync(string name, string text) { throw null; }
+
         public virtual void WriteQualifiedName(string localName, string ns) { }
-        public virtual System.Threading.Tasks.Task WriteQualifiedNameAsync(string localName, string ns) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteQualifiedNameAsync(string localName, string ns) { throw null; }
+
         public abstract void WriteRaw(char[] buffer, int index, int count);
         public abstract void WriteRaw(string data);
-        public virtual System.Threading.Tasks.Task WriteRawAsync(char[] buffer, int index, int count) { throw null; }
-        public virtual System.Threading.Tasks.Task WriteRawAsync(string data) { throw null; }
-        public void WriteStartAttribute(string localName) { }
-        public void WriteStartAttribute(string localName, string ns) { }
+        public virtual Threading.Tasks.Task WriteRawAsync(char[] buffer, int index, int count) { throw null; }
+
+        public virtual Threading.Tasks.Task WriteRawAsync(string data) { throw null; }
+
         public abstract void WriteStartAttribute(string prefix, string localName, string ns);
-        protected internal virtual System.Threading.Tasks.Task WriteStartAttributeAsync(string prefix, string localName, string ns) { throw null; }
+        public void WriteStartAttribute(string localName, string ns) { }
+
+        public void WriteStartAttribute(string localName) { }
+
+        protected internal virtual Threading.Tasks.Task WriteStartAttributeAsync(string prefix, string localName, string ns) { throw null; }
+
         public abstract void WriteStartDocument();
         public abstract void WriteStartDocument(bool standalone);
-        public virtual System.Threading.Tasks.Task WriteStartDocumentAsync() { throw null; }
-        public virtual System.Threading.Tasks.Task WriteStartDocumentAsync(bool standalone) { throw null; }
-        public void WriteStartElement(string localName) { }
-        public void WriteStartElement(string localName, string ns) { }
+        public virtual Threading.Tasks.Task WriteStartDocumentAsync() { throw null; }
+
+        public virtual Threading.Tasks.Task WriteStartDocumentAsync(bool standalone) { throw null; }
+
         public abstract void WriteStartElement(string prefix, string localName, string ns);
-        public virtual System.Threading.Tasks.Task WriteStartElementAsync(string prefix, string localName, string ns) { throw null; }
+        public void WriteStartElement(string localName, string ns) { }
+
+        public void WriteStartElement(string localName) { }
+
+        public virtual Threading.Tasks.Task WriteStartElementAsync(string prefix, string localName, string ns) { throw null; }
+
         public abstract void WriteString(string text);
-        public virtual System.Threading.Tasks.Task WriteStringAsync(string text) { throw null; }
+        public virtual Threading.Tasks.Task WriteStringAsync(string text) { throw null; }
+
         public abstract void WriteSurrogateCharEntity(char lowChar, char highChar);
-        public virtual System.Threading.Tasks.Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) { throw null; }
+        public virtual Threading.Tasks.Task WriteSurrogateCharEntityAsync(char lowChar, char highChar) { throw null; }
+
         public virtual void WriteValue(bool value) { }
-        public virtual void WriteValue(System.DateTimeOffset value) { }
+
+        public virtual void WriteValue(DateTimeOffset value) { }
+
         public virtual void WriteValue(decimal value) { }
+
         public virtual void WriteValue(double value) { }
+
         public virtual void WriteValue(int value) { }
+
         public virtual void WriteValue(long value) { }
+
         public virtual void WriteValue(object value) { }
+
         public virtual void WriteValue(float value) { }
+
         public virtual void WriteValue(string value) { }
+
         public abstract void WriteWhitespace(string ws);
-        public virtual System.Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
+        public virtual Threading.Tasks.Task WriteWhitespaceAsync(string ws) { throw null; }
     }
+
     public sealed partial class XmlWriterSettings
     {
-        public XmlWriterSettings() { }
         public bool Async { get { throw null; } set { } }
+
         public bool CheckCharacters { get { throw null; } set { } }
+
         public bool CloseOutput { get { throw null; } set { } }
-        public System.Xml.ConformanceLevel ConformanceLevel { get { throw null; } set { } }
-        public System.Text.Encoding Encoding { get { throw null; } set { } }
+
+        public ConformanceLevel ConformanceLevel { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
         public bool Indent { get { throw null; } set { } }
+
         public string IndentChars { get { throw null; } set { } }
-        public System.Xml.NamespaceHandling NamespaceHandling { get { throw null; } set { } }
+
+        public NamespaceHandling NamespaceHandling { get { throw null; } set { } }
+
         public string NewLineChars { get { throw null; } set { } }
-        public System.Xml.NewLineHandling NewLineHandling { get { throw null; } set { } }
+
+        public NewLineHandling NewLineHandling { get { throw null; } set { } }
+
         public bool NewLineOnAttributes { get { throw null; } set { } }
+
         public bool OmitXmlDeclaration { get { throw null; } set { } }
+
         public bool WriteEndDocumentOnClose { get { throw null; } set { } }
-        public System.Xml.XmlWriterSettings Clone() { throw null; }
+
+        public XmlWriterSettings Clone() { throw null; }
+
         public void Reset() { }
     }
 }
+
 namespace System.Xml.Schema
 {
     public partial class XmlSchema
     {
         internal XmlSchema() { }
     }
+
     public enum XmlSchemaForm
     {
         None = 0,
         Qualified = 1,
-        Unqualified = 2,
+        Unqualified = 2
     }
 }
+
 namespace System.Xml.Serialization
 {
     public partial interface IXmlSerializable
     {
-        System.Xml.Schema.XmlSchema GetSchema();
-        void ReadXml(System.Xml.XmlReader reader);
-        void WriteXml(System.Xml.XmlWriter writer);
+        Schema.XmlSchema GetSchema();
+        void ReadXml(XmlReader reader);
+        void WriteXml(XmlWriter writer);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.Struct)]
-    public sealed partial class XmlSchemaProviderAttribute : System.Attribute
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
+    public sealed partial class XmlSchemaProviderAttribute : Attribute
     {
         public XmlSchemaProviderAttribute(string methodName) { }
+
         public bool IsAny { get { throw null; } set { } }
+
         public string MethodName { get { throw null; } }
     }
 }

--- a/src/referencePackages/src/system.xml.readerwriter/4.0.11/system.xml.readerwriter.nuspec
+++ b/src/referencePackages/src/system.xml.readerwriter/4.0.11/system.xml.readerwriter.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Xml.ReaderWriter</id>
@@ -28,25 +28,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETCore5.0">
-        <dependency id="System.Collections" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Globalization" version="4.0.11" exclude="Compile" />
-        <dependency id="System.IO" version="4.1.0" />
-        <dependency id="System.IO.FileSystem" version="4.0.1" exclude="Compile" />
-        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1" exclude="Compile" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" exclude="Compile" />
-        <dependency id="System.Runtime" version="4.1.0" />
-        <dependency id="System.Runtime.Extensions" version="4.1.0" exclude="Compile" />
-        <dependency id="System.Runtime.InteropServices" version="4.1.0" exclude="Compile" />
-        <dependency id="System.Text.Encoding" version="4.0.11" />
-        <dependency id="System.Text.Encoding.Extensions" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Text.RegularExpressions" version="4.1.0" exclude="Compile" />
-        <dependency id="System.Threading.Tasks" version="4.0.11" />
-        <dependency id="System.Threading.Tasks.Extensions" version="4.0.0" exclude="Compile" />
-      </group>
       <group targetFramework=".NETStandard1.0">
         <dependency id="System.IO" version="4.1.0" />
         <dependency id="System.Runtime" version="4.1.0" />
@@ -70,14 +51,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Threading.Tasks" version="4.0.11" />
         <dependency id="System.Threading.Tasks.Extensions" version="4.0.0" exclude="Compile" />
       </group>
-      <group targetFramework=".NETPortable0.0-Profile259" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
These changes contain some infrastructure changes to support overriding DisableImplicitFrameworkReferences in order to avoid a circular reference with the targeting pack.