### PR TITLE
Remove obsolete Directory.Build.props

### DIFF
--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Bcl.AsyncInterfaces</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.bcl.hashcode/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Bcl.HashCode</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.build.framework/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.build.framework/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Build.Framework</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.build.tasks.core/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.build.tasks.core/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.build.utilities.core/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.build.utilities.core/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.build/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.build/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Build</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.codeanalysis.csharp.workspaces/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.codeanalysis.csharp.workspaces/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.CodeAnalysis.CSharp.Workspaces</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.codeanalysis.workspaces.common/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.codeanalysis.workspaces.common/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.CodeAnalysis.Workspaces</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.csharp/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.csharp/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.CSharp</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.configuration.abstractions/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.configuration.abstractions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Configuration.Abstractions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.configuration.binder/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.configuration.binder/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Configuration.Binder</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.configuration/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.configuration/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Configuration</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.dependencyinjection.abstractions/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.dependencyinjection.abstractions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.DependencyInjection.Abstractions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.logging/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.logging/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Logging</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.extensions.options/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.extensions.options/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Extensions.Options</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.visualbasic/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.visualbasic/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.VisualBasic</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.win32.primitives/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.win32.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.win32.registry/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.win32.registry/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/microsoft.win32.systemevents/Directory.Build.props
+++ b/src/referencePackages/src/microsoft.win32.systemevents/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>Microsoft.Win32.SystemEvents</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.appcontext/Directory.Build.props
+++ b/src/referencePackages/src/system.appcontext/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.AppContext</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.buffers/Directory.Build.props
+++ b/src/referencePackages/src/system.buffers/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Buffers</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.componentmodel.annotations/Directory.Build.props
+++ b/src/referencePackages/src/system.componentmodel.annotations/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.ComponentModel.Annotations</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.componentmodel.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.componentmodel.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.ComponentModel.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.componentmodel/Directory.Build.props
+++ b/src/referencePackages/src/system.componentmodel/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.ComponentModel</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.composition.attributedmodel/Directory.Build.props
+++ b/src/referencePackages/src/system.composition.attributedmodel/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Composition.AttributedModel</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.composition.convention/Directory.Build.props
+++ b/src/referencePackages/src/system.composition.convention/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Composition.Convention</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.composition.hosting/Directory.Build.props
+++ b/src/referencePackages/src/system.composition.hosting/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Composition.Hosting</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.composition.runtime/Directory.Build.props
+++ b/src/referencePackages/src/system.composition.runtime/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Composition.Runtime</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.composition.typedparts/Directory.Build.props
+++ b/src/referencePackages/src/system.composition.typedparts/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Composition.TypedParts</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.console/Directory.Build.props
+++ b/src/referencePackages/src/system.console/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Console</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.diagnostics.debug/Directory.Build.props
+++ b/src/referencePackages/src/system.diagnostics.debug/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Diagnostics.Debug</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.diagnostics.eventlog/Directory.Build.props
+++ b/src/referencePackages/src/system.diagnostics.eventlog/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Diagnostics.EventLog</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.diagnostics.fileversioninfo/Directory.Build.props
+++ b/src/referencePackages/src/system.diagnostics.fileversioninfo/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Diagnostics.FileVersionInfo</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.diagnostics.tools/Directory.Build.props
+++ b/src/referencePackages/src/system.diagnostics.tools/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Diagnostics.Tools</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.diagnostics.tracing/Directory.Build.props
+++ b/src/referencePackages/src/system.diagnostics.tracing/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.drawing.common/Directory.Build.props
+++ b/src/referencePackages/src/system.drawing.common/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Drawing.Common</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.formats.asn1/Directory.Build.props
+++ b/src/referencePackages/src/system.formats.asn1/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Formats.Asn1</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.globalization.calendars/Directory.Build.props
+++ b/src/referencePackages/src/system.globalization.calendars/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Globalization.Calendars</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.globalization.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.globalization.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Globalization.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.globalization/Directory.Build.props
+++ b/src/referencePackages/src/system.globalization/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Globalization</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io.compression.zipfile/Directory.Build.props
+++ b/src/referencePackages/src/system.io.compression.zipfile/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io.compression/Directory.Build.props
+++ b/src/referencePackages/src/system.io.compression/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO.Compression</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io.filesystem.accesscontrol/Directory.Build.props
+++ b/src/referencePackages/src/system.io.filesystem.accesscontrol/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO.FileSystem.AccessControl</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io.filesystem.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.io.filesystem.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io.filesystem/Directory.Build.props
+++ b/src/referencePackages/src/system.io.filesystem/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO.FileSystem</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.io/Directory.Build.props
+++ b/src/referencePackages/src/system.io/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.IO</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.linq.expressions/Directory.Build.props
+++ b/src/referencePackages/src/system.linq.expressions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Linq.Expressions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.linq.parallel/Directory.Build.props
+++ b/src/referencePackages/src/system.linq.parallel/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Linq.Parallel</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.linq/Directory.Build.props
+++ b/src/referencePackages/src/system.linq/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Linq</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.memory/Directory.Build.props
+++ b/src/referencePackages/src/system.memory/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Memory</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.net.http/Directory.Build.props
+++ b/src/referencePackages/src/system.net.http/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Net.Http</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.net.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.net.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Net.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.net.sockets/Directory.Build.props
+++ b/src/referencePackages/src/system.net.sockets/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Net.Sockets</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.numerics.vectors/Directory.Build.props
+++ b/src/referencePackages/src/system.numerics.vectors/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Numerics.Vectors</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Emit.ILGeneration</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.emit.lightweight/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.emit.lightweight/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Emit.Lightweight</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.emit/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.emit/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Emit</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.metadata/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.metadata/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Metadata</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection.typeextensions/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection.typeextensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection.TypeExtensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.reflection/Directory.Build.props
+++ b/src/referencePackages/src/system.reflection/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Reflection</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.resources.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.resources.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Resources.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.resources.resourcemanager/Directory.Build.props
+++ b/src/referencePackages/src/system.resources.resourcemanager/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Resources.ResourceManager</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.resources.writer/Directory.Build.props
+++ b/src/referencePackages/src/system.resources.writer/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Resources.Writer</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.handles/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.handles/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Handles</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.interopservices.runtimeinformation/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.InteropServices.RuntimeInformation</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.loader/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.loader/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Loader</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.numerics/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.numerics/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Numerics</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.serialization.formatters/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.serialization.formatters/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Serialization.Formatters</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.runtime.serialization.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime.serialization.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Runtime.Serialization.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.accesscontrol/Directory.Build.props
+++ b/src/referencePackages/src/system.security.accesscontrol/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.AccessControl</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.claims/Directory.Build.props
+++ b/src/referencePackages/src/system.security.claims/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Claims</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.algorithms/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.algorithms/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.csp/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.csp/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.encoding/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.encoding/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.Encoding</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.primitives/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.primitives/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.Primitives</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/Directory.Build.props
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Cryptography.ProtectedData</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.permissions/Directory.Build.props
+++ b/src/referencePackages/src/system.security.permissions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Permissions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.principal.windows/Directory.Build.props
+++ b/src/referencePackages/src/system.security.principal.windows/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Principal.Windows</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.security.principal/Directory.Build.props
+++ b/src/referencePackages/src/system.security.principal/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Security.Principal</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.text.encoding.codepages/Directory.Build.props
+++ b/src/referencePackages/src/system.text.encoding.codepages/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.text.encoding.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.text.encoding.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.text.encoding/Directory.Build.props
+++ b/src/referencePackages/src/system.text.encoding/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Text.Encoding</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.text.encodings.web/Directory.Build.props
+++ b/src/referencePackages/src/system.text.encodings.web/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Text.Encodings.Web</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.text.json/Directory.Build.props
+++ b/src/referencePackages/src/system.text.json/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Text.Json</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/Directory.Build.props
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading.tasks.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.threading.tasks.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading.Tasks.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading.tasks/Directory.Build.props
+++ b/src/referencePackages/src/system.threading.tasks/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading.Tasks</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading.thread/Directory.Build.props
+++ b/src/referencePackages/src/system.threading.thread/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading.Thread</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading.timer/Directory.Build.props
+++ b/src/referencePackages/src/system.threading.timer/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading.Timer</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.threading/Directory.Build.props
+++ b/src/referencePackages/src/system.threading/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Threading</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.windows.extensions/Directory.Build.props
+++ b/src/referencePackages/src/system.windows.extensions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Windows.Extensions</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.xml.readerwriter/Directory.Build.props
+++ b/src/referencePackages/src/system.xml.readerwriter/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.xml.xdocument/Directory.Build.props
+++ b/src/referencePackages/src/system.xml.xdocument/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Xml.XDocument</AssemblyName>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Removed the Directory.Build.props files for projects that have been regenerated since we stopped using Directory.Build.props at the package level.  The props only contain the AssemblyName property which now gets generated into the csproj files.

Related to https://github.com/dotnet/source-build/issues/3459