### PR TITLE
Regenerate reference packages with latest tooling

### DIFF
--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/System.Collections.Concurrent.4.0.12.csproj
@@ -1,35 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.concurrent/4.0.12/system.collections.concurrent.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.concurrent/4.0.12/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.concurrent/4.0.12</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Concurrent</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <PackageReference Include="System.Collections" Version="4.0.11" />
-        <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
-        <PackageReference Include="System.Diagnostics.Tracing" Version="4.1.0" />
-        <PackageReference Include="System.Globalization" Version="4.0.11" />
-        <PackageReference Include="System.Reflection" Version="4.1.0" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-        <PackageReference Include="System.Threading" Version="4.0.11" />
-        <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Collections" Version="4.0.11" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
+    <PackageReference Include="System.Diagnostics.Tracing" Version="4.1.0" />
+    <PackageReference Include="System.Globalization" Version="4.0.11" />
+    <PackageReference Include="System.Reflection" Version="4.1.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Threading" Version="4.0.11" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
+  </ItemGroup>
 
-  
 </Project>

--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/ref/netstandard1.1/System.Collections.Concurrent.cs
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/ref/netstandard1.1/System.Collections.Concurrent.cs
@@ -4,228 +4,376 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Concurrent")]
-[assembly: AssemblyDescription("System.Collections.Concurrent")]
-[assembly: AssemblyDefaultAlias("System.Collections.Concurrent")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.0.30319.17929")]
-[assembly: AssemblyInformationalVersion("4.0.30319.17929 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.0.0")]
-
-
-
-
+[assembly: System.Reflection.AssemblyFileVersion("4.0.30319.17929")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.0.30319.17929")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Concurrent
 {
-    public partial class BlockingCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
+    public partial class BlockingCollection<T> : Generic.IEnumerable<T>, ICollection, IEnumerable, IDisposable
     {
         public BlockingCollection() { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection) { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection) { }
+
         public BlockingCollection(int boundedCapacity) { }
+
         public int BoundedCapacity { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public bool IsAddingCompleted { get { throw null; } }
+
         public bool IsCompleted { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public void Add(T item, Threading.CancellationToken cancellationToken) { }
+
         public void Add(T item) { }
-        public void Add(T item, System.Threading.CancellationToken cancellationToken) { }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
         public void CompleteAdding() { }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable(System.Threading.CancellationToken cancellationToken) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable(Threading.CancellationToken cancellationToken) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T Take() { throw null; }
-        public T Take(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public T Take(Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
+
         public T[] ToArray() { throw null; }
-        public bool TryAdd(T item) { throw null; }
+
+        public bool TryAdd(T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryAdd(T item, int millisecondsTimeout) { throw null; }
-        public bool TryAdd(T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryAdd(T item, System.TimeSpan timeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.TimeSpan timeout) { throw null; }
-        public bool TryTake(out T item) { throw null; }
+
+        public bool TryAdd(T item, TimeSpan timeout) { throw null; }
+
+        public bool TryAdd(T item) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, TimeSpan timeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
+        public bool TryTake(out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryTake(out T item, int millisecondsTimeout) { throw null; }
-        public bool TryTake(out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryTake(out T item, System.TimeSpan timeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item, TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, TimeSpan timeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
     }
-    public partial class ConcurrentBag<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentBag<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentBag() { }
-        public ConcurrentBag(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentBag(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Add(T item) { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryTake(out T result) { throw null; }
     }
-    public partial class ConcurrentDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class ConcurrentDictionary<TKey, TValue> : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public ConcurrentDictionary() { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(int concurrencyLevel, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection) { }
+
+        public ConcurrentDictionary(Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, int capacity, Generic.IEqualityComparer<TKey> comparer) { }
+
         public ConcurrentDictionary(int concurrencyLevel, int capacity) { }
-        public ConcurrentDictionary(int concurrencyLevel, int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
-        public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public Generic.ICollection<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.ICollection<TValue> Values { get { throw null; } }
+
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
-        public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+
+        public Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public System.Collections.Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Contains(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
         public bool TryAdd(TKey key, TValue value) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public bool TryRemove(TKey key, out TValue value) { throw null; }
+
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue) { throw null; }
     }
-    public partial class ConcurrentQueue<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentQueue<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentQueue() { }
-        public ConcurrentQueue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentQueue(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryDequeue(out T result) { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
     }
-    public partial class ConcurrentStack<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentStack<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentStack() { }
-        public ConcurrentStack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentStack(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
         public void Push(T item) { }
-        public void PushRange(T[] items) { }
+
         public void PushRange(T[] items, int startIndex, int count) { }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public void PushRange(T[] items) { }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryPop(out T result) { throw null; }
-        public int TryPopRange(T[] items) { throw null; }
+
         public int TryPopRange(T[] items, int startIndex, int count) { throw null; }
+
+        public int TryPopRange(T[] items) { throw null; }
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum EnumerablePartitionerOptions
     {
-        NoBuffering = 1,
         None = 0,
+        NoBuffering = 1
     }
-    public partial interface IProducerConsumerCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial interface IProducerConsumerCollection<T> : Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         void CopyTo(T[] array, int index);
         T[] ToArray();
         bool TryAdd(T item);
         bool TryTake(out T item);
     }
-    public abstract partial class OrderablePartitioner<TSource> : System.Collections.Concurrent.Partitioner<TSource>
+
+    public abstract partial class OrderablePartitioner<TSource> : Partitioner<TSource>
     {
         protected OrderablePartitioner(bool keysOrderedInEachPartition, bool keysOrderedAcrossPartitions, bool keysNormalized) { }
+
         public bool KeysNormalized { get { throw null; } }
+
         public bool KeysOrderedAcrossPartitions { get { throw null; } }
+
         public bool KeysOrderedInEachPartition { get { throw null; } }
-        public override System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
-        public override System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
+
+        public override Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public virtual Generic.IEnumerable<Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
+        public override Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
     }
+
     public static partial class Partitioner
     {
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Concurrent.EnumerablePartitionerOptions partitionerOptions) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IList<TSource> list, bool loadBalance) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source, EnumerablePartitionerOptions partitionerOptions) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IList<TSource> list, bool loadBalance) { throw null; }
     }
+
     public abstract partial class Partitioner<TSource>
     {
-        protected Partitioner() { }
         public virtual bool SupportsDynamicPartitions { get { throw null; } }
-        public virtual System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
+
+        public virtual Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
     }
 }

--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/ref/netstandard1.3/System.Collections.Concurrent.cs
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/ref/netstandard1.3/System.Collections.Concurrent.cs
@@ -4,230 +4,383 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Concurrent")]
-[assembly: AssemblyDescription("System.Collections.Concurrent")]
-[assembly: AssemblyDefaultAlias("System.Collections.Concurrent")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.10.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.10.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Concurrent
 {
-    public partial class BlockingCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
+    public partial class BlockingCollection<T> : Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, ICollection, IDisposable
     {
         public BlockingCollection() { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection) { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection) { }
+
         public BlockingCollection(int boundedCapacity) { }
+
         public int BoundedCapacity { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public bool IsAddingCompleted { get { throw null; } }
+
         public bool IsCompleted { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public void Add(T item, Threading.CancellationToken cancellationToken) { }
+
         public void Add(T item) { }
-        public void Add(T item, System.Threading.CancellationToken cancellationToken) { }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
         public void CompleteAdding() { }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable(System.Threading.CancellationToken cancellationToken) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable(Threading.CancellationToken cancellationToken) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T Take() { throw null; }
-        public T Take(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public T Take(Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
+
         public T[] ToArray() { throw null; }
-        public bool TryAdd(T item) { throw null; }
+
+        public bool TryAdd(T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryAdd(T item, int millisecondsTimeout) { throw null; }
-        public bool TryAdd(T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryAdd(T item, System.TimeSpan timeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.TimeSpan timeout) { throw null; }
-        public bool TryTake(out T item) { throw null; }
+
+        public bool TryAdd(T item, TimeSpan timeout) { throw null; }
+
+        public bool TryAdd(T item) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, TimeSpan timeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
+        public bool TryTake(out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryTake(out T item, int millisecondsTimeout) { throw null; }
-        public bool TryTake(out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryTake(out T item, System.TimeSpan timeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item, TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, TimeSpan timeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
     }
-    public partial class ConcurrentBag<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentBag<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentBag() { }
-        public ConcurrentBag(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentBag(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Add(T item) { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryTake(out T result) { throw null; }
     }
-    public partial class ConcurrentDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class ConcurrentDictionary<TKey, TValue> : Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public ConcurrentDictionary() { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(int concurrencyLevel, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection) { }
+
+        public ConcurrentDictionary(Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, int capacity, Generic.IEqualityComparer<TKey> comparer) { }
+
         public ConcurrentDictionary(int concurrencyLevel, int capacity) { }
-        public ConcurrentDictionary(int concurrencyLevel, int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
-        public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public Generic.ICollection<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        Generic.IEnumerable<TKey> Generic.IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.IEnumerable<TValue> Generic.IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.ICollection<TValue> Values { get { throw null; } }
+
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
-        public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+
+        public Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public System.Collections.Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Contains(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
         public bool TryAdd(TKey key, TValue value) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public bool TryRemove(TKey key, out TValue value) { throw null; }
+
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue) { throw null; }
     }
-    public partial class ConcurrentQueue<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentQueue<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentQueue() { }
-        public ConcurrentQueue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentQueue(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryDequeue(out T result) { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
     }
-    public partial class ConcurrentStack<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentStack<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentStack() { }
-        public ConcurrentStack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentStack(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
         public void Push(T item) { }
-        public void PushRange(T[] items) { }
+
         public void PushRange(T[] items, int startIndex, int count) { }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public void PushRange(T[] items) { }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryPop(out T result) { throw null; }
-        public int TryPopRange(T[] items) { throw null; }
+
         public int TryPopRange(T[] items, int startIndex, int count) { throw null; }
+
+        public int TryPopRange(T[] items) { throw null; }
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum EnumerablePartitionerOptions
     {
-        NoBuffering = 1,
         None = 0,
+        NoBuffering = 1
     }
-    public partial interface IProducerConsumerCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial interface IProducerConsumerCollection<T> : Generic.IEnumerable<T>, IEnumerable, ICollection
     {
         void CopyTo(T[] array, int index);
         T[] ToArray();
         bool TryAdd(T item);
         bool TryTake(out T item);
     }
-    public abstract partial class OrderablePartitioner<TSource> : System.Collections.Concurrent.Partitioner<TSource>
+
+    public abstract partial class OrderablePartitioner<TSource> : Partitioner<TSource>
     {
         protected OrderablePartitioner(bool keysOrderedInEachPartition, bool keysOrderedAcrossPartitions, bool keysNormalized) { }
+
         public bool KeysNormalized { get { throw null; } }
+
         public bool KeysOrderedAcrossPartitions { get { throw null; } }
+
         public bool KeysOrderedInEachPartition { get { throw null; } }
-        public override System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
-        public override System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
+
+        public override Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public virtual Generic.IEnumerable<Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
+        public override Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
     }
+
     public static partial class Partitioner
     {
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Concurrent.EnumerablePartitionerOptions partitionerOptions) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IList<TSource> list, bool loadBalance) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source, EnumerablePartitionerOptions partitionerOptions) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IList<TSource> list, bool loadBalance) { throw null; }
     }
+
     public abstract partial class Partitioner<TSource>
     {
-        protected Partitioner() { }
         public virtual bool SupportsDynamicPartitions { get { throw null; } }
-        public virtual System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
+
+        public virtual Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
     }
 }

--- a/src/referencePackages/src/system.collections.concurrent/4.0.12/system.collections.concurrent.nuspec
+++ b/src/referencePackages/src/system.collections.concurrent/4.0.12/system.collections.concurrent.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections.Concurrent</id>
@@ -24,19 +24,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETCore5.0">
-        <dependency id="System.Collections" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Diagnostics.Tracing" version="4.1.0" exclude="Compile" />
-        <dependency id="System.Globalization" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" exclude="Compile" />
-        <dependency id="System.Runtime" version="4.1.0" />
-        <dependency id="System.Runtime.Extensions" version="4.1.0" exclude="Compile" />
-        <dependency id="System.Threading" version="4.0.11" exclude="Compile" />
-        <dependency id="System.Threading.Tasks" version="4.0.11" />
-      </group>
       <group targetFramework=".NETStandard1.1">
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
@@ -53,13 +40,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Threading" version="4.0.11" exclude="Compile" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
-      <group targetFramework=".NETPortable0.0-Profile111" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/System.Collections.Concurrent.4.3.0.csproj
@@ -2,25 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.1;netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.concurrent/4.3.0/system.collections.concurrent.nuspec</NuspecFile>
+    <AssemblyName>System.Collections.Concurrent</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.concurrent/4.3.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.concurrent/4.3.0</IntermediateOutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/ref/netstandard1.1/System.Collections.Concurrent.cs
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/ref/netstandard1.1/System.Collections.Concurrent.cs
@@ -4,228 +4,376 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Concurrent")]
-[assembly: AssemblyDescription("System.Collections.Concurrent")]
-[assembly: AssemblyDefaultAlias("System.Collections.Concurrent")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.0.30319.17929")]
-[assembly: AssemblyInformationalVersion("4.0.30319.17929 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.0.0")]
-
-
-
-
+[assembly: System.Reflection.AssemblyFileVersion("4.0.30319.17929")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Concurrent.dll")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.0.30319.17929")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Concurrent
 {
-    public partial class BlockingCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
+    public partial class BlockingCollection<T> : Generic.IEnumerable<T>, ICollection, IEnumerable, IDisposable
     {
         public BlockingCollection() { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection) { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection) { }
+
         public BlockingCollection(int boundedCapacity) { }
+
         public int BoundedCapacity { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public bool IsAddingCompleted { get { throw null; } }
+
         public bool IsCompleted { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public void Add(T item, Threading.CancellationToken cancellationToken) { }
+
         public void Add(T item) { }
-        public void Add(T item, System.Threading.CancellationToken cancellationToken) { }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
         public void CompleteAdding() { }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable(System.Threading.CancellationToken cancellationToken) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable(Threading.CancellationToken cancellationToken) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T Take() { throw null; }
-        public T Take(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public T Take(Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
+
         public T[] ToArray() { throw null; }
-        public bool TryAdd(T item) { throw null; }
+
+        public bool TryAdd(T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryAdd(T item, int millisecondsTimeout) { throw null; }
-        public bool TryAdd(T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryAdd(T item, System.TimeSpan timeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.TimeSpan timeout) { throw null; }
-        public bool TryTake(out T item) { throw null; }
+
+        public bool TryAdd(T item, TimeSpan timeout) { throw null; }
+
+        public bool TryAdd(T item) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, TimeSpan timeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
+        public bool TryTake(out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryTake(out T item, int millisecondsTimeout) { throw null; }
-        public bool TryTake(out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryTake(out T item, System.TimeSpan timeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item, TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, TimeSpan timeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
     }
-    public partial class ConcurrentBag<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentBag<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentBag() { }
-        public ConcurrentBag(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentBag(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Add(T item) { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryTake(out T result) { throw null; }
     }
-    public partial class ConcurrentDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class ConcurrentDictionary<TKey, TValue> : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public ConcurrentDictionary() { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(int concurrencyLevel, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection) { }
+
+        public ConcurrentDictionary(Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, int capacity, Generic.IEqualityComparer<TKey> comparer) { }
+
         public ConcurrentDictionary(int concurrencyLevel, int capacity) { }
-        public ConcurrentDictionary(int concurrencyLevel, int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
-        public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public Generic.ICollection<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.ICollection<TValue> Values { get { throw null; } }
+
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
-        public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+
+        public Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public System.Collections.Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Contains(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
         public bool TryAdd(TKey key, TValue value) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public bool TryRemove(TKey key, out TValue value) { throw null; }
+
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue) { throw null; }
     }
-    public partial class ConcurrentQueue<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentQueue<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentQueue() { }
-        public ConcurrentQueue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentQueue(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryDequeue(out T result) { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
     }
-    public partial class ConcurrentStack<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentStack<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         public ConcurrentStack() { }
-        public ConcurrentStack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentStack(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
         public void Push(T item) { }
-        public void PushRange(T[] items) { }
+
         public void PushRange(T[] items, int startIndex, int count) { }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public void PushRange(T[] items) { }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryPop(out T result) { throw null; }
-        public int TryPopRange(T[] items) { throw null; }
+
         public int TryPopRange(T[] items, int startIndex, int count) { throw null; }
+
+        public int TryPopRange(T[] items) { throw null; }
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum EnumerablePartitionerOptions
     {
-        NoBuffering = 1,
         None = 0,
+        NoBuffering = 1
     }
-    public partial interface IProducerConsumerCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial interface IProducerConsumerCollection<T> : Generic.IEnumerable<T>, ICollection, IEnumerable
     {
         void CopyTo(T[] array, int index);
         T[] ToArray();
         bool TryAdd(T item);
         bool TryTake(out T item);
     }
-    public abstract partial class OrderablePartitioner<TSource> : System.Collections.Concurrent.Partitioner<TSource>
+
+    public abstract partial class OrderablePartitioner<TSource> : Partitioner<TSource>
     {
         protected OrderablePartitioner(bool keysOrderedInEachPartition, bool keysOrderedAcrossPartitions, bool keysNormalized) { }
+
         public bool KeysNormalized { get { throw null; } }
+
         public bool KeysOrderedAcrossPartitions { get { throw null; } }
+
         public bool KeysOrderedInEachPartition { get { throw null; } }
-        public override System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
-        public override System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
+
+        public override Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public virtual Generic.IEnumerable<Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
+        public override Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
     }
+
     public static partial class Partitioner
     {
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Concurrent.EnumerablePartitionerOptions partitionerOptions) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IList<TSource> list, bool loadBalance) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source, EnumerablePartitionerOptions partitionerOptions) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IList<TSource> list, bool loadBalance) { throw null; }
     }
+
     public abstract partial class Partitioner<TSource>
     {
-        protected Partitioner() { }
         public virtual bool SupportsDynamicPartitions { get { throw null; } }
-        public virtual System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
+
+        public virtual Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
     }
 }

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/ref/netstandard1.3/System.Collections.Concurrent.cs
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/ref/netstandard1.3/System.Collections.Concurrent.cs
@@ -4,230 +4,383 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Concurrent")]
-[assembly: AssemblyDescription("System.Collections.Concurrent")]
-[assembly: AssemblyDefaultAlias("System.Collections.Concurrent")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.10.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Concurrent")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.10.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Concurrent
 {
-    public partial class BlockingCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.IDisposable
+    public partial class BlockingCollection<T> : Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, ICollection, IDisposable
     {
         public BlockingCollection() { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection) { }
-        public BlockingCollection(System.Collections.Concurrent.IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection, int boundedCapacity) { }
+
+        public BlockingCollection(IProducerConsumerCollection<T> collection) { }
+
         public BlockingCollection(int boundedCapacity) { }
+
         public int BoundedCapacity { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public bool IsAddingCompleted { get { throw null; } }
+
         public bool IsCompleted { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public void Add(T item, Threading.CancellationToken cancellationToken) { }
+
         public void Add(T item) { }
-        public void Add(T item, System.Threading.CancellationToken cancellationToken) { }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int AddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int AddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
         public void CompleteAdding() { }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Dispose() { }
+
         protected virtual void Dispose(bool disposing) { }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
-        public System.Collections.Generic.IEnumerable<T> GetConsumingEnumerable(System.Threading.CancellationToken cancellationToken) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable() { throw null; }
+
+        public Generic.IEnumerable<T> GetConsumingEnumerable(Threading.CancellationToken cancellationToken) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T Take() { throw null; }
-        public T Take(System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public T Take(Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
+
         public T[] ToArray() { throw null; }
-        public bool TryAdd(T item) { throw null; }
+
+        public bool TryAdd(T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryAdd(T item, int millisecondsTimeout) { throw null; }
-        public bool TryAdd(T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryAdd(T item, System.TimeSpan timeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryAddToAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, T item, System.TimeSpan timeout) { throw null; }
-        public bool TryTake(out T item) { throw null; }
+
+        public bool TryAdd(T item, TimeSpan timeout) { throw null; }
+
+        public bool TryAdd(T item) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item, TimeSpan timeout) { throw null; }
+
+        public static int TryAddToAny(BlockingCollection<T>[] collections, T item) { throw null; }
+
+        public bool TryTake(out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
         public bool TryTake(out T item, int millisecondsTimeout) { throw null; }
-        public bool TryTake(out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public bool TryTake(out T item, System.TimeSpan timeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, System.Threading.CancellationToken cancellationToken) { throw null; }
-        public static int TryTakeFromAny(System.Collections.Concurrent.BlockingCollection<T>[] collections, out T item, System.TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item, TimeSpan timeout) { throw null; }
+
+        public bool TryTake(out T item) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, int millisecondsTimeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item, TimeSpan timeout) { throw null; }
+
+        public static int TryTakeFromAny(BlockingCollection<T>[] collections, out T item) { throw null; }
     }
-    public partial class ConcurrentBag<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentBag<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentBag() { }
-        public ConcurrentBag(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentBag(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Add(T item) { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryTake(out T result) { throw null; }
     }
-    public partial class ConcurrentDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class ConcurrentDictionary<TKey, TValue> : Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public ConcurrentDictionary() { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public ConcurrentDictionary(int concurrencyLevel, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> collection, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection) { }
+
+        public ConcurrentDictionary(Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> collection, Generic.IEqualityComparer<TKey> comparer) { }
+
+        public ConcurrentDictionary(int concurrencyLevel, int capacity, Generic.IEqualityComparer<TKey> comparer) { }
+
         public ConcurrentDictionary(int concurrencyLevel, int capacity) { }
-        public ConcurrentDictionary(int concurrencyLevel, int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.ICollection<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.ICollection<TValue> Values { get { throw null; } }
-        public TValue AddOrUpdate(TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public TValue AddOrUpdate(TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public Generic.ICollection<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        Generic.IEnumerable<TKey> Generic.IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.IEnumerable<TValue> Generic.IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.ICollection<TValue> Values { get { throw null; } }
+
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
-        public TValue GetOrAdd(TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
+
+        public Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public TValue GetOrAdd(TKey key, TValue value) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public System.Collections.Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Contains(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.KeyValuePair<TKey, TValue>[] ToArray() { throw null; }
+
         public bool TryAdd(TKey key, TValue value) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public bool TryRemove(TKey key, out TValue value) { throw null; }
+
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue) { throw null; }
     }
-    public partial class ConcurrentQueue<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentQueue<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentQueue() { }
-        public ConcurrentQueue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentQueue(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void CopyTo(T[] array, int index) { }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryDequeue(out T result) { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
     }
-    public partial class ConcurrentStack<T> : System.Collections.Concurrent.IProducerConsumerCollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class ConcurrentStack<T> : IProducerConsumerCollection<T>, Generic.IEnumerable<T>, IEnumerable, ICollection, Generic.IReadOnlyCollection<T>
     {
         public ConcurrentStack() { }
-        public ConcurrentStack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public ConcurrentStack(Generic.IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
         public void Push(T item) { }
-        public void PushRange(T[] items) { }
+
         public void PushRange(T[] items, int startIndex, int count) { }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
-        bool System.Collections.Concurrent.IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public void PushRange(T[] items) { }
+
+        bool IProducerConsumerCollection<T>.TryAdd(T item) { throw null; }
+
+        bool IProducerConsumerCollection<T>.TryTake(out T item) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public bool TryPeek(out T result) { throw null; }
+
         public bool TryPop(out T result) { throw null; }
-        public int TryPopRange(T[] items) { throw null; }
+
         public int TryPopRange(T[] items, int startIndex, int count) { throw null; }
+
+        public int TryPopRange(T[] items) { throw null; }
     }
-    [System.FlagsAttribute]
+
+    [Flags]
     public enum EnumerablePartitionerOptions
     {
-        NoBuffering = 1,
         None = 0,
+        NoBuffering = 1
     }
-    public partial interface IProducerConsumerCollection<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial interface IProducerConsumerCollection<T> : Generic.IEnumerable<T>, IEnumerable, ICollection
     {
         void CopyTo(T[] array, int index);
         T[] ToArray();
         bool TryAdd(T item);
         bool TryTake(out T item);
     }
-    public abstract partial class OrderablePartitioner<TSource> : System.Collections.Concurrent.Partitioner<TSource>
+
+    public abstract partial class OrderablePartitioner<TSource> : Partitioner<TSource>
     {
         protected OrderablePartitioner(bool keysOrderedInEachPartition, bool keysOrderedAcrossPartitions, bool keysNormalized) { }
+
         public bool KeysNormalized { get { throw null; } }
+
         public bool KeysOrderedAcrossPartitions { get { throw null; } }
+
         public bool KeysOrderedInEachPartition { get { throw null; } }
-        public override System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
-        public override System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
+
+        public override Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public virtual Generic.IEnumerable<Generic.KeyValuePair<long, TSource>> GetOrderableDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<Generic.KeyValuePair<long, TSource>>> GetOrderablePartitions(int partitionCount);
+        public override Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount) { throw null; }
     }
+
     public static partial class Partitioner
     {
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<System.Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Concurrent.EnumerablePartitionerOptions partitionerOptions) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(System.Collections.Generic.IList<TSource> list, bool loadBalance) { throw null; }
-        public static System.Collections.Concurrent.OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize) { throw null; }
+
+        public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(TSource[] array, bool loadBalance) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source, EnumerablePartitionerOptions partitionerOptions) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static OrderablePartitioner<TSource> Create<TSource>(Generic.IList<TSource> list, bool loadBalance) { throw null; }
     }
+
     public abstract partial class Partitioner<TSource>
     {
-        protected Partitioner() { }
         public virtual bool SupportsDynamicPartitions { get { throw null; } }
-        public virtual System.Collections.Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
-        public abstract System.Collections.Generic.IList<System.Collections.Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
+
+        public virtual Generic.IEnumerable<TSource> GetDynamicPartitions() { throw null; }
+
+        public abstract Generic.IList<Generic.IEnumerator<TSource>> GetPartitions(int partitionCount);
     }
 }

--- a/src/referencePackages/src/system.collections.concurrent/4.3.0/system.collections.concurrent.nuspec
+++ b/src/referencePackages/src/system.collections.concurrent/4.3.0/system.collections.concurrent.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections.Concurrent</id>
@@ -24,19 +24,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETCore5.0">
-        <dependency id="System.Collections" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Diagnostics.Debug" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Diagnostics.Tracing" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Globalization" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Resources.ResourceManager" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Runtime" version="4.3.0" />
-        <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
-        <dependency id="System.Threading.Tasks" version="4.3.0" />
-      </group>
       <group targetFramework=".NETStandard1.1">
         <dependency id="System.Runtime" version="4.3.0" />
         <dependency id="System.Threading.Tasks" version="4.3.0" />
@@ -53,13 +40,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
         <dependency id="System.Threading.Tasks" version="4.3.0" />
       </group>
-      <group targetFramework=".NETPortable0.0-Profile111" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.concurrent/Directory.Build.props
+++ b/src/referencePackages/src/system.collections.concurrent/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Collections.Concurrent</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.2.0/System.Collections.Immutable.1.2.0.csproj
@@ -1,32 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.2.0/system.collections.immutable.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.2.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.immutable/1.2.0</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Immutable</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.2.0/lib/</OutputPath>
-    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.Collections" Version="4.0.11" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
+    <PackageReference Include="System.Globalization" Version="4.0.11" />
+    <PackageReference Include="System.Linq" Version="4.1.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
+    <PackageReference Include="System.Threading" Version="4.0.11" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="System.Collections" Version="4.0.11" />
-        <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
-        <PackageReference Include="System.Globalization" Version="4.0.11" />
-        <PackageReference Include="System.Linq" Version="4.1.0" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-        <PackageReference Include="System.Threading" Version="4.0.11" />
-    </ItemGroup>
-
-  
 </Project>

--- a/src/referencePackages/src/system.collections.immutable/1.2.0/lib/netstandard1.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.2.0/lib/netstandard1.0/System.Collections.Immutable.cs
@@ -4,1072 +4,1946 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.0.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Security.SecurityTransparent]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IImmutableList<T>, IList, ICollection, IStructuralComparable, IStructuralEquatable
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.2.0/system.collections.immutable.nuspec
+++ b/src/referencePackages/src/system.collections.immutable/1.2.0/system.collections.immutable.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8.6">
     <id>System.Collections.Immutable</id>
@@ -33,8 +33,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
       <group targetFramework=".NETStandard1.0">
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
@@ -45,13 +43,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
       </group>
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.0/System.Collections.Immutable.1.3.0.csproj
@@ -1,32 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.0/system.collections.immutable.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.3.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.immutable/1.3.0</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Immutable</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.3.0/lib/</OutputPath>
-    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="System.Collections" Version="4.3.0" />
-        <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-        <PackageReference Include="System.Globalization" Version="4.3.0" />
-        <PackageReference Include="System.Linq" Version="4.3.0" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-        <PackageReference Include="System.Runtime" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Threading" Version="4.3.0" />
-    </ItemGroup>
-
-  
 </Project>

--- a/src/referencePackages/src/system.collections.immutable/1.3.0/lib/netstandard1.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.3.0/lib/netstandard1.0/System.Collections.Immutable.cs
@@ -4,1072 +4,1946 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.6.24705.01")]
-[assembly: AssemblyInformationalVersion("4.6.24705.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.1.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Security.SecurityTransparent]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.6.24705.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.24705.01. Commit Hash: 4d1af962ca0fede10beb01d197367c2f90e92c97")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.1.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IImmutableList<T>, IList, ICollection, IStructuralComparable, IStructuralEquatable
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.3.0/system.collections.immutable.nuspec
+++ b/src/referencePackages/src/system.collections.immutable/1.3.0/system.collections.immutable.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8.6">
     <id>System.Collections.Immutable</id>
@@ -33,8 +33,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
       <group targetFramework=".NETStandard1.0">
         <dependency id="System.Collections" version="4.3.0" />
         <dependency id="System.Diagnostics.Debug" version="4.3.0" />
@@ -45,13 +43,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
         <dependency id="System.Runtime.Extensions" version="4.3.0" />
         <dependency id="System.Threading" version="4.3.0" />
       </group>
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.3.1/System.Collections.Immutable.1.3.1.csproj
@@ -1,32 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.3.1/system.collections.immutable.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.3.1/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.immutable/1.3.1</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Immutable</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.3.1/lib/</OutputPath>
-    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="System.Collections" Version="4.3.0" />
-        <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-        <PackageReference Include="System.Globalization" Version="4.3.0" />
-        <PackageReference Include="System.Linq" Version="4.3.0" />
-        <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-        <PackageReference Include="System.Runtime" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Threading" Version="4.3.0" />
-    </ItemGroup>
-
-  
 </Project>

--- a/src/referencePackages/src/system.collections.immutable/1.3.1/lib/netstandard1.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.3.1/lib/netstandard1.0/System.Collections.Immutable.cs
@@ -4,1072 +4,1946 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.6.24816.01")]
-[assembly: AssemblyInformationalVersion("4.6.24816.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.1.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Security.SecurityTransparent]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.6.24816.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.24816.01. Commit Hash: 4d1af962ca0fede10beb01d197367c2f90e92c97")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.1.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IImmutableList<T>, IList, ICollection, IStructuralComparable, IStructuralEquatable
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.3.1/system.collections.immutable.nuspec
+++ b/src/referencePackages/src/system.collections.immutable/1.3.1/system.collections.immutable.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8.6">
     <id>System.Collections.Immutable</id>
@@ -33,8 +33,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
       <group targetFramework=".NETStandard1.0">
         <dependency id="System.Collections" version="4.3.0" />
         <dependency id="System.Diagnostics.Debug" version="4.3.0" />
@@ -45,13 +43,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
         <dependency id="System.Runtime.Extensions" version="4.3.0" />
         <dependency id="System.Threading" version="4.3.0" />
       </group>
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/System.Collections.Immutable.1.5.0.csproj
@@ -1,38 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/1.5.0/system.collections.immutable.nuspec</NuspecFile>
-    <LangVersion>7.2</LangVersion>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.5.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.immutable/1.5.0</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Immutable</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.5.0/lib/</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.5.0/lib/</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <OutputPath>$(ArtifactsBinDir)system.collections.immutable/1.5.0/lib/</OutputPath>
-    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
-    </ItemGroup>
-
-  
 </Project>

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard1.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard1.0/System.Collections.Immutable.cs
@@ -4,1072 +4,1946 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.6.26515.06")]
-[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.3.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.6.26515.06")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.26515.06 @BuiltBy: dlab-DDVSOWINAGE059 @Branch: release/2.1 @SrcCode: https://github.com/dotnet/corefx/tree/30ab651fcb4354552bd4891619a0bdd81e0ebdbf")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.3.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard1.3/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard1.3/System.Collections.Immutable.cs
@@ -4,1082 +4,1967 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.6.26515.06")]
-[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.3.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.6.26515.06")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.26515.06 @BuiltBy: dlab-DDVSOWINAGE059 @Branch: release/2.1 @SrcCode: https://github.com/dotnet/corefx/tree/30ab651fcb4354552bd4891619a0bdd81e0ebdbf")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.3.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public ref readonly TValue ValueRef(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
             public ref readonly TValue ValueRef(TKey key) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard2.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/lib/netstandard2.0/System.Collections.Immutable.cs
@@ -4,1082 +4,1966 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.6.26515.06")]
-[assembly: AssemblyInformationalVersion("4.6.26515.06 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("1.2.3.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.6.26515.06")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.26515.06 @BuiltBy: dlab-DDVSOWINAGE059 @Branch: release/2.1 @SrcCode: https://github.com/dotnet/corefx/tree/30ab651fcb4354552bd4891619a0bdd81e0ebdbf")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.2.3.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T> comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
         public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Nullable<System.Collections.Immutable.ImmutableArray<T>> left, System.Nullable<System.Collections.Immutable.ImmutableArray<T>> right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T> equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T> comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T> comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T> comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T> comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T> comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T> comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public ref readonly TValue ValueRef(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer, Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey> keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
             public ref readonly TValue ValueRef(TKey key) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T> comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T> comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource> comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T> comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
             public T Max { get { throw null; } }
+
             public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase> comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/1.5.0/system.collections.immutable.nuspec
+++ b/src/referencePackages/src/system.collections.immutable/1.5.0/system.collections.immutable.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8.6">
     <id>System.Collections.Immutable</id>
@@ -42,10 +42,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
       <group targetFramework=".NETStandard2.0" />
-      <group targetFramework=".NETPortable4.5-Profile259" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
@@ -2,42 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.immutable/5.0.0/system.collections.immutable.nuspec</NuspecFile>
+    <AssemblyName>System.Collections.Immutable</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/5.0.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.immutable/5.0.0</IntermediateOutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/5.0.0/lib/</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/5.0.0/lib/</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <OutputPath>$(ArtifactsBinDir)system.collections.immutable/5.0.0/lib/</OutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="NETStandard.Library" Version="$(NETStandardImplicitPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard1.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard1.0/System.Collections.Immutable.cs
@@ -4,1082 +4,1968 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("5.0.20.51904")]
-[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("5.0.0.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.0", FrameworkDisplayName = "")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyFileVersion("5.0.20.51904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("5.0.0+cf258a14b70ad9069470a108f13765e0e5988f51")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "git://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("5.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Immutable.ImmutableArray<TSource>.Builder builder) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[]? items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this ImmutableArray<TSource>.Builder builder) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Immutable.ImmutableHashSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T>? equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this ImmutableHashSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, System.Collections.Immutable.ImmutableArray<T>> transformer) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, TArg, System.Collections.Immutable.ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, ImmutableArray<T>> transformer) { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, TArg, ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Immutable.ImmutableList<TSource>.Builder builder) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this ImmutableList<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T? Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T? FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object? IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T? Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T? FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Immutable.ImmutableSortedSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T>? comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this ImmutableSortedSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
-        public T Max { get { throw null; } }
-        public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public T? Max { get { throw null; } }
+
+        public T? Min { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T>? comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
-            public T Max { get { throw null; } }
-            public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public T? Max { get { throw null; } }
+
+            public T? Min { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T? Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T? ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard1.3/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard1.3/System.Collections.Immutable.cs
@@ -4,1094 +4,1992 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("5.0.20.51904")]
-[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("5.0.0.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.3", FrameworkDisplayName = "")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyFileVersion("5.0.20.51904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("5.0.0+cf258a14b70ad9069470a108f13765e0e5988f51")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "git://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("5.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Immutable.ImmutableArray<TSource>.Builder builder) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[]? items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this ImmutableArray<TSource>.Builder builder) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.ReadOnlyMemory<T> AsMemory() { throw null; }
-        public System.ReadOnlySpan<T> AsSpan() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ReadOnlyMemory<T> AsMemory() { throw null; }
+
+        public ReadOnlySpan<T> AsSpan() { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Immutable.ImmutableHashSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T>? equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this ImmutableHashSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, System.Collections.Immutable.ImmutableArray<T>> transformer) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, TArg, System.Collections.Immutable.ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, ImmutableArray<T>> transformer) { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, TArg, ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Immutable.ImmutableList<TSource>.Builder builder) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this ImmutableList<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T? Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T? FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object? IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T? Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T? FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public ref readonly TValue ValueRef(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
             public ref readonly TValue ValueRef(TKey key) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Immutable.ImmutableSortedSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T>? comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this ImmutableSortedSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
-        public T Max { get { throw null; } }
-        public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public T? Max { get { throw null; } }
+
+        public T? Min { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T>? comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
-            public T Max { get { throw null; } }
-            public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public T? Max { get { throw null; } }
+
+            public T? Min { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T? Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T? ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard2.0/System.Collections.Immutable.cs
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/lib/netstandard2.0/System.Collections.Immutable.cs
@@ -4,1094 +4,1992 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Immutable")]
-[assembly: AssemblyDescription("System.Collections.Immutable")]
-[assembly: AssemblyDefaultAlias("System.Collections.Immutable")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("5.0.20.51904")]
-[assembly: AssemblyInformationalVersion("5.0.20.51904 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("5.0.0.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.Collections.Immutable.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Immutable")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyFileVersion("5.0.20.51904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("5.0.0+cf258a14b70ad9069470a108f13765e0e5988f51")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Immutable")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "git://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("5.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Immutable
 {
-    public partial interface IImmutableDictionary<TKey, TValue> : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.IEnumerable
+    public partial interface IImmutableDictionary<TKey, TValue> : Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>
     {
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Clear();
-        bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> Remove(TKey key);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items);
+        IImmutableDictionary<TKey, TValue> Add(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs);
+        IImmutableDictionary<TKey, TValue> Clear();
+        bool Contains(Generic.KeyValuePair<TKey, TValue> pair);
+        IImmutableDictionary<TKey, TValue> Remove(TKey key);
+        IImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys);
+        IImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value);
+        IImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items);
         bool TryGetKey(TKey equalKey, out TKey actualKey);
     }
-    public partial interface IImmutableList<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableList<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>
     {
-        System.Collections.Immutable.IImmutableList<T> Add(T value);
-        System.Collections.Immutable.IImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items);
-        System.Collections.Immutable.IImmutableList<T> Clear();
-        int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Insert(int index, T element);
-        System.Collections.Immutable.IImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items);
-        int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveAll(System.Predicate<T> match);
-        System.Collections.Immutable.IImmutableList<T> RemoveAt(int index);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> RemoveRange(int index, int count);
-        System.Collections.Immutable.IImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer);
-        System.Collections.Immutable.IImmutableList<T> SetItem(int index, T value);
+        IImmutableList<T> Add(T value);
+        IImmutableList<T> AddRange(Generic.IEnumerable<T> items);
+        IImmutableList<T> Clear();
+        int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Insert(int index, T element);
+        IImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items);
+        int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveAll(Predicate<T> match);
+        IImmutableList<T> RemoveAt(int index);
+        IImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> RemoveRange(int index, int count);
+        IImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer);
+        IImmutableList<T> SetItem(int index, T value);
     }
-    public partial interface IImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableQueue<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableQueue<T> Clear();
-        System.Collections.Immutable.IImmutableQueue<T> Dequeue();
-        System.Collections.Immutable.IImmutableQueue<T> Enqueue(T value);
+
+        IImmutableQueue<T> Clear();
+        IImmutableQueue<T> Dequeue();
+        IImmutableQueue<T> Enqueue(T value);
         T Peek();
     }
-    public partial interface IImmutableSet<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableSet<T> : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable
     {
-        System.Collections.Immutable.IImmutableSet<T> Add(T value);
-        System.Collections.Immutable.IImmutableSet<T> Clear();
+        IImmutableSet<T> Add(T value);
+        IImmutableSet<T> Clear();
         bool Contains(T value);
-        System.Collections.Immutable.IImmutableSet<T> Except(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other);
-        bool Overlaps(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> Remove(T value);
-        bool SetEquals(System.Collections.Generic.IEnumerable<T> other);
-        System.Collections.Immutable.IImmutableSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Except(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Intersect(Generic.IEnumerable<T> other);
+        bool IsProperSubsetOf(Generic.IEnumerable<T> other);
+        bool IsProperSupersetOf(Generic.IEnumerable<T> other);
+        bool IsSubsetOf(Generic.IEnumerable<T> other);
+        bool IsSupersetOf(Generic.IEnumerable<T> other);
+        bool Overlaps(Generic.IEnumerable<T> other);
+        IImmutableSet<T> Remove(T value);
+        bool SetEquals(Generic.IEnumerable<T> other);
+        IImmutableSet<T> SymmetricExcept(Generic.IEnumerable<T> other);
         bool TryGetValue(T equalValue, out T actualValue);
-        System.Collections.Immutable.IImmutableSet<T> Union(System.Collections.Generic.IEnumerable<T> other);
+        IImmutableSet<T> Union(Generic.IEnumerable<T> other);
     }
-    public partial interface IImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+
+    public partial interface IImmutableStack<T> : Generic.IEnumerable<T>, IEnumerable
     {
         bool IsEmpty { get; }
-        System.Collections.Immutable.IImmutableStack<T> Clear();
+
+        IImmutableStack<T> Clear();
         T Peek();
-        System.Collections.Immutable.IImmutableStack<T> Pop();
-        System.Collections.Immutable.IImmutableStack<T> Push(T value);
+        IImmutableStack<T> Pop();
+        IImmutableStack<T> Push(T value);
     }
+
     public static partial class ImmutableArray
     {
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, int index, int length, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value) { throw null; }
-        public static int BinarySearch<T>(this System.Collections.Immutable.ImmutableArray<T> array, T value, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TResult> selector) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(System.Collections.Immutable.ImmutableArray<TSource> items, int start, int length, System.Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(System.Collections.Immutable.ImmutableArray<T> items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Generic.IEnumerable<TSource> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<TSource> ToImmutableArray<TSource>(this System.Collections.Immutable.ImmutableArray<TSource>.Builder builder) { throw null; }
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, T value) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value, Generic.IComparer<T>? comparer) { throw null; }
+
+        public static int BinarySearch<T>(this ImmutableArray<T> array, int index, int length, T value) { throw null; }
+
+        public static ImmutableArray<T> Create<T>() { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3, T item4) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2, T item3) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item1, T item2) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(T[] items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(params T[]? items) { throw null; }
+
+        public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length) { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableArray<T>.Builder CreateBuilder<T>(int initialCapacity) { throw null; }
+
+        public static ImmutableArray<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TResult> selector) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, int start, int length, Func<TSource, TArg, TResult> selector, TArg arg) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this Generic.IEnumerable<TSource> items) { throw null; }
+
+        public static ImmutableArray<TSource> ToImmutableArray<TSource>(this ImmutableArray<TSource>.Builder builder) { throw null; }
     }
-    public partial struct ImmutableArray<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>, System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IEquatable<System.Collections.Immutable.ImmutableArray<T>>
+
+    public partial struct ImmutableArray<T> : Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IEquatable<ImmutableArray<T>>, IList, ICollection, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
-        internal T[] array;
         private object _dummy;
-        public static readonly System.Collections.Immutable.ImmutableArray<T> Empty;
+        private int _dummyPrimitive;
+        public static readonly ImmutableArray<T> Empty;
         public bool IsDefault { get { throw null; } }
+
         public bool IsDefaultOrEmpty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
+
         public int Length { get { throw null; } }
-        int System.Collections.Generic.ICollection<T>.Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        int System.Collections.Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
-        T System.Collections.Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableArray<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> AddRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.ReadOnlyMemory<T> AsMemory() { throw null; }
-        public System.ReadOnlySpan<T> AsSpan() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> As<TOther>() where TOther : class { throw null; }
-        public System.Collections.Immutable.ImmutableArray<TOther> CastArray<TOther>() where TOther : class { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> CastUp<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : class, T { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Clear() { throw null; }
+
+        int Generic.ICollection<T>.Count { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        int Generic.IReadOnlyCollection<T>.Count { get { throw null; } }
+
+        T Generic.IReadOnlyList<T>.this[int index] { get { throw null; } }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableArray<T> Add(T item) { throw null; }
+
+        public ImmutableArray<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> AddRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<TOther> As<TOther>()
+            where TOther : class { throw null; }
+
+        public ReadOnlyMemory<T> AsMemory() { throw null; }
+
+        public ReadOnlySpan<T> AsSpan() { throw null; }
+
+        public ImmutableArray<TOther> CastArray<TOther>()
+            where TOther : class { throw null; }
+
+        public static ImmutableArray<T> CastUp<TDerived>(ImmutableArray<TDerived> items)
+            where TDerived : class, T { throw null; }
+
+        public ImmutableArray<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
-        public void CopyTo(T[] destination) { }
+
         public void CopyTo(T[] destination, int destinationIndex) { }
-        public bool Equals(System.Collections.Immutable.ImmutableArray<T> other) { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(T[] destination) { }
+
+        public void CopyTo(int sourceIndex, T[] destination, int destinationIndex, int length) { }
+
+        public bool Equals(ImmutableArray<T> other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public ImmutableArray<T>.Enumerator GetEnumerator() { throw null; }
+
         public override int GetHashCode() { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int startIndex) { throw null; }
-        public int IndexOf(T item, int startIndex, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T item, int startIndex, int count) { throw null; }
-        public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> InsertRange(int index, System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
+
+        public int IndexOf(T item, int startIndex) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
+        public ImmutableArray<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> InsertRange(int index, ImmutableArray<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-        public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator ==(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T> left, System.Collections.Immutable.ImmutableArray<T> right) { throw null; }
-        public static bool operator !=(System.Collections.Immutable.ImmutableArray<T>? left, System.Collections.Immutable.ImmutableArray<T>? right) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Remove(T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(System.Collections.Immutable.ImmutableArray<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> SetItem(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T element) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        int System.Collections.IStructuralComparable.CompareTo(object other, System.Collections.IComparer comparer) { throw null; }
-        bool System.Collections.IStructuralEquatable.Equals(object other, System.Collections.IEqualityComparer comparer) { throw null; }
-        int System.Collections.IStructuralEquatable.GetHashCode(System.Collections.IEqualityComparer comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableArray<T>.Builder ToBuilder() { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+
+        public int LastIndexOf(T item, int startIndex) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
+        public Generic.IEnumerable<TResult> OfType<TResult>() { throw null; }
+
+        public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator ==(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right) { throw null; }
+
+        public static bool operator !=(ImmutableArray<T>? left, ImmutableArray<T>? right) { throw null; }
+
+        public ImmutableArray<T> Remove(T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Remove(T item) { throw null; }
+
+        public ImmutableArray<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableArray<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(ImmutableArray<T> items) { throw null; }
+
+        public ImmutableArray<T> RemoveRange(int index, int length) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableArray<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableArray<T> SetItem(int index, T item) { throw null; }
+
+        public ImmutableArray<T> Sort() { throw null; }
+
+        public ImmutableArray<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableArray<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableArray<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T element) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        int IStructuralComparable.CompareTo(object other, IComparer comparer) { throw null; }
+
+        bool IStructuralEquatable.Equals(object other, IEqualityComparer comparer) { throw null; }
+
+        int IStructuralEquatable.GetHashCode(IEqualityComparer comparer) { throw null; }
+
+        public ImmutableArray<T>.Builder ToBuilder() { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Capacity { get { throw null; } set { } }
+
             public int Count { get { throw null; } set { } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T> items, int length) { }
-            public void AddRange(System.Collections.Immutable.ImmutableArray<T>.Builder items) { }
-            public void AddRange(params T[] items) { }
+
             public void AddRange(T[] items, int length) { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived> items) where TDerived : T { }
-            public void AddRange<TDerived>(System.Collections.Immutable.ImmutableArray<TDerived>.Builder items) where TDerived : T { }
-            public void AddRange<TDerived>(TDerived[] items) where TDerived : T { }
+
+            public void AddRange(params T[] items) { }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public void AddRange(ImmutableArray<T> items, int length) { }
+
+            public void AddRange(ImmutableArray<T>.Builder items) { }
+
+            public void AddRange(ImmutableArray<T> items) { }
+
+            public void AddRange<TDerived>(TDerived[] items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items)
+                where TDerived : T { }
+
+            public void AddRange<TDerived>(ImmutableArray<TDerived> items)
+                where TDerived : T { }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
+
             public void CopyTo(T[] array, int index) { }
-            public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+            public int IndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int startIndex, int count) { throw null; }
-            public int IndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int startIndex) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> MoveToImmutable() { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
+            public ImmutableArray<T> MoveToImmutable() { throw null; }
+
             public bool Remove(T element) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
             public T[] ToArray() { throw null; }
-            public System.Collections.Immutable.ImmutableArray<T> ToImmutable() { throw null; }
+
+            public ImmutableArray<T> ToImmutable() { throw null; }
         }
+
         public partial struct Enumerator
         {
-            private readonly T[] _array;
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableDictionary
     {
-        public static bool Contains<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
-        public static TValue GetValueOrDefault<TKey, TValue>(this System.Collections.Immutable.IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) { throw null; }
+
+        public static TValue? GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TSource> ToImmutableDictionary<TSource, TKey>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this ImmutableDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> Remove(TKey key) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IEqualityComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableDictionary<TKey, TValue> WithComparers(Generic.IEqualityComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IEqualityComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableHashSet
     {
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> CreateRange<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(System.Collections.Generic.IEqualityComparer<T> equalityComparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IEqualityComparer<TSource> equalityComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this System.Collections.Immutable.ImmutableHashSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableHashSet<T> Create<T>() { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, T item) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer, params T[] items) { throw null; }
+
+        public static ImmutableHashSet<T> Create<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableHashSet<T>.Builder CreateBuilder<T>(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<T> CreateRange<T>(Generic.IEqualityComparer<T>? equalityComparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IEqualityComparer<TSource>? equalityComparer) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableHashSet<TSource> ToImmutableHashSet<TSource>(this ImmutableHashSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableHashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableHashSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ICollection<T>, Generic.ISet<T>, ICollection
     {
         internal ImmutableHashSet() { }
-        public static readonly System.Collections.Immutable.ImmutableHashSet<T> Empty;
+
+        public static readonly ImmutableHashSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.Immutable.ImmutableHashSet<T> Add(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Clear() { throw null; }
+
+        public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public ImmutableHashSet<T> Add(T item) { throw null; }
+
+        public ImmutableHashSet<T> Clear() { throw null; }
+
         public bool Contains(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Remove(T item) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T item) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
+        public ImmutableHashSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableHashSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> Remove(T item) { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T item) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableHashSet<T> WithComparer(System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+        public ImmutableHashSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableHashSet<T> WithComparer(Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            public Generic.IEqualityComparer<T> KeyComparer { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableHashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableHashSet<T> ToImmutable() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableHashSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableInterlocked
     {
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> addValueFactory, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static TValue AddOrUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, System.Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
-        public static void Enqueue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, T value) { }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TValue> valueFactory) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static TValue GetOrAdd<TKey, TValue, TArg>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, System.Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedCompareExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value, System.Collections.Immutable.ImmutableArray<T> comparand) { throw null; }
-        public static System.Collections.Immutable.ImmutableArray<T> InterlockedExchange<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static bool InterlockedInitialize<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Collections.Immutable.ImmutableArray<T> value) { throw null; }
-        public static void Push<T>(ref System.Collections.Immutable.ImmutableStack<T> location, T value) { }
-        public static bool TryAdd<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
-        public static bool TryDequeue<T>(ref System.Collections.Immutable.ImmutableQueue<T> location, out T value) { throw null; }
-        public static bool TryPop<T>(ref System.Collections.Immutable.ImmutableStack<T> location, out T value) { throw null; }
-        public static bool TryRemove<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
-        public static bool TryUpdate<TKey, TValue>(ref System.Collections.Immutable.ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
-        public static bool Update<T>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, System.Collections.Immutable.ImmutableArray<T>> transformer) { throw null; }
-        public static bool Update<T>(ref T location, System.Func<T, T> transformer) where T : class { throw null; }
-        public static bool Update<T, TArg>(ref System.Collections.Immutable.ImmutableArray<T> location, System.Func<System.Collections.Immutable.ImmutableArray<T>, TArg, System.Collections.Immutable.ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
-        public static bool Update<T, TArg>(ref T location, System.Func<T, TArg, T> transformer, TArg transformerArgument) where T : class { throw null; }
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory) { throw null; }
+
+        public static void Enqueue<T>(ref ImmutableQueue<T> location, T value) { }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory) { throw null; }
+
+        public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument) { throw null; }
+
+        public static ImmutableArray<T> InterlockedCompareExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value, ImmutableArray<T> comparand) { throw null; }
+
+        public static ImmutableArray<T> InterlockedExchange<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static bool InterlockedInitialize<T>(ref ImmutableArray<T> location, ImmutableArray<T> value) { throw null; }
+
+        public static void Push<T>(ref ImmutableStack<T> location, T value) { }
+
+        public static bool TryAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue value) { throw null; }
+
+        public static bool TryDequeue<T>(ref ImmutableQueue<T> location, out T value) { throw null; }
+
+        public static bool TryPop<T>(ref ImmutableStack<T> location, out T value) { throw null; }
+
+        public static bool TryRemove<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, out TValue value) { throw null; }
+
+        public static bool TryUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue newValue, TValue comparisonValue) { throw null; }
+
+        public static bool Update<T>(ref T location, Func<T, T> transformer)
+            where T : class { throw null; }
+
+        public static bool Update<T>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, ImmutableArray<T>> transformer) { throw null; }
+
+        public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument)
+            where T : class { throw null; }
+
+        public static bool Update<T, TArg>(ref ImmutableArray<T> location, Func<ImmutableArray<T>, TArg, ImmutableArray<T>> transformer, TArg transformerArgument) { throw null; }
     }
+
     public static partial class ImmutableList
     {
-        public static System.Collections.Immutable.ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<T> Create<T>(params T[] items) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int IndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex) { throw null; }
-        public static int LastIndexOf<T>(this System.Collections.Immutable.IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> RemoveRange<T>(this System.Collections.Immutable.IImmutableList<T> list, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Remove<T>(this System.Collections.Immutable.IImmutableList<T> list, T value) { throw null; }
-        public static System.Collections.Immutable.IImmutableList<T> Replace<T>(this System.Collections.Immutable.IImmutableList<T> list, T oldValue, T newValue) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableList<TSource> ToImmutableList<TSource>(this System.Collections.Immutable.ImmutableList<TSource>.Builder builder) { throw null; }
+        public static ImmutableList<T> Create<T>() { throw null; }
+
+        public static ImmutableList<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableList<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableList<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableList<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int IndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex) { throw null; }
+
+        public static int LastIndexOf<T>(this IImmutableList<T> list, T item) { throw null; }
+
+        public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value) { throw null; }
+
+        public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableList<TSource> ToImmutableList<TSource>(this ImmutableList<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableList<T>
+
+    public sealed partial class ImmutableList<T> : IImmutableList<T>, Generic.IReadOnlyList<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyCollection<T>, Generic.IList<T>, Generic.ICollection<T>, IList, ICollection
     {
         internal ImmutableList() { }
-        public static readonly System.Collections.Immutable.ImmutableList<T> Empty;
+
+        public static readonly ImmutableList<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableList<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableList<T> Add(T value) { throw null; }
+
+        public ImmutableList<T> AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Clear() { throw null; }
+
+        public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
+        public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T? Find(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T? FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
         public int IndexOf(T value) { throw null; }
-        public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Insert(int index, T item) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> Insert(int index, T item) { throw null; }
+
+        public ImmutableList<T> InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public int LastIndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAll(System.Predicate<T> match) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveAt(int index) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> RemoveRange(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Reverse(int index, int count) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort() { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(System.Comparison<T> comparison) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T> Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.AddRange(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Insert(int index, T item) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Remove(T value, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAll(System.Predicate<T> match) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveAt(int index) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(System.Collections.Generic.IEnumerable<T> items, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
-        System.Collections.Immutable.IImmutableList<T> System.Collections.Immutable.IImmutableList<T>.SetItem(int index, T value) { throw null; }
-        public System.Collections.Immutable.ImmutableList<T>.Builder ToBuilder() { throw null; }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+        public int LastIndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Remove(T value) { throw null; }
+
+        public ImmutableList<T> RemoveAll(Predicate<T> match) { throw null; }
+
+        public ImmutableList<T> RemoveAt(int index) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> RemoveRange(Generic.IEnumerable<T> items) { throw null; }
+
+        public ImmutableList<T> RemoveRange(int index, int count) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
+        public ImmutableList<T> Replace(T oldValue, T newValue) { throw null; }
+
+        public ImmutableList<T> Reverse() { throw null; }
+
+        public ImmutableList<T> Reverse(int index, int count) { throw null; }
+
+        public ImmutableList<T> SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T> Sort() { throw null; }
+
+        public ImmutableList<T> Sort(Generic.IComparer<T>? comparer) { throw null; }
+
+        public ImmutableList<T> Sort(Comparison<T> comparison) { throw null; }
+
+        public ImmutableList<T> Sort(int index, int count, Generic.IComparer<T>? comparer) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableList<T> IImmutableList<T>.Add(T value) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.AddRange(Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Clear() { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Insert(int index, T item) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.InsertRange(int index, Generic.IEnumerable<T> items) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Remove(T value, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveAt(int index) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(Generic.IEnumerable<T> items, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+        IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) { throw null; }
+
+        public ImmutableList<T>.Builder ToBuilder() { throw null; }
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public sealed partial class Builder : Generic.IList<T>, Generic.ICollection<T>, Generic.IEnumerable<T>, IEnumerable, IList, ICollection, Generic.IReadOnlyList<T>, Generic.IReadOnlyCollection<T>
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } set { } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IList.IsFixedSize { get { throw null; } }
-            bool System.Collections.IList.IsReadOnly { get { throw null; } }
-            object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IList.IsFixedSize { get { throw null; } }
+
+            bool IList.IsReadOnly { get { throw null; } }
+
+            object? IList.this[int index] { get { throw null; } set { } }
+
             public void Add(T item) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<T> items) { }
-            public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public void AddRange(Generic.IEnumerable<T> items) { }
+
+            public int BinarySearch(T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public int BinarySearch(T item) { throw null; }
-            public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+            public int BinarySearch(int index, int count, T item, Generic.IComparer<T>? comparer) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public System.Collections.Immutable.ImmutableList<TOutput> ConvertAll<TOutput>(System.Func<T, TOutput> converter) { throw null; }
-            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-            public void CopyTo(T[] array) { }
+
+            public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter) { throw null; }
+
             public void CopyTo(T[] array, int arrayIndex) { }
-            public bool Exists(System.Predicate<T> match) { throw null; }
-            public T Find(System.Predicate<T> match) { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> FindAll(System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindIndex(System.Predicate<T> match) { throw null; }
-            public T FindLast(System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-            public int FindLastIndex(System.Predicate<T> match) { throw null; }
-            public void ForEach(System.Action<T> action) { }
-            public System.Collections.Immutable.ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableList<T> GetRange(int index, int count) { throw null; }
-            public int IndexOf(T item) { throw null; }
-            public int IndexOf(T item, int index) { throw null; }
+
+            public void CopyTo(T[] array) { }
+
+            public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+            public bool Exists(Predicate<T> match) { throw null; }
+
+            public T? Find(Predicate<T> match) { throw null; }
+
+            public ImmutableList<T> FindAll(Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindIndex(Predicate<T> match) { throw null; }
+
+            public T? FindLast(Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+            public int FindLastIndex(Predicate<T> match) { throw null; }
+
+            public void ForEach(Action<T> action) { }
+
+            public ImmutableList<T>.Enumerator GetEnumerator() { throw null; }
+
+            public ImmutableList<T> GetRange(int index, int count) { throw null; }
+
+            public int IndexOf(T item, int index, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int IndexOf(T item, int index, int count) { throw null; }
-            public int IndexOf(T item, int index, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int IndexOf(T item, int index) { throw null; }
+
+            public int IndexOf(T item) { throw null; }
+
             public void Insert(int index, T item) { }
-            public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> items) { }
+
+            public void InsertRange(int index, Generic.IEnumerable<T> items) { }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public int LastIndexOf(T item) { throw null; }
-            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex, int count, Generic.IEqualityComparer<T>? equalityComparer) { throw null; }
+
             public int LastIndexOf(T item, int startIndex, int count) { throw null; }
-            public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
+
+            public int LastIndexOf(T item, int startIndex) { throw null; }
+
+            public int LastIndexOf(T item) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+            public int RemoveAll(Predicate<T> match) { throw null; }
+
             public void RemoveAt(int index) { }
+
             public void Reverse() { }
+
             public void Reverse(int index, int count) { }
+
             public void Sort() { }
-            public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-            public void Sort(System.Comparison<T> comparison) { }
-            public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            int System.Collections.IList.Add(object value) { throw null; }
-            void System.Collections.IList.Clear() { }
-            bool System.Collections.IList.Contains(object value) { throw null; }
-            int System.Collections.IList.IndexOf(object value) { throw null; }
-            void System.Collections.IList.Insert(int index, object value) { }
-            void System.Collections.IList.Remove(object value) { }
-            public System.Collections.Immutable.ImmutableList<T> ToImmutable() { throw null; }
-            public bool TrueForAll(System.Predicate<T> match) { throw null; }
+
+            public void Sort(Generic.IComparer<T>? comparer) { }
+
+            public void Sort(Comparison<T> comparison) { }
+
+            public void Sort(int index, int count, Generic.IComparer<T>? comparer) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            int IList.Add(object value) { throw null; }
+
+            void IList.Clear() { }
+
+            bool IList.Contains(object value) { throw null; }
+
+            int IList.IndexOf(object value) { throw null; }
+
+            void IList.Insert(int index, object value) { }
+
+            void IList.Remove(object value) { }
+
+            public ImmutableList<T> ToImmutable() { throw null; }
+
+            public bool TrueForAll(Predicate<T> match) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableQueue
     {
-        public static System.Collections.Immutable.ImmutableQueue<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableQueue<T> Dequeue<T>(this System.Collections.Immutable.IImmutableQueue<T> queue, out T value) { throw null; }
+        public static ImmutableQueue<T> Create<T>() { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableQueue<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableQueue<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value) { throw null; }
     }
-    public sealed partial class ImmutableQueue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableQueue<T>
+
+    public sealed partial class ImmutableQueue<T> : IImmutableQueue<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableQueue() { }
-        public static System.Collections.Immutable.ImmutableQueue<T> Empty { get { throw null; } }
+
+        public static ImmutableQueue<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableQueue<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue() { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Dequeue(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T> Enqueue(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableQueue<T> Clear() { throw null; }
+
+        public ImmutableQueue<T> Dequeue() { throw null; }
+
+        public ImmutableQueue<T> Dequeue(out T value) { throw null; }
+
+        public ImmutableQueue<T> Enqueue(T value) { throw null; }
+
+        public ImmutableQueue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Dequeue() { throw null; }
-        System.Collections.Immutable.IImmutableQueue<T> System.Collections.Immutable.IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Clear() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Dequeue() { throw null; }
+
+        IImmutableQueue<T> IImmutableQueue<T>.Enqueue(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableQueue<T> _originalQueue;
+            private ImmutableStack<T> _remainingForwardsStack;
+            private ImmutableStack<T> _remainingBackwardsStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
+
     public static partial class ImmutableSortedDictionary
     {
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> source, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TValue> elementSelector, System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> Create<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>() { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue>.Builder CreateBuilder<TKey, TValue>(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> CreateRange<TKey, TValue>(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> source) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this ImmutableSortedDictionary<TKey, TValue>.Builder builder) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this Generic.IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector) { throw null; }
     }
-    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableDictionary<TKey, TValue>
+
+    public sealed partial class ImmutableSortedDictionary<TKey, TValue> : IImmutableDictionary<TKey, TValue>, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
     {
         internal ImmutableSortedDictionary() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Empty;
+
+        public static readonly ImmutableSortedDictionary<TKey, TValue> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } }
-        public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        TValue System.Collections.Generic.IDictionary<TKey,TValue>.this[TKey key] { get { throw null; } set { } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
-        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
+        public Generic.IComparer<TKey> KeyComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        TValue Generic.IDictionary<TKey, TValue>.this[TKey key] { get { throw null; } set { } }
+
+        Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object? IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } }
+
+        public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
+        public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Clear() { throw null; }
+
+        public bool Contains(Generic.KeyValuePair<TKey, TValue> pair) { throw null; }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Clear() { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
-        void System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value) { }
-        bool System.Collections.Generic.IDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        void System.Collections.IDictionary.Clear() { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Add(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.Remove(TKey key) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItem(TKey key, TValue value) { throw null; }
-        System.Collections.Immutable.IImmutableDictionary<TKey, TValue> System.Collections.Immutable.IImmutableDictionary<TKey,TValue>.SetItems(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Clear() { }
+
+        void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+        void Generic.IDictionary<TKey, TValue>.Add(TKey key, TValue value) { }
+
+        bool Generic.IDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        void IDictionary.Clear() { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> pairs) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear() { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(Generic.IEnumerable<TKey> keys) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value) { throw null; }
+
+        IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItems(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue>.Builder ToBuilder() { throw null; }
+
         public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
         public ref readonly TValue ValueRef(TKey key) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> WithComparers(System.Collections.Generic.IComparer<TKey> keyComparer, System.Collections.Generic.IEqualityComparer<TValue> valueComparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer, Generic.IEqualityComparer<TValue>? valueComparer) { throw null; }
+
+        public ImmutableSortedDictionary<TKey, TValue> WithComparers(Generic.IComparer<TKey>? keyComparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IDictionary<TKey, TValue>, Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>, Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>, IEnumerable, Generic.IReadOnlyDictionary<TKey, TValue>, Generic.IReadOnlyCollection<Generic.KeyValuePair<TKey, TValue>>, IDictionary, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public TValue this[TKey key] { get { throw null; } set { } }
-            public System.Collections.Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TKey> Keys { get { throw null; } }
-            bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-            System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-            System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
-            bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-            bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-            object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-            System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-            System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-            public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
-            public System.Collections.Generic.IEnumerable<TValue> Values { get { throw null; } }
-            public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public Generic.IComparer<TKey> KeyComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TKey> Keys { get { throw null; } }
+
+            bool Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+            Generic.ICollection<TKey> Generic.IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+            Generic.ICollection<TValue> Generic.IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
+            bool IDictionary.IsFixedSize { get { throw null; } }
+
+            bool IDictionary.IsReadOnly { get { throw null; } }
+
+            object? IDictionary.this[object key] { get { throw null; } set { } }
+
+            ICollection IDictionary.Keys { get { throw null; } }
+
+            ICollection IDictionary.Values { get { throw null; } }
+
+            public Generic.IEqualityComparer<TValue> ValueComparer { get { throw null; } set { } }
+
+            public Generic.IEnumerable<TValue> Values { get { throw null; } }
+
             public void Add(TKey key, TValue value) { }
-            public void AddRange(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items) { }
+
+            public void Add(Generic.KeyValuePair<TKey, TValue> item) { }
+
+            public void AddRange(Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>> items) { }
+
             public void Clear() { }
-            public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public bool Contains(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
             public bool ContainsKey(TKey key) { throw null; }
+
             public bool ContainsValue(TValue value) { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
-            public TValue GetValueOrDefault(TKey key) { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
             public TValue GetValueOrDefault(TKey key, TValue defaultValue) { throw null; }
-            public bool Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public TValue? GetValueOrDefault(TKey key) { throw null; }
+
             public bool Remove(TKey key) { throw null; }
-            public void RemoveRange(System.Collections.Generic.IEnumerable<TKey> keys) { }
-            void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            void System.Collections.IDictionary.Add(object key, object value) { }
-            bool System.Collections.IDictionary.Contains(object key) { throw null; }
-            System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-            void System.Collections.IDictionary.Remove(object key) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
+            public bool Remove(Generic.KeyValuePair<TKey, TValue> item) { throw null; }
+
+            public void RemoveRange(Generic.IEnumerable<TKey> keys) { }
+
+            void Generic.ICollection<Generic.KeyValuePair<TKey, TValue>>.CopyTo(Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>> Generic.IEnumerable<Generic.KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            void IDictionary.Add(object key, object value) { }
+
+            bool IDictionary.Contains(object key) { throw null; }
+
+            IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+            void IDictionary.Remove(object key) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedDictionary<TKey, TValue> ToImmutable() { throw null; }
+
             public bool TryGetKey(TKey equalKey, out TKey actualKey) { throw null; }
+
             public bool TryGetValue(TKey key, out TValue value) { throw null; }
+
             public ref readonly TValue ValueRef(TKey key) { throw null; }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<Generic.KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableSortedSet
     {
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T>.Builder CreateBuilder<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IComparer<T> comparer, System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(System.Collections.Generic.IComparer<T> comparer, params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Generic.IEnumerable<TSource> source, System.Collections.Generic.IComparer<TSource> comparer) { throw null; }
-        public static System.Collections.Immutable.ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this System.Collections.Immutable.ImmutableSortedSet<TSource>.Builder builder) { throw null; }
+        public static ImmutableSortedSet<T> Create<T>() { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, T item) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer, params T[] items) { throw null; }
+
+        public static ImmutableSortedSet<T> Create<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>() { throw null; }
+
+        public static ImmutableSortedSet<T>.Builder CreateBuilder<T>(Generic.IComparer<T>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IComparer<T>? comparer, Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source, Generic.IComparer<TSource>? comparer) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this Generic.IEnumerable<TSource> source) { throw null; }
+
+        public static ImmutableSortedSet<TSource> ToImmutableSortedSet<TSource>(this ImmutableSortedSet<TSource>.Builder builder) { throw null; }
     }
-    public sealed partial class ImmutableSortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.Collections.Immutable.IImmutableSet<T>
+
+    public sealed partial class ImmutableSortedSet<T> : IImmutableSet<T>, Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.IReadOnlyList<T>, Generic.IList<T>, Generic.ICollection<T>, Generic.ISet<T>, IList, ICollection
     {
         internal ImmutableSortedSet() { }
-        public static readonly System.Collections.Immutable.ImmutableSortedSet<T> Empty;
+
+        public static readonly ImmutableSortedSet<T> Empty;
         public int Count { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
+
         public T this[int index] { get { throw null; } }
-        public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } }
-        public T Max { get { throw null; } }
-        public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        T System.Collections.Generic.IList<T>.this[int index] { get { throw null; } set { } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Add(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Clear() { throw null; }
+
+        public Generic.IComparer<T> KeyComparer { get { throw null; } }
+
+        public T? Max { get { throw null; } }
+
+        public T? Min { get { throw null; } }
+
+        bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        T Generic.IList<T>.this[int index] { get { throw null; } set { } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object? IList.this[int index] { get { throw null; } set { } }
+
+        public ImmutableSortedSet<T> Add(T value) { throw null; }
+
+        public ImmutableSortedSet<T> Clear() { throw null; }
+
         public bool Contains(T value) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableSortedSet<T> Except(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
         public int IndexOf(T item) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
         public ref readonly T ItemRef(int index) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Remove(T value) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        void System.Collections.Generic.ICollection<T>.Clear() { }
-        void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<T>.Remove(T item) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.Generic.IList<T>.Insert(int index, T item) { }
-        void System.Collections.Generic.IList<T>.RemoveAt(int index) { }
-        bool System.Collections.Generic.ISet<T>.Add(T item) { throw null; }
-        void System.Collections.Generic.ISet<T>.ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ISet<T>.UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        void System.Collections.IList.Clear() { }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
-        void System.Collections.IList.RemoveAt(int index) { }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Add(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Except(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Intersect(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Remove(T value) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.SymmetricExcept(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        System.Collections.Immutable.IImmutableSet<T> System.Collections.Immutable.IImmutableSet<T>.Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
+        public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> Remove(T value) { throw null; }
+
+        public Generic.IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        void Generic.ICollection<T>.Add(T item) { }
+
+        void Generic.ICollection<T>.Clear() { }
+
+        void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+        bool Generic.ICollection<T>.Remove(T item) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void Generic.IList<T>.Insert(int index, T item) { }
+
+        void Generic.IList<T>.RemoveAt(int index) { }
+
+        bool Generic.ISet<T>.Add(T item) { throw null; }
+
+        void Generic.ISet<T>.ExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.IntersectWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+        void Generic.ISet<T>.UnionWith(Generic.IEnumerable<T> other) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        void IList.Clear() { }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
+
+        void IList.RemoveAt(int index) { }
+
+        IImmutableSet<T> IImmutableSet<T>.Add(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Clear() { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Except(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Intersect(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Remove(T value) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(Generic.IEnumerable<T> other) { throw null; }
+
+        IImmutableSet<T> IImmutableSet<T>.Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T>.Builder ToBuilder() { throw null; }
+
         public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> Union(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public System.Collections.Immutable.ImmutableSortedSet<T> WithComparer(System.Collections.Generic.IComparer<T> comparer) { throw null; }
-        public sealed partial class Builder : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public ImmutableSortedSet<T> Union(Generic.IEnumerable<T> other) { throw null; }
+
+        public ImmutableSortedSet<T> WithComparer(Generic.IComparer<T>? comparer) { throw null; }
+
+        public sealed partial class Builder : Generic.IReadOnlyCollection<T>, Generic.IEnumerable<T>, IEnumerable, Generic.ISet<T>, Generic.ICollection<T>, ICollection
         {
             internal Builder() { }
+
             public int Count { get { throw null; } }
+
             public T this[int index] { get { throw null; } }
-            public System.Collections.Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
-            public T Max { get { throw null; } }
-            public T Min { get { throw null; } }
-            bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            public Generic.IComparer<T> KeyComparer { get { throw null; } set { } }
+
+            public T? Max { get { throw null; } }
+
+            public T? Min { get { throw null; } }
+
+            bool Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public bool Add(T item) { throw null; }
+
             public void Clear() { }
+
             public bool Contains(T item) { throw null; }
-            public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public System.Collections.Immutable.ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
-            public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-            public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public void ExceptWith(Generic.IEnumerable<T> other) { }
+
+            public ImmutableSortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+            public void IntersectWith(Generic.IEnumerable<T> other) { }
+
+            public bool IsProperSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsProperSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSubsetOf(Generic.IEnumerable<T> other) { throw null; }
+
+            public bool IsSupersetOf(Generic.IEnumerable<T> other) { throw null; }
+
             public ref readonly T ItemRef(int index) { throw null; }
-            public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+            public bool Overlaps(Generic.IEnumerable<T> other) { throw null; }
+
             public bool Remove(T item) { throw null; }
-            public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-            public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-            public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-            void System.Collections.Generic.ICollection<T>.Add(T item) { }
-            void System.Collections.Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
-            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public System.Collections.Immutable.ImmutableSortedSet<T> ToImmutable() { throw null; }
+
+            public Generic.IEnumerable<T> Reverse() { throw null; }
+
+            public bool SetEquals(Generic.IEnumerable<T> other) { throw null; }
+
+            public void SymmetricExceptWith(Generic.IEnumerable<T> other) { }
+
+            void Generic.ICollection<T>.Add(T item) { }
+
+            void Generic.ICollection<T>.CopyTo(T[] array, int arrayIndex) { }
+
+            Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public ImmutableSortedSet<T> ToImmutable() { throw null; }
+
             public bool TryGetValue(T equalValue, out T actualValue) { throw null; }
-            public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
+
+            public void UnionWith(Generic.IEnumerable<T> other) { }
         }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : Generic.IEnumerator<T>, IEnumerator, IDisposable
         {
             private object _dummy;
             private int _dummyPrimitive;
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object? IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
+
             public void Reset() { }
         }
     }
+
     public static partial class ImmutableStack
     {
-        public static System.Collections.Immutable.ImmutableStack<T> CreateRange<T>(System.Collections.Generic.IEnumerable<T> items) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>() { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(T item) { throw null; }
-        public static System.Collections.Immutable.ImmutableStack<T> Create<T>(params T[] items) { throw null; }
-        public static System.Collections.Immutable.IImmutableStack<T> Pop<T>(this System.Collections.Immutable.IImmutableStack<T> stack, out T value) { throw null; }
+        public static ImmutableStack<T> Create<T>() { throw null; }
+
+        public static ImmutableStack<T> Create<T>(T item) { throw null; }
+
+        public static ImmutableStack<T> Create<T>(params T[] items) { throw null; }
+
+        public static ImmutableStack<T> CreateRange<T>(Generic.IEnumerable<T> items) { throw null; }
+
+        public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value) { throw null; }
     }
-    public sealed partial class ImmutableStack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.Collections.Immutable.IImmutableStack<T>
+
+    public sealed partial class ImmutableStack<T> : IImmutableStack<T>, Generic.IEnumerable<T>, IEnumerable
     {
         internal ImmutableStack() { }
-        public static System.Collections.Immutable.ImmutableStack<T> Empty { get { throw null; } }
+
+        public static ImmutableStack<T> Empty { get { throw null; } }
+
         public bool IsEmpty { get { throw null; } }
-        public System.Collections.Immutable.ImmutableStack<T> Clear() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public ImmutableStack<T> Clear() { throw null; }
+
+        public ImmutableStack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public ref readonly T PeekRef() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop() { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Pop(out T value) { throw null; }
-        public System.Collections.Immutable.ImmutableStack<T> Push(T value) { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Clear() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Pop() { throw null; }
-        System.Collections.Immutable.IImmutableStack<T> System.Collections.Immutable.IImmutableStack<T>.Push(T value) { throw null; }
+
+        public ImmutableStack<T> Pop() { throw null; }
+
+        public ImmutableStack<T> Pop(out T value) { throw null; }
+
+        public ImmutableStack<T> Push(T value) { throw null; }
+
+        Generic.IEnumerator<T> Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Clear() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Pop() { throw null; }
+
+        IImmutableStack<T> IImmutableStack<T>.Push(T value) { throw null; }
+
         public partial struct Enumerator
         {
+            private ImmutableStack<T> _originalStack;
+            private ImmutableStack<T> _remainingStack;
             private object _dummy;
+            private int _dummyPrimitive;
             public T Current { get { throw null; } }
+
             public bool MoveNext() { throw null; }
         }
     }
 }
+
 namespace System.Linq
 {
     public static partial class ImmutableArrayExtensions
     {
-        public static T Aggregate<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, T, T> func) { throw null; }
-        public static TAccumulate Aggregate<TAccumulate, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func) { throw null; }
-        public static TResult Aggregate<TAccumulate, TResult, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, System.Func<TAccumulate, T, TAccumulate> func, System.Func<TAccumulate, TResult> resultSelector) { throw null; }
-        public static bool All<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static bool Any<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T ElementAtOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T ElementAt<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T FirstOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T First<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T LastOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Last<T>(this System.Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this System.Collections.Immutable.ImmutableArray<TSource> immutableArray, System.Func<TSource, System.Collections.Generic.IEnumerable<TCollection>> collectionSelector, System.Func<TSource, TCollection, TResult> resultSelector) { throw null; }
-        public static System.Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TResult> selector) { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Generic.IEnumerable<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Collections.Generic.IEqualityComparer<TBase> comparer = null) where TDerived : TBase { throw null; }
-        public static bool SequenceEqual<TDerived, TBase>(this System.Collections.Immutable.ImmutableArray<TBase> immutableArray, System.Collections.Immutable.ImmutableArray<TDerived> items, System.Func<TBase, TBase, bool> predicate) where TDerived : TBase { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T SingleOrDefault<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static T Single<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
-        public static T[] ToArray<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector) { throw null; }
-        public static System.Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, TKey> keySelector, System.Func<T, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { throw null; }
-        public static System.Collections.Generic.IEnumerable<T> Where<T>(this System.Collections.Immutable.ImmutableArray<T> immutableArray, System.Func<T, bool> predicate) { throw null; }
+        public static T? Aggregate<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, T, T> func) { throw null; }
+
+        public static TAccumulate Aggregate<TAccumulate, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func) { throw null; }
+
+        public static TResult Aggregate<TAccumulate, TResult, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) { throw null; }
+
+        public static bool All<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static bool Any<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T ElementAt<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T? ElementAtOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, int index) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T First<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? FirstOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T Last<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T>.Builder builder) { throw null; }
+
+        public static T? LastOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> Select<T, TResult>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TResult> selector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this Collections.Immutable.ImmutableArray<TSource> immutableArray, Func<TSource, Collections.Generic.IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Generic.IEnumerable<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Collections.Generic.IEqualityComparer<TBase>? comparer = null)
+            where TDerived : TBase { throw null; }
+
+        public static bool SequenceEqual<TDerived, TBase>(this Collections.Immutable.ImmutableArray<TBase> immutableArray, Collections.Immutable.ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate)
+            where TDerived : TBase { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T Single<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
+
+        public static T? SingleOrDefault<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static T[] ToArray<T>(this Collections.Immutable.ImmutableArray<T> immutableArray) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, T> ToDictionary<TKey, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, Collections.Generic.IEqualityComparer<TKey>? comparer) { throw null; }
+
+        public static Collections.Generic.Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector) { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> Where<T>(this Collections.Immutable.ImmutableArray<T> immutableArray, Func<T, bool> predicate) { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/system.collections.immutable.nuspec
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/system.collections.immutable.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8.6">
     <id>System.Collections.Immutable</id>
@@ -35,12 +35,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
     <serviceable>true</serviceable>
     <repository type="git" url="git://github.com/dotnet/runtime" commit="cf258a14b70ad9069470a108f13765e0e5988f51" />
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETFramework4.6">
-        <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="System.Memory" version="4.5.4" />
-      </group>
       <group targetFramework=".NETStandard1.0">
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
@@ -51,17 +45,6 @@ System.Collections.Immutable.ImmutableStack&lt;T&gt;</description>
       <group targetFramework=".NETStandard2.0">
         <dependency id="System.Memory" version="4.5.4" />
       </group>
-      <group targetFramework=".NETPortable4.5-Profile259" />
-      <group targetFramework="UAP10.0.16299">
-        <dependency id="System.Memory" version="4.5.4" />
-      </group>
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.immutable/Directory.Build.props
+++ b/src/referencePackages/src/system.collections.immutable/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Collections.Immutable</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.nongeneric/4.3.0/System.Collections.NonGeneric.4.3.0.csproj
@@ -1,26 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.nongeneric/4.3.0/system.collections.nongeneric.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.nongeneric/4.3.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.nongeneric/4.3.0</IntermediateOutputPath>
+    <AssemblyName>System.Collections.NonGeneric</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-      <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
-      <PackageReference Include="System.Globalization" Version="4.3.0" />
-      <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-      <PackageReference Include="System.Runtime" Version="4.3.0" />
-      <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-      <PackageReference Include="System.Threading" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.collections.nongeneric/4.3.0/ref/netstandard1.3/System.Collections.NonGeneric.cs
+++ b/src/referencePackages/src/system.collections.nongeneric/4.3.0/ref/netstandard1.3/System.Collections.NonGeneric.cs
@@ -4,298 +4,513 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.NonGeneric")]
-[assembly: AssemblyDescription("System.Collections.NonGeneric")]
-[assembly: AssemblyDefaultAlias("System.Collections.NonGeneric")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.1.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.NonGeneric")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.NonGeneric")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.NonGeneric")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.1.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections
 {
-    public partial class ArrayList : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+    public partial class ArrayList : IEnumerable, IList, ICollection
     {
         public ArrayList() { }
-        public ArrayList(System.Collections.ICollection c) { }
+
+        public ArrayList(ICollection c) { }
+
         public ArrayList(int capacity) { }
+
         public virtual int Capacity { get { throw null; } set { } }
+
         public virtual int Count { get { throw null; } }
+
         public virtual bool IsFixedSize { get { throw null; } }
+
         public virtual bool IsReadOnly { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual object this[int index] { get { throw null; } set { } }
+
         public virtual object SyncRoot { get { throw null; } }
-        public static System.Collections.ArrayList Adapter(System.Collections.IList list) { throw null; }
+
+        public static ArrayList Adapter(IList list) { throw null; }
+
         public virtual int Add(object value) { throw null; }
-        public virtual void AddRange(System.Collections.ICollection c) { }
-        public virtual int BinarySearch(int index, int count, object value, System.Collections.IComparer comparer) { throw null; }
+
+        public virtual void AddRange(ICollection c) { }
+
+        public virtual int BinarySearch(int index, int count, object value, IComparer comparer) { throw null; }
+
+        public virtual int BinarySearch(object value, IComparer comparer) { throw null; }
+
         public virtual int BinarySearch(object value) { throw null; }
-        public virtual int BinarySearch(object value, System.Collections.IComparer comparer) { throw null; }
+
         public virtual void Clear() { }
+
         public virtual object Clone() { throw null; }
+
         public virtual bool Contains(object item) { throw null; }
-        public virtual void CopyTo(System.Array array) { }
-        public virtual void CopyTo(System.Array array, int arrayIndex) { }
-        public virtual void CopyTo(int index, System.Array array, int arrayIndex, int count) { }
-        public static System.Collections.ArrayList FixedSize(System.Collections.ArrayList list) { throw null; }
-        public static System.Collections.IList FixedSize(System.Collections.IList list) { throw null; }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.IEnumerator GetEnumerator(int index, int count) { throw null; }
-        public virtual System.Collections.ArrayList GetRange(int index, int count) { throw null; }
-        public virtual int IndexOf(object value) { throw null; }
-        public virtual int IndexOf(object value, int startIndex) { throw null; }
+
+        public virtual void CopyTo(Array array, int arrayIndex) { }
+
+        public virtual void CopyTo(Array array) { }
+
+        public virtual void CopyTo(int index, Array array, int arrayIndex, int count) { }
+
+        public static ArrayList FixedSize(ArrayList list) { throw null; }
+
+        public static IList FixedSize(IList list) { throw null; }
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
+        public virtual IEnumerator GetEnumerator(int index, int count) { throw null; }
+
+        public virtual ArrayList GetRange(int index, int count) { throw null; }
+
         public virtual int IndexOf(object value, int startIndex, int count) { throw null; }
+
+        public virtual int IndexOf(object value, int startIndex) { throw null; }
+
+        public virtual int IndexOf(object value) { throw null; }
+
         public virtual void Insert(int index, object value) { }
-        public virtual void InsertRange(int index, System.Collections.ICollection c) { }
-        public virtual int LastIndexOf(object value) { throw null; }
-        public virtual int LastIndexOf(object value, int startIndex) { throw null; }
+
+        public virtual void InsertRange(int index, ICollection c) { }
+
         public virtual int LastIndexOf(object value, int startIndex, int count) { throw null; }
-        public static System.Collections.ArrayList ReadOnly(System.Collections.ArrayList list) { throw null; }
-        public static System.Collections.IList ReadOnly(System.Collections.IList list) { throw null; }
+
+        public virtual int LastIndexOf(object value, int startIndex) { throw null; }
+
+        public virtual int LastIndexOf(object value) { throw null; }
+
+        public static ArrayList ReadOnly(ArrayList list) { throw null; }
+
+        public static IList ReadOnly(IList list) { throw null; }
+
         public virtual void Remove(object obj) { }
+
         public virtual void RemoveAt(int index) { }
+
         public virtual void RemoveRange(int index, int count) { }
-        public static System.Collections.ArrayList Repeat(object value, int count) { throw null; }
+
+        public static ArrayList Repeat(object value, int count) { throw null; }
+
         public virtual void Reverse() { }
+
         public virtual void Reverse(int index, int count) { }
-        public virtual void SetRange(int index, System.Collections.ICollection c) { }
+
+        public virtual void SetRange(int index, ICollection c) { }
+
         public virtual void Sort() { }
-        public virtual void Sort(System.Collections.IComparer comparer) { }
-        public virtual void Sort(int index, int count, System.Collections.IComparer comparer) { }
-        public static System.Collections.ArrayList Synchronized(System.Collections.ArrayList list) { throw null; }
-        public static System.Collections.IList Synchronized(System.Collections.IList list) { throw null; }
+
+        public virtual void Sort(IComparer comparer) { }
+
+        public virtual void Sort(int index, int count, IComparer comparer) { }
+
+        public static ArrayList Synchronized(ArrayList list) { throw null; }
+
+        public static IList Synchronized(IList list) { throw null; }
+
         public virtual object[] ToArray() { throw null; }
-        public virtual System.Array ToArray(System.Type type) { throw null; }
+
+        public virtual Array ToArray(Type type) { throw null; }
+
         public virtual void TrimToSize() { }
     }
-    public partial class CaseInsensitiveComparer : System.Collections.IComparer
+
+    public partial class CaseInsensitiveComparer : IComparer
     {
         public CaseInsensitiveComparer() { }
-        public CaseInsensitiveComparer(System.Globalization.CultureInfo culture) { }
-        public static System.Collections.CaseInsensitiveComparer Default { get { throw null; } }
-        public static System.Collections.CaseInsensitiveComparer DefaultInvariant { get { throw null; } }
+
+        public CaseInsensitiveComparer(Globalization.CultureInfo culture) { }
+
+        public static CaseInsensitiveComparer Default { get { throw null; } }
+
+        public static CaseInsensitiveComparer DefaultInvariant { get { throw null; } }
+
         public int Compare(object a, object b) { throw null; }
     }
-    public abstract partial class CollectionBase : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public abstract partial class CollectionBase : ICollection, IEnumerable, IList
     {
         protected CollectionBase() { }
+
         protected CollectionBase(int capacity) { }
+
         public int Capacity { get { throw null; } set { } }
+
         public int Count { get { throw null; } }
-        protected System.Collections.ArrayList InnerList { get { throw null; } }
-        protected System.Collections.IList List { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        protected ArrayList InnerList { get { throw null; } }
+
+        protected IList List { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public void Clear() { }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public IEnumerator GetEnumerator() { throw null; }
+
         protected virtual void OnClear() { }
+
         protected virtual void OnClearComplete() { }
+
         protected virtual void OnInsert(int index, object value) { }
+
         protected virtual void OnInsertComplete(int index, object value) { }
+
         protected virtual void OnRemove(int index, object value) { }
+
         protected virtual void OnRemoveComplete(int index, object value) { }
+
         protected virtual void OnSet(int index, object oldValue, object newValue) { }
+
         protected virtual void OnSetComplete(int index, object oldValue, object newValue) { }
+
         protected virtual void OnValidate(object value) { }
+
         public void RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        int System.Collections.IList.Add(object value) { throw null; }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        int IList.Add(object value) { throw null; }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
     }
-    public sealed partial class Comparer : System.Collections.IComparer
+
+    public sealed partial class Comparer : IComparer
     {
-        public static readonly System.Collections.Comparer Default;
-        public static readonly System.Collections.Comparer DefaultInvariant;
-        public Comparer(System.Globalization.CultureInfo culture) { }
+        public static readonly Comparer Default;
+        public static readonly Comparer DefaultInvariant;
+        public Comparer(Globalization.CultureInfo culture) { }
+
         public int Compare(object a, object b) { throw null; }
     }
-    public abstract partial class DictionaryBase : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public abstract partial class DictionaryBase : ICollection, IEnumerable, IDictionary
     {
-        protected DictionaryBase() { }
         public int Count { get { throw null; } }
-        protected System.Collections.IDictionary Dictionary { get { throw null; } }
-        protected System.Collections.Hashtable InnerHashtable { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
+
+        protected IDictionary Dictionary { get { throw null; } }
+
+        protected Hashtable InnerHashtable { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
         public void Clear() { }
-        public void CopyTo(System.Array array, int index) { }
-        public System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public IDictionaryEnumerator GetEnumerator() { throw null; }
+
         protected virtual void OnClear() { }
+
         protected virtual void OnClearComplete() { }
+
         protected virtual object OnGet(object key, object currentValue) { throw null; }
+
         protected virtual void OnInsert(object key, object value) { }
+
         protected virtual void OnInsertComplete(object key, object value) { }
+
         protected virtual void OnRemove(object key, object value) { }
+
         protected virtual void OnRemoveComplete(object key, object value) { }
+
         protected virtual void OnSet(object key, object oldValue, object newValue) { }
+
         protected virtual void OnSetComplete(object key, object oldValue, object newValue) { }
+
         protected virtual void OnValidate(object key, object value) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class Hashtable : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class Hashtable : ICollection, IEnumerable, IDictionary
     {
         public Hashtable() { }
-        public Hashtable(System.Collections.IDictionary d) { }
-        public Hashtable(System.Collections.IDictionary d, System.Collections.IEqualityComparer equalityComparer) { }
-        public Hashtable(System.Collections.IDictionary d, float loadFactor) { }
-        public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IEqualityComparer equalityComparer) { }
-        public Hashtable(System.Collections.IEqualityComparer equalityComparer) { }
-        public Hashtable(int capacity) { }
-        public Hashtable(int capacity, System.Collections.IEqualityComparer equalityComparer) { }
+
+        public Hashtable(IDictionary d, IEqualityComparer equalityComparer) { }
+
+        public Hashtable(IDictionary d, float loadFactor, IEqualityComparer equalityComparer) { }
+
+        public Hashtable(IDictionary d, float loadFactor) { }
+
+        public Hashtable(IDictionary d) { }
+
+        public Hashtable(IEqualityComparer equalityComparer) { }
+
+        public Hashtable(int capacity, IEqualityComparer equalityComparer) { }
+
+        public Hashtable(int capacity, float loadFactor, IEqualityComparer equalityComparer) { }
+
         public Hashtable(int capacity, float loadFactor) { }
-        public Hashtable(int capacity, float loadFactor, System.Collections.IEqualityComparer equalityComparer) { }
+
+        public Hashtable(int capacity) { }
+
         public virtual int Count { get { throw null; } }
-        protected System.Collections.IEqualityComparer EqualityComparer { get { throw null; } }
+
+        protected IEqualityComparer EqualityComparer { get { throw null; } }
+
         public virtual bool IsFixedSize { get { throw null; } }
+
         public virtual bool IsReadOnly { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual object this[object key] { get { throw null; } set { } }
-        public virtual System.Collections.ICollection Keys { get { throw null; } }
+
+        public virtual ICollection Keys { get { throw null; } }
+
         public virtual object SyncRoot { get { throw null; } }
-        public virtual System.Collections.ICollection Values { get { throw null; } }
+
+        public virtual ICollection Values { get { throw null; } }
+
         public virtual void Add(object key, object value) { }
+
         public virtual void Clear() { }
+
         public virtual object Clone() { throw null; }
+
         public virtual bool Contains(object key) { throw null; }
+
         public virtual bool ContainsKey(object key) { throw null; }
+
         public virtual bool ContainsValue(object value) { throw null; }
-        public virtual void CopyTo(System.Array array, int arrayIndex) { }
-        public virtual System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public virtual void CopyTo(Array array, int arrayIndex) { }
+
+        public virtual IDictionaryEnumerator GetEnumerator() { throw null; }
+
         protected virtual int GetHash(object key) { throw null; }
+
         protected virtual bool KeyEquals(object item, object key) { throw null; }
+
         public virtual void Remove(object key) { }
-        public static System.Collections.Hashtable Synchronized(System.Collections.Hashtable table) { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public static Hashtable Synchronized(Hashtable table) { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class Queue : System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Queue : ICollection, IEnumerable
     {
         public Queue() { }
-        public Queue(System.Collections.ICollection col) { }
-        public Queue(int capacity) { }
+
+        public Queue(ICollection col) { }
+
         public Queue(int capacity, float growFactor) { }
+
+        public Queue(int capacity) { }
+
         public virtual int Count { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual object SyncRoot { get { throw null; } }
+
         public virtual void Clear() { }
+
         public virtual object Clone() { throw null; }
+
         public virtual bool Contains(object obj) { throw null; }
-        public virtual void CopyTo(System.Array array, int index) { }
+
+        public virtual void CopyTo(Array array, int index) { }
+
         public virtual object Dequeue() { throw null; }
+
         public virtual void Enqueue(object obj) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
         public virtual object Peek() { throw null; }
-        public static System.Collections.Queue Synchronized(System.Collections.Queue queue) { throw null; }
+
+        public static Queue Synchronized(Queue queue) { throw null; }
+
         public virtual object[] ToArray() { throw null; }
+
         public virtual void TrimToSize() { }
     }
-    public abstract partial class ReadOnlyCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable
+
+    public abstract partial class ReadOnlyCollectionBase : ICollection, IEnumerable
     {
-        protected ReadOnlyCollectionBase() { }
         public virtual int Count { get { throw null; } }
-        protected System.Collections.ArrayList InnerList { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+
+        protected ArrayList InnerList { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
     }
-    public partial class SortedList : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedList : ICollection, IEnumerable, IDictionary
     {
         public SortedList() { }
-        public SortedList(System.Collections.IComparer comparer) { }
-        public SortedList(System.Collections.IComparer comparer, int capacity) { }
-        public SortedList(System.Collections.IDictionary d) { }
-        public SortedList(System.Collections.IDictionary d, System.Collections.IComparer comparer) { }
+
+        public SortedList(IComparer comparer, int capacity) { }
+
+        public SortedList(IComparer comparer) { }
+
+        public SortedList(IDictionary d, IComparer comparer) { }
+
+        public SortedList(IDictionary d) { }
+
         public SortedList(int initialCapacity) { }
+
         public virtual int Capacity { get { throw null; } set { } }
+
         public virtual int Count { get { throw null; } }
+
         public virtual bool IsFixedSize { get { throw null; } }
+
         public virtual bool IsReadOnly { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual object this[object key] { get { throw null; } set { } }
-        public virtual System.Collections.ICollection Keys { get { throw null; } }
+
+        public virtual ICollection Keys { get { throw null; } }
+
         public virtual object SyncRoot { get { throw null; } }
-        public virtual System.Collections.ICollection Values { get { throw null; } }
+
+        public virtual ICollection Values { get { throw null; } }
+
         public virtual void Add(object key, object value) { }
+
         public virtual void Clear() { }
+
         public virtual object Clone() { throw null; }
+
         public virtual bool Contains(object key) { throw null; }
+
         public virtual bool ContainsKey(object key) { throw null; }
+
         public virtual bool ContainsValue(object value) { throw null; }
-        public virtual void CopyTo(System.Array array, int arrayIndex) { }
+
+        public virtual void CopyTo(Array array, int arrayIndex) { }
+
         public virtual object GetByIndex(int index) { throw null; }
-        public virtual System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public virtual IDictionaryEnumerator GetEnumerator() { throw null; }
+
         public virtual object GetKey(int index) { throw null; }
-        public virtual System.Collections.IList GetKeyList() { throw null; }
-        public virtual System.Collections.IList GetValueList() { throw null; }
+
+        public virtual IList GetKeyList() { throw null; }
+
+        public virtual IList GetValueList() { throw null; }
+
         public virtual int IndexOfKey(object key) { throw null; }
+
         public virtual int IndexOfValue(object value) { throw null; }
+
         public virtual void Remove(object key) { }
+
         public virtual void RemoveAt(int index) { }
+
         public virtual void SetByIndex(int index, object value) { }
-        public static System.Collections.SortedList Synchronized(System.Collections.SortedList list) { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public static SortedList Synchronized(SortedList list) { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public virtual void TrimToSize() { }
     }
-    public partial class Stack : System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Stack : ICollection, IEnumerable
     {
         public Stack() { }
-        public Stack(System.Collections.ICollection col) { }
+
+        public Stack(ICollection col) { }
+
         public Stack(int initialCapacity) { }
+
         public virtual int Count { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual object SyncRoot { get { throw null; } }
+
         public virtual void Clear() { }
+
         public virtual object Clone() { throw null; }
+
         public virtual bool Contains(object obj) { throw null; }
-        public virtual void CopyTo(System.Array array, int index) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public virtual void CopyTo(Array array, int index) { }
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
         public virtual object Peek() { throw null; }
+
         public virtual object Pop() { throw null; }
+
         public virtual void Push(object obj) { }
-        public static System.Collections.Stack Synchronized(System.Collections.Stack stack) { throw null; }
+
+        public static Stack Synchronized(Stack stack) { throw null; }
+
         public virtual object[] ToArray() { throw null; }
     }
 }
+
 namespace System.Collections.Specialized
 {
     public partial class CollectionsUtil
     {
-        public CollectionsUtil() { }
-        public static System.Collections.Hashtable CreateCaseInsensitiveHashtable() { throw null; }
-        public static System.Collections.Hashtable CreateCaseInsensitiveHashtable(System.Collections.IDictionary d) { throw null; }
-        public static System.Collections.Hashtable CreateCaseInsensitiveHashtable(int capacity) { throw null; }
-        public static System.Collections.SortedList CreateCaseInsensitiveSortedList() { throw null; }
+        public static Hashtable CreateCaseInsensitiveHashtable() { throw null; }
+
+        public static Hashtable CreateCaseInsensitiveHashtable(IDictionary d) { throw null; }
+
+        public static Hashtable CreateCaseInsensitiveHashtable(int capacity) { throw null; }
+
+        public static SortedList CreateCaseInsensitiveSortedList() { throw null; }
     }
 }

--- a/src/referencePackages/src/system.collections.nongeneric/4.3.0/system.collections.nongeneric.nuspec
+++ b/src/referencePackages/src/system.collections.nongeneric/4.3.0/system.collections.nongeneric.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections.NonGeneric</id>
@@ -29,8 +29,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Diagnostics.Debug" version="4.3.0" exclude="Compile" />
         <dependency id="System.Globalization" version="4.3.0" />
@@ -39,10 +37,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
         <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
       </group>
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.nongeneric/Directory.Build.props
+++ b/src/referencePackages/src/system.collections.nongeneric/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Collections.NonGeneric</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections.specialized/4.3.0/System.Collections.Specialized.4.3.0.csproj
@@ -1,27 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections.specialized/4.3.0/system.collections.specialized.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections.specialized/4.3.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections.specialized/4.3.0</IntermediateOutputPath>
+    <AssemblyName>System.Collections.Specialized</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-      <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-      <PackageReference Include="System.Globalization" Version="4.3.0" />
-      <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-      <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
-      <PackageReference Include="System.Runtime" Version="4.3.0" />
-      <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-      <PackageReference Include="System.Threading" Version="4.3.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
+    <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.collections.specialized/4.3.0/ref/netstandard1.3/System.Collections.Specialized.cs
+++ b/src/referencePackages/src/system.collections.specialized/4.3.0/ref/netstandard1.3/System.Collections.Specialized.cs
@@ -4,250 +4,419 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections.Specialized")]
-[assembly: AssemblyDescription("System.Collections.Specialized")]
-[assembly: AssemblyDefaultAlias("System.Collections.Specialized")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.1.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.Specialized")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.Specialized")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.Specialized")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.1.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections.Specialized
 {
     public partial struct BitVector32
     {
-        public BitVector32(System.Collections.Specialized.BitVector32 value) { throw null; }
-        public BitVector32(int data) { throw null; }
+        public BitVector32(BitVector32 value) { }
+
+        public BitVector32(int data) { }
+
         public int Data { get { throw null; } }
-        public int this[System.Collections.Specialized.BitVector32.Section section] { get { throw null; } set { } }
+
+        public int this[Section section] { get { throw null; } set { } }
+
         public bool this[int bit] { get { throw null; } set { } }
+
         public static int CreateMask() { throw null; }
+
         public static int CreateMask(int previous) { throw null; }
-        public static System.Collections.Specialized.BitVector32.Section CreateSection(short maxValue) { throw null; }
-        public static System.Collections.Specialized.BitVector32.Section CreateSection(short maxValue, System.Collections.Specialized.BitVector32.Section previous) { throw null; }
+
+        public static Section CreateSection(short maxValue, Section previous) { throw null; }
+
+        public static Section CreateSection(short maxValue) { throw null; }
+
         public override bool Equals(object o) { throw null; }
+
         public override int GetHashCode() { throw null; }
+
         public override string ToString() { throw null; }
-        public static string ToString(System.Collections.Specialized.BitVector32 value) { throw null; }
+
+        public static string ToString(BitVector32 value) { throw null; }
+
         public partial struct Section
         {
             public short Mask { get { throw null; } }
+
             public short Offset { get { throw null; } }
-            public bool Equals(System.Collections.Specialized.BitVector32.Section obj) { throw null; }
+
+            public bool Equals(Section obj) { throw null; }
+
             public override bool Equals(object o) { throw null; }
+
             public override int GetHashCode() { throw null; }
-            public static bool operator ==(System.Collections.Specialized.BitVector32.Section a, System.Collections.Specialized.BitVector32.Section b) { throw null; }
-            public static bool operator !=(System.Collections.Specialized.BitVector32.Section a, System.Collections.Specialized.BitVector32.Section b) { throw null; }
+
+            public static bool operator ==(Section a, Section b) { throw null; }
+
+            public static bool operator !=(Section a, Section b) { throw null; }
+
             public override string ToString() { throw null; }
-            public static string ToString(System.Collections.Specialized.BitVector32.Section value) { throw null; }
+
+            public static string ToString(Section value) { throw null; }
         }
     }
-    public partial class HybridDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class HybridDictionary : ICollection, IEnumerable, IDictionary
     {
         public HybridDictionary() { }
+
         public HybridDictionary(bool caseInsensitive) { }
-        public HybridDictionary(int initialSize) { }
+
         public HybridDictionary(int initialSize, bool caseInsensitive) { }
+
+        public HybridDictionary(int initialSize) { }
+
         public int Count { get { throw null; } }
+
         public bool IsFixedSize { get { throw null; } }
+
         public bool IsReadOnly { get { throw null; } }
+
         public bool IsSynchronized { get { throw null; } }
+
         public object this[object key] { get { throw null; } set { } }
-        public System.Collections.ICollection Keys { get { throw null; } }
+
+        public ICollection Keys { get { throw null; } }
+
         public object SyncRoot { get { throw null; } }
-        public System.Collections.ICollection Values { get { throw null; } }
+
+        public ICollection Values { get { throw null; } }
+
         public void Add(object key, object value) { }
+
         public void Clear() { }
+
         public bool Contains(object key) { throw null; }
-        public void CopyTo(System.Array array, int index) { }
-        public System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public IDictionaryEnumerator GetEnumerator() { throw null; }
+
         public void Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial interface IOrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial interface IOrderedDictionary : ICollection, IEnumerable, IDictionary
     {
         object this[int index] { get; set; }
-        new System.Collections.IDictionaryEnumerator GetEnumerator();
+
+        IDictionaryEnumerator GetEnumerator();
         void Insert(int index, object key, object value);
         void RemoveAt(int index);
     }
-    public partial class ListDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class ListDictionary : ICollection, IEnumerable, IDictionary
     {
         public ListDictionary() { }
-        public ListDictionary(System.Collections.IComparer comparer) { }
+
+        public ListDictionary(IComparer comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsFixedSize { get { throw null; } }
+
         public bool IsReadOnly { get { throw null; } }
+
         public bool IsSynchronized { get { throw null; } }
+
         public object this[object key] { get { throw null; } set { } }
-        public System.Collections.ICollection Keys { get { throw null; } }
+
+        public ICollection Keys { get { throw null; } }
+
         public object SyncRoot { get { throw null; } }
-        public System.Collections.ICollection Values { get { throw null; } }
+
+        public ICollection Values { get { throw null; } }
+
         public void Add(object key, object value) { }
+
         public void Clear() { }
+
         public bool Contains(object key) { throw null; }
-        public void CopyTo(System.Array array, int index) { }
-        public System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public IDictionaryEnumerator GetEnumerator() { throw null; }
+
         public void Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
     }
-    public abstract partial class NameObjectCollectionBase : System.Collections.ICollection, System.Collections.IEnumerable
+
+    public abstract partial class NameObjectCollectionBase : ICollection, IEnumerable
     {
         protected NameObjectCollectionBase() { }
-        protected NameObjectCollectionBase(System.Collections.IEqualityComparer equalityComparer) { }
+
+        protected NameObjectCollectionBase(IEqualityComparer equalityComparer) { }
+
+        protected NameObjectCollectionBase(int capacity, IEqualityComparer equalityComparer) { }
+
         protected NameObjectCollectionBase(int capacity) { }
-        protected NameObjectCollectionBase(int capacity, System.Collections.IEqualityComparer equalityComparer) { }
+
         public virtual int Count { get { throw null; } }
+
         protected bool IsReadOnly { get { throw null; } set { } }
-        public virtual System.Collections.Specialized.NameObjectCollectionBase.KeysCollection Keys { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        public virtual KeysCollection Keys { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         protected void BaseAdd(string name, object value) { }
+
         protected void BaseClear() { }
+
         protected object BaseGet(int index) { throw null; }
+
         protected object BaseGet(string name) { throw null; }
+
         protected string[] BaseGetAllKeys() { throw null; }
+
         protected object[] BaseGetAllValues() { throw null; }
-        protected object[] BaseGetAllValues(System.Type type) { throw null; }
+
+        protected object[] BaseGetAllValues(Type type) { throw null; }
+
         protected string BaseGetKey(int index) { throw null; }
+
         protected bool BaseHasKeys() { throw null; }
+
         protected void BaseRemove(string name) { }
+
         protected void BaseRemoveAt(int index) { }
+
         protected void BaseSet(int index, object value) { }
+
         protected void BaseSet(string name, object value) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        public partial class KeysCollection : System.Collections.ICollection, System.Collections.IEnumerable
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        public partial class KeysCollection : ICollection, IEnumerable
         {
             internal KeysCollection() { }
+
             public int Count { get { throw null; } }
+
             public string this[int index] { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public virtual string Get(int index) { throw null; }
-            public System.Collections.IEnumerator GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
+
+            public IEnumerator GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
         }
     }
-    public partial class NameValueCollection : System.Collections.Specialized.NameObjectCollectionBase
+
+    public partial class NameValueCollection : NameObjectCollectionBase
     {
         public NameValueCollection() { }
-        public NameValueCollection(System.Collections.IEqualityComparer equalityComparer) { }
-        public NameValueCollection(System.Collections.Specialized.NameValueCollection col) { }
+
+        public NameValueCollection(IEqualityComparer equalityComparer) { }
+
+        public NameValueCollection(NameValueCollection col) { }
+
+        public NameValueCollection(int capacity, IEqualityComparer equalityComparer) { }
+
+        public NameValueCollection(int capacity, NameValueCollection col) { }
+
         public NameValueCollection(int capacity) { }
-        public NameValueCollection(int capacity, System.Collections.IEqualityComparer equalityComparer) { }
-        public NameValueCollection(int capacity, System.Collections.Specialized.NameValueCollection col) { }
+
         public virtual string[] AllKeys { get { throw null; } }
+
         public string this[int index] { get { throw null; } }
+
         public string this[string name] { get { throw null; } set { } }
-        public void Add(System.Collections.Specialized.NameValueCollection c) { }
+
+        public void Add(NameValueCollection c) { }
+
         public virtual void Add(string name, string value) { }
+
         public virtual void Clear() { }
-        public void CopyTo(System.Array dest, int index) { }
+
+        public void CopyTo(Array dest, int index) { }
+
         public virtual string Get(int index) { throw null; }
+
         public virtual string Get(string name) { throw null; }
+
         public virtual string GetKey(int index) { throw null; }
+
         public virtual string[] GetValues(int index) { throw null; }
+
         public virtual string[] GetValues(string name) { throw null; }
+
         public bool HasKeys() { throw null; }
+
         protected void InvalidateCachedArrays() { }
+
         public virtual void Remove(string name) { }
+
         public virtual void Set(string name, string value) { }
     }
-    public partial class OrderedDictionary : System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.IOrderedDictionary
+
+    public partial class OrderedDictionary : ICollection, IEnumerable, IDictionary, IOrderedDictionary
     {
         public OrderedDictionary() { }
-        public OrderedDictionary(System.Collections.IEqualityComparer comparer) { }
+
+        public OrderedDictionary(IEqualityComparer comparer) { }
+
+        public OrderedDictionary(int capacity, IEqualityComparer comparer) { }
+
         public OrderedDictionary(int capacity) { }
-        public OrderedDictionary(int capacity, System.Collections.IEqualityComparer comparer) { }
+
         public int Count { get { throw null; } }
+
         public bool IsReadOnly { get { throw null; } }
+
         public object this[int index] { get { throw null; } set { } }
+
         public object this[object key] { get { throw null; } set { } }
-        public System.Collections.ICollection Keys { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        public System.Collections.ICollection Values { get { throw null; } }
+
+        public ICollection Keys { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        public ICollection Values { get { throw null; } }
+
         public void Add(object key, object value) { }
-        public System.Collections.Specialized.OrderedDictionary AsReadOnly() { throw null; }
+
+        public OrderedDictionary AsReadOnly() { throw null; }
+
         public void Clear() { }
+
         public bool Contains(object key) { throw null; }
-        public void CopyTo(System.Array array, int index) { }
-        public virtual System.Collections.IDictionaryEnumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public virtual IDictionaryEnumerator GetEnumerator() { throw null; }
+
         public void Insert(int index, object key, object value) { }
+
         public void Remove(object key) { }
+
         public void RemoveAt(int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
     }
-    public partial class StringCollection : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public partial class StringCollection : ICollection, IEnumerable, IList
     {
-        public StringCollection() { }
         public int Count { get { throw null; } }
+
         public bool IsReadOnly { get { throw null; } }
+
         public bool IsSynchronized { get { throw null; } }
+
         public string this[int index] { get { throw null; } set { } }
+
         public object SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public int Add(string value) { throw null; }
+
         public void AddRange(string[] value) { }
+
         public void Clear() { }
+
         public bool Contains(string value) { throw null; }
+
         public void CopyTo(string[] array, int index) { }
-        public System.Collections.Specialized.StringEnumerator GetEnumerator() { throw null; }
+
+        public StringEnumerator GetEnumerator() { throw null; }
+
         public int IndexOf(string value) { throw null; }
+
         public void Insert(int index, string value) { }
+
         public void Remove(string value) { }
+
         public void RemoveAt(int index) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object value) { throw null; }
-        bool System.Collections.IList.Contains(object value) { throw null; }
-        int System.Collections.IList.IndexOf(object value) { throw null; }
-        void System.Collections.IList.Insert(int index, object value) { }
-        void System.Collections.IList.Remove(object value) { }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object value) { throw null; }
+
+        bool IList.Contains(object value) { throw null; }
+
+        int IList.IndexOf(object value) { throw null; }
+
+        void IList.Insert(int index, object value) { }
+
+        void IList.Remove(object value) { }
     }
-    public partial class StringDictionary : System.Collections.IEnumerable
+
+    public partial class StringDictionary : IEnumerable
     {
-        public StringDictionary() { }
         public virtual int Count { get { throw null; } }
+
         public virtual bool IsSynchronized { get { throw null; } }
+
         public virtual string this[string key] { get { throw null; } set { } }
-        public virtual System.Collections.ICollection Keys { get { throw null; } }
+
+        public virtual ICollection Keys { get { throw null; } }
+
         public virtual object SyncRoot { get { throw null; } }
-        public virtual System.Collections.ICollection Values { get { throw null; } }
+
+        public virtual ICollection Values { get { throw null; } }
+
         public virtual void Add(string key, string value) { }
+
         public virtual void Clear() { }
+
         public virtual bool ContainsKey(string key) { throw null; }
+
         public virtual bool ContainsValue(string value) { throw null; }
-        public virtual void CopyTo(System.Array array, int index) { }
-        public virtual System.Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public virtual void CopyTo(Array array, int index) { }
+
+        public virtual IEnumerator GetEnumerator() { throw null; }
+
         public virtual void Remove(string key) { }
     }
+
     public partial class StringEnumerator
     {
         internal StringEnumerator() { }
+
         public string Current { get { throw null; } }
+
         public bool MoveNext() { throw null; }
+
         public void Reset() { }
     }
 }

--- a/src/referencePackages/src/system.collections.specialized/4.3.0/system.collections.specialized.nuspec
+++ b/src/referencePackages/src/system.collections.specialized/4.3.0/system.collections.specialized.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections.Specialized</id>
@@ -28,8 +28,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Collections.NonGeneric" version="4.3.0" exclude="Compile" />
         <dependency id="System.Globalization" version="4.3.0" exclude="Compile" />
@@ -39,14 +37,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Runtime.Extensions" version="4.3.0" exclude="Compile" />
         <dependency id="System.Threading" version="4.3.0" exclude="Compile" />
       </group>
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="mscorlib" targetFramework=".NETFramework4.6" />
-      <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.6" />
-    </frameworkAssemblies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections.specialized/Directory.Build.props
+++ b/src/referencePackages/src/system.collections.specialized/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Collections.Specialized</AssemblyName>
-  </PropertyGroup>
-
-</Project>

--- a/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
+++ b/src/referencePackages/src/system.collections/4.0.11/System.Collections.4.0.11.csproj
@@ -1,29 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections/4.0.11/system.collections.nuspec</NuspecFile>
-   </PropertyGroup>
-
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections/4.0.11/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections/4.0.11</IntermediateOutputPath>
+    <AssemblyName>System.Collections</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="1.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
   </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-        <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.1" />
-        <PackageReference Include="Microsoft.NETCore.Targets" Version="1.0.1" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.1" />
-        <PackageReference Include="Microsoft.NETCore.Targets" Version="1.0.1" />
-        <PackageReference Include="System.Runtime" Version="4.1.0" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="1.0.1" />
+    <PackageReference Include="System.Runtime" Version="4.1.0" />
+  </ItemGroup>
 
-  
 </Project>

--- a/src/referencePackages/src/system.collections/4.0.11/ref/netstandard1.0/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.0.11/ref/netstandard1.0/System.Collections.cs
@@ -4,554 +4,969 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections")]
-[assembly: AssemblyDescription("System.Collections")]
-[assembly: AssemblyDefaultAlias("System.Collections")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.0.30319.17929")]
-[assembly: AssemblyInformationalVersion("4.0.30319.17929 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.0.0")]
-
-
-
-
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.0.30319.17929")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.0.30319.17929")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections
 {
-    public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable
+    public sealed partial class BitArray : ICollection, IEnumerable
     {
         public BitArray(bool[] values) { }
+
         public BitArray(byte[] bytes) { }
-        public BitArray(System.Collections.BitArray bits) { }
-        public BitArray(int length) { }
+
+        public BitArray(BitArray bits) { }
+
         public BitArray(int length, bool defaultValue) { }
+
+        public BitArray(int length) { }
+
         public BitArray(int[] values) { }
+
         public bool this[int index] { get { throw null; } set { } }
+
         public int Length { get { throw null; } set { } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.BitArray And(System.Collections.BitArray value) { throw null; }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public BitArray And(BitArray value) { throw null; }
+
         public bool Get(int index) { throw null; }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.BitArray Not() { throw null; }
-        public System.Collections.BitArray Or(System.Collections.BitArray value) { throw null; }
+
+        public IEnumerator GetEnumerator() { throw null; }
+
+        public BitArray Not() { throw null; }
+
+        public BitArray Or(BitArray value) { throw null; }
+
         public void Set(int index, bool value) { }
+
         public void SetAll(bool value) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        public BitArray Xor(BitArray value) { throw null; }
     }
+
     public static partial class StructuralComparisons
     {
-        public static System.Collections.IComparer StructuralComparer { get { throw null; } }
-        public static System.Collections.IEqualityComparer StructuralEqualityComparer { get { throw null; } }
+        public static IComparer StructuralComparer { get { throw null; } }
+
+        public static IEqualityComparer StructuralEqualityComparer { get { throw null; } }
     }
 }
+
 namespace System.Collections.Generic
 {
-    public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
+    public abstract partial class Comparer<T> : IComparer<T>, IComparer
     {
-        protected Comparer() { }
-        public static System.Collections.Generic.Comparer<T> Default { get { throw null; } }
+        public static Comparer<T> Default { get { throw null; } }
+
         public abstract int Compare(T x, T y);
-        public static System.Collections.Generic.Comparer<T> Create(System.Comparison<T> comparison) { throw null; }
-        int System.Collections.IComparer.Compare(object x, object y) { throw null; }
+        public static Comparer<T> Create(Comparison<T> comparison) { throw null; }
+
+        int IComparer.Compare(object x, object y) { throw null; }
     }
-    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public Dictionary() { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public Dictionary(IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(int capacity, IEqualityComparer<TKey> comparer) { }
+
         public Dictionary(int capacity) { }
-        public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get { throw null; } }
+
+        public IEqualityComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator, IEnumerator, IDisposable
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, ICollection, IEnumerable
         {
-            public KeyCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, ICollection, IEnumerable
         {
-            public ValueCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public abstract partial class EqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>, System.Collections.IEqualityComparer
+
+    public abstract partial class EqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        protected EqualityComparer() { }
-        public static System.Collections.Generic.EqualityComparer<T> Default { get { throw null; } }
+        public static EqualityComparer<T> Default { get { throw null; } }
+
         public abstract bool Equals(T x, T y);
         public abstract int GetHashCode(T obj);
-        bool System.Collections.IEqualityComparer.Equals(object x, object y) { throw null; }
-        int System.Collections.IEqualityComparer.GetHashCode(object obj) { throw null; }
+        bool IEqualityComparer.Equals(object x, object y) { throw null; }
+
+        int IEqualityComparer.GetHashCode(object obj) { throw null; }
     }
-    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+    public partial class HashSet<T> : ISet<T>, ICollection<T>, IEnumerable<T>, IEnumerable
     {
         public HashSet() { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<T> Comparer { get { throw null; } }
+
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer) { }
+
+        public HashSet(IEnumerable<T> collection) { }
+
+        public HashSet(IEqualityComparer<T> comparer) { }
+
+        public IEqualityComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int arrayIndex) { }
+
         public void CopyTo(T[] array, int arrayIndex, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int arrayIndex) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
+
     public sealed partial class LinkedListNode<T>
     {
         public LinkedListNode(T value) { }
-        public System.Collections.Generic.LinkedList<T> List { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Next { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Previous { get { throw null; } }
+
+        public LinkedList<T> List { get { throw null; } }
+
+        public LinkedListNode<T> Next { get { throw null; } }
+
+        public LinkedListNode<T> Previous { get { throw null; } }
+
         public T Value { get { throw null; } set { } }
     }
-    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class LinkedList<T> : ICollection<T>, IEnumerable<T>, ICollection, IEnumerable
     {
         public LinkedList() { }
-        public LinkedList(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public LinkedList(IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> First { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Last { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public void AddAfter(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddAfter(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddBefore(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddBefore(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddFirst(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddFirst(T value) { throw null; }
-        public void AddLast(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public LinkedListNode<T> First { get { throw null; } }
+
+        public LinkedListNode<T> Last { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public LinkedListNode<T> AddAfter(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddAfter(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddBefore(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddBefore(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddFirst(T value) { throw null; }
+
+        public void AddFirst(LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public void AddLast(LinkedListNode<T> node) { }
+
         public void Clear() { }
+
         public bool Contains(T value) { throw null; }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.LinkedListNode<T> Find(T value) { throw null; }
-        public System.Collections.Generic.LinkedListNode<T> FindLast(T value) { throw null; }
-        public System.Collections.Generic.LinkedList<T>.Enumerator GetEnumerator() { throw null; }
-        public void Remove(System.Collections.Generic.LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> Find(T value) { throw null; }
+
+        public LinkedListNode<T> FindLast(T value) { throw null; }
+
+        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(T value) { throw null; }
+
+        public void Remove(LinkedListNode<T> node) { }
+
         public void RemoveFirst() { }
+
         public void RemoveLast() { }
-        void System.Collections.Generic.ICollection<T>.Add(T value) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        void ICollection<T>.Add(T value) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class List<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public partial class List<T> : IList<T>, ICollection<T>, IReadOnlyList<T>, IReadOnlyCollection<T>, IEnumerable<T>, IList, ICollection, IEnumerable
     {
         public List() { }
-        public List(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public List(IEnumerable<T> collection) { }
+
         public List(int capacity) { }
+
         public int Capacity { get { throw null; } set { } }
+
         public int Count { get { throw null; } }
+
         public T this[int index] { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public void Add(T item) { }
-        public void AddRange(System.Collections.Generic.IEnumerable<T> collection) { }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public void AddRange(IEnumerable<T> collection) { }
+
+        public int BinarySearch(T item, IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Generic.List<T> GetRange(int index, int count) { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int index) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public List<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public List<T>.Enumerator GetEnumerator() { throw null; }
+
+        public List<T> GetRange(int index, int count) { throw null; }
+
         public int IndexOf(T item, int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
         public void Insert(int index, T item) { }
-        public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int index) { throw null; }
+
+        public void InsertRange(int index, IEnumerable<T> collection) { }
+
         public int LastIndexOf(T item, int index, int count) { throw null; }
+
+        public int LastIndexOf(T item, int index) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+        public int RemoveAll(Predicate<T> match) { throw null; }
+
         public void RemoveAt(int index) { }
+
         public void RemoveRange(int index, int count) { }
+
         public void Reverse() { }
+
         public void Reverse(int index, int count) { }
+
         public void Sort() { }
-        public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-        public void Sort(System.Comparison<T> comparison) { }
-        public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object item) { throw null; }
-        bool System.Collections.IList.Contains(object item) { throw null; }
-        int System.Collections.IList.IndexOf(object item) { throw null; }
-        void System.Collections.IList.Insert(int index, object item) { }
-        void System.Collections.IList.Remove(object item) { }
+
+        public void Sort(IComparer<T> comparer) { }
+
+        public void Sort(Comparison<T> comparison) { }
+
+        public void Sort(int index, int count, IComparer<T> comparer) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object item) { throw null; }
+
+        bool IList.Contains(object item) { throw null; }
+
+        int IList.IndexOf(object item) { throw null; }
+
+        void IList.Insert(int index, object item) { }
+
+        void IList.Remove(object item) { }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Queue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Queue<T> : IEnumerable<T>, ICollection, IEnumerable
     {
         public Queue() { }
-        public Queue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Queue(IEnumerable<T> collection) { }
+
         public Queue(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
+
         public T Dequeue() { throw null; }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.Queue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class SortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public SortedDictionary() { }
-        public SortedDictionary(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public SortedDictionary(IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator, IEnumerator, IDisposable
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, ICollection, IEnumerable
         {
-            public KeyCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, ICollection, IEnumerable
         {
-            public ValueCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class SortedSet<T> : ISet<T>, ICollection<T>, IEnumerable<T>, ICollection, IEnumerable
     {
         public SortedSet() { }
-        public SortedSet(System.Collections.Generic.IComparer<T> comparer) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IComparer<T> comparer) { }
-        public System.Collections.Generic.IComparer<T> Comparer { get { throw null; } }
+
+        public SortedSet(IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection, IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection) { }
+
+        public IComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public virtual void Clear() { }
+
         public virtual bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int index) { }
+
         public void CopyTo(T[] array, int index, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.SortedSet<T>.Enumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
-        public virtual void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int index) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
+
+        public virtual void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Stack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Stack<T> : IEnumerable<T>, ICollection, IEnumerable
     {
         public Stack() { }
-        public Stack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Stack(IEnumerable<T> collection) { }
+
         public Stack(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public System.Collections.Generic.Stack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public T Pop() { throw null; }
+
         public void Push(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
 }

--- a/src/referencePackages/src/system.collections/4.0.11/ref/netstandard1.3/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.0.11/ref/netstandard1.3/System.Collections.cs
@@ -4,607 +4,1075 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections")]
-[assembly: AssemblyDescription("System.Collections")]
-[assembly: AssemblyDefaultAlias("System.Collections")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.10.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.10.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections
 {
-    public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable
+    public sealed partial class BitArray : ICollection, IEnumerable
     {
         public BitArray(bool[] values) { }
+
         public BitArray(byte[] bytes) { }
-        public BitArray(System.Collections.BitArray bits) { }
-        public BitArray(int length) { }
+
+        public BitArray(BitArray bits) { }
+
         public BitArray(int length, bool defaultValue) { }
+
+        public BitArray(int length) { }
+
         public BitArray(int[] values) { }
+
         public bool this[int index] { get { throw null; } set { } }
+
         public int Length { get { throw null; } set { } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.BitArray And(System.Collections.BitArray value) { throw null; }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public BitArray And(BitArray value) { throw null; }
+
         public bool Get(int index) { throw null; }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.BitArray Not() { throw null; }
-        public System.Collections.BitArray Or(System.Collections.BitArray value) { throw null; }
+
+        public IEnumerator GetEnumerator() { throw null; }
+
+        public BitArray Not() { throw null; }
+
+        public BitArray Or(BitArray value) { throw null; }
+
         public void Set(int index, bool value) { }
+
         public void SetAll(bool value) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        public BitArray Xor(BitArray value) { throw null; }
     }
+
     public static partial class StructuralComparisons
     {
-        public static System.Collections.IComparer StructuralComparer { get { throw null; } }
-        public static System.Collections.IEqualityComparer StructuralEqualityComparer { get { throw null; } }
+        public static IComparer StructuralComparer { get { throw null; } }
+
+        public static IEqualityComparer StructuralEqualityComparer { get { throw null; } }
     }
 }
+
 namespace System.Collections.Generic
 {
-    public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
+    public abstract partial class Comparer<T> : IComparer<T>, IComparer
     {
-        protected Comparer() { }
-        public static System.Collections.Generic.Comparer<T> Default { get { throw null; } }
+        public static Comparer<T> Default { get { throw null; } }
+
         public abstract int Compare(T x, T y);
-        public static System.Collections.Generic.Comparer<T> Create(System.Comparison<T> comparison) { throw null; }
-        int System.Collections.IComparer.Compare(object x, object y) { throw null; }
+        public static Comparer<T> Create(Comparison<T> comparison) { throw null; }
+
+        int IComparer.Compare(object x, object y) { throw null; }
     }
-    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class Dictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public Dictionary() { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public Dictionary(IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(int capacity, IEqualityComparer<TKey> comparer) { }
+
         public Dictionary(int capacity) { }
-        public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get { throw null; } }
+
+        public IEqualityComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable, IDictionaryEnumerator
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.Generic.IReadOnlyCollection<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, IEnumerable, IReadOnlyCollection<TKey>, ICollection
         {
-            public KeyCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.Generic.IReadOnlyCollection<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, IEnumerable, IReadOnlyCollection<TValue>, ICollection
         {
-            public ValueCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public abstract partial class EqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>, System.Collections.IEqualityComparer
+
+    public abstract partial class EqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        protected EqualityComparer() { }
-        public static System.Collections.Generic.EqualityComparer<T> Default { get { throw null; } }
+        public static EqualityComparer<T> Default { get { throw null; } }
+
         public abstract bool Equals(T x, T y);
         public abstract int GetHashCode(T obj);
-        bool System.Collections.IEqualityComparer.Equals(object x, object y) { throw null; }
-        int System.Collections.IEqualityComparer.GetHashCode(object obj) { throw null; }
+        bool IEqualityComparer.Equals(object x, object y) { throw null; }
+
+        int IEqualityComparer.GetHashCode(object obj) { throw null; }
     }
-    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+    public partial class HashSet<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ISet<T>
     {
         public HashSet() { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<T> Comparer { get { throw null; } }
+
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer) { }
+
+        public HashSet(IEnumerable<T> collection) { }
+
+        public HashSet(IEqualityComparer<T> comparer) { }
+
+        public IEqualityComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int arrayIndex) { }
+
         public void CopyTo(T[] array, int arrayIndex, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int arrayIndex) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
+
     public sealed partial class LinkedListNode<T>
     {
         public LinkedListNode(T value) { }
-        public System.Collections.Generic.LinkedList<T> List { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Next { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Previous { get { throw null; } }
+
+        public LinkedList<T> List { get { throw null; } }
+
+        public LinkedListNode<T> Next { get { throw null; } }
+
+        public LinkedListNode<T> Previous { get { throw null; } }
+
         public T Value { get { throw null; } set { } }
     }
-    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class LinkedList<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public LinkedList() { }
-        public LinkedList(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public LinkedList(IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> First { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Last { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public void AddAfter(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddAfter(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddBefore(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddBefore(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddFirst(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddFirst(T value) { throw null; }
-        public void AddLast(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public LinkedListNode<T> First { get { throw null; } }
+
+        public LinkedListNode<T> Last { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public LinkedListNode<T> AddAfter(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddAfter(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddBefore(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddBefore(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddFirst(T value) { throw null; }
+
+        public void AddFirst(LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public void AddLast(LinkedListNode<T> node) { }
+
         public void Clear() { }
+
         public bool Contains(T value) { throw null; }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.LinkedListNode<T> Find(T value) { throw null; }
-        public System.Collections.Generic.LinkedListNode<T> FindLast(T value) { throw null; }
-        public System.Collections.Generic.LinkedList<T>.Enumerator GetEnumerator() { throw null; }
-        public void Remove(System.Collections.Generic.LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> Find(T value) { throw null; }
+
+        public LinkedListNode<T> FindLast(T value) { throw null; }
+
+        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(T value) { throw null; }
+
+        public void Remove(LinkedListNode<T> node) { }
+
         public void RemoveFirst() { }
+
         public void RemoveLast() { }
-        void System.Collections.Generic.ICollection<T>.Add(T value) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        void ICollection<T>.Add(T value) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class List<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public partial class List<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IList<T>, IReadOnlyCollection<T>, IReadOnlyList<T>, ICollection, IList
     {
         public List() { }
-        public List(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public List(IEnumerable<T> collection) { }
+
         public List(int capacity) { }
+
         public int Capacity { get { throw null; } set { } }
+
         public int Count { get { throw null; } }
+
         public T this[int index] { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public void Add(T item) { }
-        public void AddRange(System.Collections.Generic.IEnumerable<T> collection) { }
-        public System.Collections.ObjectModel.ReadOnlyCollection<T> AsReadOnly() { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public void AddRange(IEnumerable<T> collection) { }
+
+        public ObjectModel.ReadOnlyCollection<T> AsReadOnly() { throw null; }
+
+        public int BinarySearch(T item, IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Generic.List<T> GetRange(int index, int count) { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int index) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public List<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public List<T>.Enumerator GetEnumerator() { throw null; }
+
+        public List<T> GetRange(int index, int count) { throw null; }
+
         public int IndexOf(T item, int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
         public void Insert(int index, T item) { }
-        public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int index) { throw null; }
+
+        public void InsertRange(int index, IEnumerable<T> collection) { }
+
         public int LastIndexOf(T item, int index, int count) { throw null; }
+
+        public int LastIndexOf(T item, int index) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+        public int RemoveAll(Predicate<T> match) { throw null; }
+
         public void RemoveAt(int index) { }
+
         public void RemoveRange(int index, int count) { }
+
         public void Reverse() { }
+
         public void Reverse(int index, int count) { }
+
         public void Sort() { }
-        public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-        public void Sort(System.Comparison<T> comparison) { }
-        public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object item) { throw null; }
-        bool System.Collections.IList.Contains(object item) { throw null; }
-        int System.Collections.IList.IndexOf(object item) { throw null; }
-        void System.Collections.IList.Insert(int index, object item) { }
-        void System.Collections.IList.Remove(object item) { }
+
+        public void Sort(IComparer<T> comparer) { }
+
+        public void Sort(Comparison<T> comparison) { }
+
+        public void Sort(int index, int count, IComparer<T> comparer) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object item) { throw null; }
+
+        bool IList.Contains(object item) { throw null; }
+
+        int IList.IndexOf(object item) { throw null; }
+
+        void IList.Insert(int index, object item) { }
+
+        void IList.Remove(object item) { }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Queue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Queue<T> : IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public Queue() { }
-        public Queue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Queue(IEnumerable<T> collection) { }
+
         public Queue(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
+
         public T Dequeue() { throw null; }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.Queue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class SortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedDictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public SortedDictionary() { }
-        public SortedDictionary(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public SortedDictionary(IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable, IDictionaryEnumerator
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.Generic.IReadOnlyCollection<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, IEnumerable, IReadOnlyCollection<TKey>, ICollection
         {
-            public KeyCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.Generic.IReadOnlyCollection<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, IEnumerable, IReadOnlyCollection<TValue>, ICollection
         {
-            public ValueCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public partial class SortedList<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedList<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public SortedList() { }
-        public SortedList(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedList(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedList(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
+
+        public SortedList(IComparer<TKey> comparer) { }
+
+        public SortedList(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedList(IDictionary<TKey, TValue> dictionary) { }
+
+        public SortedList(int capacity, IComparer<TKey> comparer) { }
+
         public SortedList(int capacity) { }
-        public SortedList(int capacity, System.Collections.Generic.IComparer<TKey> comparer) { }
+
         public int Capacity { get { throw null; } set { } }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.IList<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IList<TValue> Values { get { throw null; } }
+
+        public IList<TKey> Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public IList<TValue> Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public int IndexOfKey(TKey key) { throw null; }
+
         public int IndexOfValue(TValue value) { throw null; }
+
         public bool Remove(TKey key) { throw null; }
+
         public void RemoveAt(int index) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
     }
-    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class SortedSet<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ISet<T>, ICollection
     {
         public SortedSet() { }
-        public SortedSet(System.Collections.Generic.IComparer<T> comparer) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IComparer<T> comparer) { }
-        public System.Collections.Generic.IComparer<T> Comparer { get { throw null; } }
+
+        public SortedSet(IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection, IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection) { }
+
+        public IComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public virtual void Clear() { }
+
         public virtual bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int index) { }
+
         public void CopyTo(T[] array, int index, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.SortedSet<T>.Enumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
-        public virtual void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int index) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
+
+        public virtual void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Stack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Stack<T> : IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public Stack() { }
-        public Stack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Stack(IEnumerable<T> collection) { }
+
         public Stack(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public System.Collections.Generic.Stack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public T Pop() { throw null; }
+
         public void Push(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
 }

--- a/src/referencePackages/src/system.collections/4.0.11/system.collections.nuspec
+++ b/src/referencePackages/src/system.collections/4.0.11/system.collections.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections</id>
@@ -28,13 +28,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETCore5.0">
-        <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
-        <dependency id="Microsoft.NETCore.Targets" version="1.0.1" />
-        <dependency id="System.Runtime" version="4.1.0" />
-      </group>
       <group targetFramework=".NETStandard1.0">
         <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" />
         <dependency id="Microsoft.NETCore.Targets" version="1.0.1" />
@@ -45,14 +38,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.NETCore.Targets" version="1.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
       </group>
-      <group targetFramework=".NETPortable0.0-Profile259" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
+++ b/src/referencePackages/src/system.collections/4.3.0/System.Collections.4.3.0.csproj
@@ -2,26 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
-    <NuspecFile>$(ArtifactsBinDir)system.collections/4.3.0/system.collections.nuspec</NuspecFile>
+    <AssemblyName>System.Collections</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputPath>$(ArtifactsBinDir)system.collections/4.3.0/ref/</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)system.collections/4.3.0</IntermediateOutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="**/ref/$(TargetFramework)/*.cs" />
-    <Compile Include="**/lib/$(TargetFramework)/*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />

--- a/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.0/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.0/System.Collections.cs
@@ -4,554 +4,969 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections")]
-[assembly: AssemblyDescription("System.Collections")]
-[assembly: AssemblyDefaultAlias("System.Collections")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("4.0.30319.17929")]
-[assembly: AssemblyInformationalVersion("4.0.30319.17929 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.0.0")]
-
-
-
-
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyTitle("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections.dll")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("4.0.30319.17929")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.0.30319.17929")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.0.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections
 {
-    public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable
+    public sealed partial class BitArray : ICollection, IEnumerable
     {
         public BitArray(bool[] values) { }
+
         public BitArray(byte[] bytes) { }
-        public BitArray(System.Collections.BitArray bits) { }
-        public BitArray(int length) { }
+
+        public BitArray(BitArray bits) { }
+
         public BitArray(int length, bool defaultValue) { }
+
+        public BitArray(int length) { }
+
         public BitArray(int[] values) { }
+
         public bool this[int index] { get { throw null; } set { } }
+
         public int Length { get { throw null; } set { } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.BitArray And(System.Collections.BitArray value) { throw null; }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public BitArray And(BitArray value) { throw null; }
+
         public bool Get(int index) { throw null; }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.BitArray Not() { throw null; }
-        public System.Collections.BitArray Or(System.Collections.BitArray value) { throw null; }
+
+        public IEnumerator GetEnumerator() { throw null; }
+
+        public BitArray Not() { throw null; }
+
+        public BitArray Or(BitArray value) { throw null; }
+
         public void Set(int index, bool value) { }
+
         public void SetAll(bool value) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        public BitArray Xor(BitArray value) { throw null; }
     }
+
     public static partial class StructuralComparisons
     {
-        public static System.Collections.IComparer StructuralComparer { get { throw null; } }
-        public static System.Collections.IEqualityComparer StructuralEqualityComparer { get { throw null; } }
+        public static IComparer StructuralComparer { get { throw null; } }
+
+        public static IEqualityComparer StructuralEqualityComparer { get { throw null; } }
     }
 }
+
 namespace System.Collections.Generic
 {
-    public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
+    public abstract partial class Comparer<T> : IComparer<T>, IComparer
     {
-        protected Comparer() { }
-        public static System.Collections.Generic.Comparer<T> Default { get { throw null; } }
+        public static Comparer<T> Default { get { throw null; } }
+
         public abstract int Compare(T x, T y);
-        public static System.Collections.Generic.Comparer<T> Create(System.Comparison<T> comparison) { throw null; }
-        int System.Collections.IComparer.Compare(object x, object y) { throw null; }
+        public static Comparer<T> Create(Comparison<T> comparison) { throw null; }
+
+        int IComparer.Compare(object x, object y) { throw null; }
     }
-    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public Dictionary() { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public Dictionary(IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(int capacity, IEqualityComparer<TKey> comparer) { }
+
         public Dictionary(int capacity) { }
-        public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get { throw null; } }
+
+        public IEqualityComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator, IEnumerator, IDisposable
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, ICollection, IEnumerable
         {
-            public KeyCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, ICollection, IEnumerable
         {
-            public ValueCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public abstract partial class EqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>, System.Collections.IEqualityComparer
+
+    public abstract partial class EqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        protected EqualityComparer() { }
-        public static System.Collections.Generic.EqualityComparer<T> Default { get { throw null; } }
+        public static EqualityComparer<T> Default { get { throw null; } }
+
         public abstract bool Equals(T x, T y);
         public abstract int GetHashCode(T obj);
-        bool System.Collections.IEqualityComparer.Equals(object x, object y) { throw null; }
-        int System.Collections.IEqualityComparer.GetHashCode(object obj) { throw null; }
+        bool IEqualityComparer.Equals(object x, object y) { throw null; }
+
+        int IEqualityComparer.GetHashCode(object obj) { throw null; }
     }
-    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+    public partial class HashSet<T> : ISet<T>, ICollection<T>, IEnumerable<T>, IEnumerable
     {
         public HashSet() { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<T> Comparer { get { throw null; } }
+
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer) { }
+
+        public HashSet(IEnumerable<T> collection) { }
+
+        public HashSet(IEqualityComparer<T> comparer) { }
+
+        public IEqualityComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int arrayIndex) { }
+
         public void CopyTo(T[] array, int arrayIndex, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int arrayIndex) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
+
     public sealed partial class LinkedListNode<T>
     {
         public LinkedListNode(T value) { }
-        public System.Collections.Generic.LinkedList<T> List { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Next { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Previous { get { throw null; } }
+
+        public LinkedList<T> List { get { throw null; } }
+
+        public LinkedListNode<T> Next { get { throw null; } }
+
+        public LinkedListNode<T> Previous { get { throw null; } }
+
         public T Value { get { throw null; } set { } }
     }
-    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class LinkedList<T> : ICollection<T>, IEnumerable<T>, ICollection, IEnumerable
     {
         public LinkedList() { }
-        public LinkedList(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public LinkedList(IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> First { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Last { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public void AddAfter(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddAfter(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddBefore(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddBefore(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddFirst(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddFirst(T value) { throw null; }
-        public void AddLast(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public LinkedListNode<T> First { get { throw null; } }
+
+        public LinkedListNode<T> Last { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public LinkedListNode<T> AddAfter(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddAfter(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddBefore(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddBefore(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddFirst(T value) { throw null; }
+
+        public void AddFirst(LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public void AddLast(LinkedListNode<T> node) { }
+
         public void Clear() { }
+
         public bool Contains(T value) { throw null; }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.LinkedListNode<T> Find(T value) { throw null; }
-        public System.Collections.Generic.LinkedListNode<T> FindLast(T value) { throw null; }
-        public System.Collections.Generic.LinkedList<T>.Enumerator GetEnumerator() { throw null; }
-        public void Remove(System.Collections.Generic.LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> Find(T value) { throw null; }
+
+        public LinkedListNode<T> FindLast(T value) { throw null; }
+
+        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(T value) { throw null; }
+
+        public void Remove(LinkedListNode<T> node) { }
+
         public void RemoveFirst() { }
+
         public void RemoveLast() { }
-        void System.Collections.Generic.ICollection<T>.Add(T value) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        void ICollection<T>.Add(T value) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class List<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public partial class List<T> : IList<T>, ICollection<T>, IReadOnlyList<T>, IReadOnlyCollection<T>, IEnumerable<T>, IList, ICollection, IEnumerable
     {
         public List() { }
-        public List(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public List(IEnumerable<T> collection) { }
+
         public List(int capacity) { }
+
         public int Capacity { get { throw null; } set { } }
+
         public int Count { get { throw null; } }
+
         public T this[int index] { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public void Add(T item) { }
-        public void AddRange(System.Collections.Generic.IEnumerable<T> collection) { }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public void AddRange(IEnumerable<T> collection) { }
+
+        public int BinarySearch(T item, IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Generic.List<T> GetRange(int index, int count) { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int index) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public List<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public List<T>.Enumerator GetEnumerator() { throw null; }
+
+        public List<T> GetRange(int index, int count) { throw null; }
+
         public int IndexOf(T item, int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
         public void Insert(int index, T item) { }
-        public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int index) { throw null; }
+
+        public void InsertRange(int index, IEnumerable<T> collection) { }
+
         public int LastIndexOf(T item, int index, int count) { throw null; }
+
+        public int LastIndexOf(T item, int index) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+        public int RemoveAll(Predicate<T> match) { throw null; }
+
         public void RemoveAt(int index) { }
+
         public void RemoveRange(int index, int count) { }
+
         public void Reverse() { }
+
         public void Reverse(int index, int count) { }
+
         public void Sort() { }
-        public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-        public void Sort(System.Comparison<T> comparison) { }
-        public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object item) { throw null; }
-        bool System.Collections.IList.Contains(object item) { throw null; }
-        int System.Collections.IList.IndexOf(object item) { throw null; }
-        void System.Collections.IList.Insert(int index, object item) { }
-        void System.Collections.IList.Remove(object item) { }
+
+        public void Sort(IComparer<T> comparer) { }
+
+        public void Sort(Comparison<T> comparison) { }
+
+        public void Sort(int index, int count, IComparer<T> comparer) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object item) { throw null; }
+
+        bool IList.Contains(object item) { throw null; }
+
+        int IList.IndexOf(object item) { throw null; }
+
+        void IList.Insert(int index, object item) { }
+
+        void IList.Remove(object item) { }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Queue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Queue<T> : IEnumerable<T>, ICollection, IEnumerable
     {
         public Queue() { }
-        public Queue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Queue(IEnumerable<T> collection) { }
+
         public Queue(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
+
         public T Dequeue() { throw null; }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.Queue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class SortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
     {
         public SortedDictionary() { }
-        public SortedDictionary(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public SortedDictionary(IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator, IEnumerator, IDisposable
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, ICollection, IEnumerable
         {
-            public KeyCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, ICollection, IEnumerable
         {
-            public ValueCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class SortedSet<T> : ISet<T>, ICollection<T>, IEnumerable<T>, ICollection, IEnumerable
     {
         public SortedSet() { }
-        public SortedSet(System.Collections.Generic.IComparer<T> comparer) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IComparer<T> comparer) { }
-        public System.Collections.Generic.IComparer<T> Comparer { get { throw null; } }
+
+        public SortedSet(IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection, IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection) { }
+
+        public IComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public virtual void Clear() { }
+
         public virtual bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int index) { }
+
         public void CopyTo(T[] array, int index, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.SortedSet<T>.Enumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
-        public virtual void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int index) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
+
+        public virtual void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Stack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Stack<T> : IEnumerable<T>, ICollection, IEnumerable
     {
         public Stack() { }
-        public Stack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Stack(IEnumerable<T> collection) { }
+
         public Stack(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public System.Collections.Generic.Stack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public T Pop() { throw null; }
+
         public void Push(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
 }

--- a/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.3/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.3/System.Collections.cs
@@ -4,607 +4,1075 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Security;
-
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: ReferenceAssembly]
-[assembly: AssemblyTitle("System.Collections")]
-[assembly: AssemblyDescription("System.Collections")]
-[assembly: AssemblyDefaultAlias("System.Collections")]
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("Microsoft® .NET Framework")]
-[assembly: AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
-[assembly: AssemblyFileVersion("1.0.24212.01")]
-[assembly: AssemblyInformationalVersion("1.0.24212.01 built by: SOURCEBUILD")]
-[assembly: CLSCompliant(true)]
-[assembly: AssemblyMetadata("", "")]
-[assembly: AssemblyVersion("4.0.10.0")]
-
-
-
-
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Security.AllowPartiallyTrustedCallers]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyTitle("System.Collections")]
+[assembly: System.Reflection.AssemblyDescription("System.Collections")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Collections")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyFileVersion("1.0.24212.01")]
+[assembly: System.Reflection.AssemblyInformationalVersion("1.0.24212.01. Commit Hash: 9688ddbb62c04189cac4c4a06e31e93377dccd41")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.10.0")]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
 namespace System.Collections
 {
-    public sealed partial class BitArray : System.Collections.ICollection, System.Collections.IEnumerable
+    public sealed partial class BitArray : ICollection, IEnumerable
     {
         public BitArray(bool[] values) { }
+
         public BitArray(byte[] bytes) { }
-        public BitArray(System.Collections.BitArray bits) { }
-        public BitArray(int length) { }
+
+        public BitArray(BitArray bits) { }
+
         public BitArray(int length, bool defaultValue) { }
+
+        public BitArray(int length) { }
+
         public BitArray(int[] values) { }
+
         public bool this[int index] { get { throw null; } set { } }
+
         public int Length { get { throw null; } set { } }
-        int System.Collections.ICollection.Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public System.Collections.BitArray And(System.Collections.BitArray value) { throw null; }
+
+        int ICollection.Count { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public BitArray And(BitArray value) { throw null; }
+
         public bool Get(int index) { throw null; }
-        public System.Collections.IEnumerator GetEnumerator() { throw null; }
-        public System.Collections.BitArray Not() { throw null; }
-        public System.Collections.BitArray Or(System.Collections.BitArray value) { throw null; }
+
+        public IEnumerator GetEnumerator() { throw null; }
+
+        public BitArray Not() { throw null; }
+
+        public BitArray Or(BitArray value) { throw null; }
+
         public void Set(int index, bool value) { }
+
         public void SetAll(bool value) { }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        public System.Collections.BitArray Xor(System.Collections.BitArray value) { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        public BitArray Xor(BitArray value) { throw null; }
     }
+
     public static partial class StructuralComparisons
     {
-        public static System.Collections.IComparer StructuralComparer { get { throw null; } }
-        public static System.Collections.IEqualityComparer StructuralEqualityComparer { get { throw null; } }
+        public static IComparer StructuralComparer { get { throw null; } }
+
+        public static IEqualityComparer StructuralEqualityComparer { get { throw null; } }
     }
 }
+
 namespace System.Collections.Generic
 {
-    public abstract partial class Comparer<T> : System.Collections.Generic.IComparer<T>, System.Collections.IComparer
+    public abstract partial class Comparer<T> : IComparer<T>, IComparer
     {
-        protected Comparer() { }
-        public static System.Collections.Generic.Comparer<T> Default { get { throw null; } }
+        public static Comparer<T> Default { get { throw null; } }
+
         public abstract int Compare(T x, T y);
-        public static System.Collections.Generic.Comparer<T> Create(System.Comparison<T> comparison) { throw null; }
-        int System.Collections.IComparer.Compare(object x, object y) { throw null; }
+        public static Comparer<T> Create(Comparison<T> comparison) { throw null; }
+
+        int IComparer.Compare(object x, object y) { throw null; }
     }
-    public partial class Dictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class Dictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public Dictionary() { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public Dictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public Dictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public Dictionary(IEqualityComparer<TKey> comparer) { }
+
+        public Dictionary(int capacity, IEqualityComparer<TKey> comparer) { }
+
         public Dictionary(int capacity) { }
-        public Dictionary(int capacity, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get { throw null; } }
+
+        public IEqualityComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable, IDictionaryEnumerator
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.Generic.IReadOnlyCollection<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, IEnumerable, IReadOnlyCollection<TKey>, ICollection
         {
-            public KeyCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.Generic.IReadOnlyCollection<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, IEnumerable, IReadOnlyCollection<TValue>, ICollection
         {
-            public ValueCollection(System.Collections.Generic.Dictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(Dictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public abstract partial class EqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>, System.Collections.IEqualityComparer
+
+    public abstract partial class EqualityComparer<T> : IEqualityComparer<T>, IEqualityComparer
     {
-        protected EqualityComparer() { }
-        public static System.Collections.Generic.EqualityComparer<T> Default { get { throw null; } }
+        public static EqualityComparer<T> Default { get { throw null; } }
+
         public abstract bool Equals(T x, T y);
         public abstract int GetHashCode(T obj);
-        bool System.Collections.IEqualityComparer.Equals(object x, object y) { throw null; }
-        int System.Collections.IEqualityComparer.GetHashCode(object obj) { throw null; }
+        bool IEqualityComparer.Equals(object x, object y) { throw null; }
+
+        int IEqualityComparer.GetHashCode(object obj) { throw null; }
     }
-    public partial class HashSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.IEnumerable
+
+    public partial class HashSet<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ISet<T>
     {
         public HashSet() { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public HashSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public HashSet(System.Collections.Generic.IEqualityComparer<T> comparer) { }
-        public System.Collections.Generic.IEqualityComparer<T> Comparer { get { throw null; } }
+
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer) { }
+
+        public HashSet(IEnumerable<T> collection) { }
+
+        public HashSet(IEqualityComparer<T> comparer) { }
+
+        public IEqualityComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int arrayIndex) { }
+
         public void CopyTo(T[] array, int arrayIndex, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.HashSet<T>.Enumerator GetEnumerator() { throw null; }
-        public void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int arrayIndex) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
+
     public sealed partial class LinkedListNode<T>
     {
         public LinkedListNode(T value) { }
-        public System.Collections.Generic.LinkedList<T> List { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Next { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Previous { get { throw null; } }
+
+        public LinkedList<T> List { get { throw null; } }
+
+        public LinkedListNode<T> Next { get { throw null; } }
+
+        public LinkedListNode<T> Previous { get { throw null; } }
+
         public T Value { get { throw null; } set { } }
     }
-    public partial class LinkedList<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class LinkedList<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public LinkedList() { }
-        public LinkedList(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public LinkedList(IEnumerable<T> collection) { }
+
         public int Count { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> First { get { throw null; } }
-        public System.Collections.Generic.LinkedListNode<T> Last { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        public void AddAfter(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddAfter(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddBefore(System.Collections.Generic.LinkedListNode<T> node, System.Collections.Generic.LinkedListNode<T> newNode) { }
-        public System.Collections.Generic.LinkedListNode<T> AddBefore(System.Collections.Generic.LinkedListNode<T> node, T value) { throw null; }
-        public void AddFirst(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddFirst(T value) { throw null; }
-        public void AddLast(System.Collections.Generic.LinkedListNode<T> node) { }
-        public System.Collections.Generic.LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public LinkedListNode<T> First { get { throw null; } }
+
+        public LinkedListNode<T> Last { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        public LinkedListNode<T> AddAfter(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddAfter(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddBefore(LinkedListNode<T> node, T value) { throw null; }
+
+        public void AddBefore(LinkedListNode<T> node, LinkedListNode<T> newNode) { }
+
+        public LinkedListNode<T> AddFirst(T value) { throw null; }
+
+        public void AddFirst(LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> AddLast(T value) { throw null; }
+
+        public void AddLast(LinkedListNode<T> node) { }
+
         public void Clear() { }
+
         public bool Contains(T value) { throw null; }
+
         public void CopyTo(T[] array, int index) { }
-        public System.Collections.Generic.LinkedListNode<T> Find(T value) { throw null; }
-        public System.Collections.Generic.LinkedListNode<T> FindLast(T value) { throw null; }
-        public System.Collections.Generic.LinkedList<T>.Enumerator GetEnumerator() { throw null; }
-        public void Remove(System.Collections.Generic.LinkedListNode<T> node) { }
+
+        public LinkedListNode<T> Find(T value) { throw null; }
+
+        public LinkedListNode<T> FindLast(T value) { throw null; }
+
+        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(T value) { throw null; }
+
+        public void Remove(LinkedListNode<T> node) { }
+
         public void RemoveFirst() { }
+
         public void RemoveLast() { }
-        void System.Collections.Generic.ICollection<T>.Add(T value) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        void ICollection<T>.Add(T value) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class List<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IList<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
+
+    public partial class List<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IList<T>, IReadOnlyCollection<T>, IReadOnlyList<T>, ICollection, IList
     {
         public List() { }
-        public List(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public List(IEnumerable<T> collection) { }
+
         public List(int capacity) { }
+
         public int Capacity { get { throw null; } set { } }
+
         public int Count { get { throw null; } }
+
         public T this[int index] { get { throw null; } set { } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IList.IsFixedSize { get { throw null; } }
-        bool System.Collections.IList.IsReadOnly { get { throw null; } }
-        object System.Collections.IList.this[int index] { get { throw null; } set { } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IList.IsFixedSize { get { throw null; } }
+
+        bool IList.IsReadOnly { get { throw null; } }
+
+        object IList.this[int index] { get { throw null; } set { } }
+
         public void Add(T item) { }
-        public void AddRange(System.Collections.Generic.IEnumerable<T> collection) { }
-        public System.Collections.ObjectModel.ReadOnlyCollection<T> AsReadOnly() { throw null; }
-        public int BinarySearch(int index, int count, T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public void AddRange(IEnumerable<T> collection) { }
+
+        public ObjectModel.ReadOnlyCollection<T> AsReadOnly() { throw null; }
+
+        public int BinarySearch(T item, IComparer<T> comparer) { throw null; }
+
         public int BinarySearch(T item) { throw null; }
-        public int BinarySearch(T item, System.Collections.Generic.IComparer<T> comparer) { throw null; }
+
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer) { throw null; }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
-        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
-        public void CopyTo(T[] array) { }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Exists(System.Predicate<T> match) { throw null; }
-        public T Find(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.List<T> FindAll(System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindIndex(System.Predicate<T> match) { throw null; }
-        public T FindLast(System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, int count, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(int startIndex, System.Predicate<T> match) { throw null; }
-        public int FindLastIndex(System.Predicate<T> match) { throw null; }
-        public void ForEach(System.Action<T> action) { }
-        public System.Collections.Generic.List<T>.Enumerator GetEnumerator() { throw null; }
-        public System.Collections.Generic.List<T> GetRange(int index, int count) { throw null; }
-        public int IndexOf(T item) { throw null; }
-        public int IndexOf(T item, int index) { throw null; }
+
+        public void CopyTo(T[] array) { }
+
+        public void CopyTo(int index, T[] array, int arrayIndex, int count) { }
+
+        public bool Exists(Predicate<T> match) { throw null; }
+
+        public T Find(Predicate<T> match) { throw null; }
+
+        public List<T> FindAll(Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindIndex(Predicate<T> match) { throw null; }
+
+        public T FindLast(Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match) { throw null; }
+
+        public int FindLastIndex(Predicate<T> match) { throw null; }
+
+        public void ForEach(Action<T> action) { }
+
+        public List<T>.Enumerator GetEnumerator() { throw null; }
+
+        public List<T> GetRange(int index, int count) { throw null; }
+
         public int IndexOf(T item, int index, int count) { throw null; }
+
+        public int IndexOf(T item, int index) { throw null; }
+
+        public int IndexOf(T item) { throw null; }
+
         public void Insert(int index, T item) { }
-        public void InsertRange(int index, System.Collections.Generic.IEnumerable<T> collection) { }
-        public int LastIndexOf(T item) { throw null; }
-        public int LastIndexOf(T item, int index) { throw null; }
+
+        public void InsertRange(int index, IEnumerable<T> collection) { }
+
         public int LastIndexOf(T item, int index, int count) { throw null; }
+
+        public int LastIndexOf(T item, int index) { throw null; }
+
+        public int LastIndexOf(T item) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveAll(System.Predicate<T> match) { throw null; }
+
+        public int RemoveAll(Predicate<T> match) { throw null; }
+
         public void RemoveAt(int index) { }
+
         public void RemoveRange(int index, int count) { }
+
         public void Reverse() { }
+
         public void Reverse(int index, int count) { }
+
         public void Sort() { }
-        public void Sort(System.Collections.Generic.IComparer<T> comparer) { }
-        public void Sort(System.Comparison<T> comparison) { }
-        public void Sort(int index, int count, System.Collections.Generic.IComparer<T> comparer) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        int System.Collections.IList.Add(object item) { throw null; }
-        bool System.Collections.IList.Contains(object item) { throw null; }
-        int System.Collections.IList.IndexOf(object item) { throw null; }
-        void System.Collections.IList.Insert(int index, object item) { }
-        void System.Collections.IList.Remove(object item) { }
+
+        public void Sort(IComparer<T> comparer) { }
+
+        public void Sort(Comparison<T> comparison) { }
+
+        public void Sort(int index, int count, IComparer<T> comparer) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        int IList.Add(object item) { throw null; }
+
+        bool IList.Contains(object item) { throw null; }
+
+        int IList.IndexOf(object item) { throw null; }
+
+        void IList.Insert(int index, object item) { }
+
+        void IList.Remove(object item) { }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public bool TrueForAll(System.Predicate<T> match) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public bool TrueForAll(Predicate<T> match) { throw null; }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Queue<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Queue<T> : IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public Queue() { }
-        public Queue(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Queue(IEnumerable<T> collection) { }
+
         public Queue(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
+
         public T Dequeue() { throw null; }
+
         public void Enqueue(T item) { }
-        public System.Collections.Generic.Queue<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class SortedDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedDictionary<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public SortedDictionary() { }
-        public SortedDictionary(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public SortedDictionary(IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary) { }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public void CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int index) { }
-        public System.Collections.Generic.SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
+
+        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+
         public bool Remove(TKey key) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IEnumerator, IDisposable, IDictionaryEnumerator
         {
-            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get { throw null; } }
-            System.Collections.DictionaryEntry System.Collections.IDictionaryEnumerator.Entry { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Key { get { throw null; } }
-            object System.Collections.IDictionaryEnumerator.Value { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public KeyValuePair<TKey, TValue> Current { get { throw null; } }
+
+            DictionaryEntry IDictionaryEnumerator.Entry { get { throw null; } }
+
+            object IDictionaryEnumerator.Key { get { throw null; } }
+
+            object IDictionaryEnumerator.Value { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
-        public sealed partial class KeyCollection : System.Collections.Generic.ICollection<TKey>, System.Collections.Generic.IEnumerable<TKey>, System.Collections.Generic.IReadOnlyCollection<TKey>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class KeyCollection : ICollection<TKey>, IEnumerable<TKey>, IEnumerable, IReadOnlyCollection<TKey>, ICollection
         {
-            public KeyCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public KeyCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TKey>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TKey>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TKey[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TKey>.Add(TKey item) { }
-            void System.Collections.Generic.ICollection<TKey>.Clear() { }
-            bool System.Collections.Generic.ICollection<TKey>.Contains(TKey item) { throw null; }
-            bool System.Collections.Generic.ICollection<TKey>.Remove(TKey item) { throw null; }
-            System.Collections.Generic.IEnumerator<TKey> System.Collections.Generic.IEnumerable<TKey>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TKey>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TKey>.Add(TKey item) { }
+
+            void ICollection<TKey>.Clear() { }
+
+            bool ICollection<TKey>.Contains(TKey item) { throw null; }
+
+            bool ICollection<TKey>.Remove(TKey item) { throw null; }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TKey>, IEnumerator, IDisposable
             {
                 public TKey Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
-        public sealed partial class ValueCollection : System.Collections.Generic.ICollection<TValue>, System.Collections.Generic.IEnumerable<TValue>, System.Collections.Generic.IReadOnlyCollection<TValue>, System.Collections.ICollection, System.Collections.IEnumerable
+
+        public sealed partial class ValueCollection : ICollection<TValue>, IEnumerable<TValue>, IEnumerable, IReadOnlyCollection<TValue>, ICollection
         {
-            public ValueCollection(System.Collections.Generic.SortedDictionary<TKey, TValue> dictionary) { }
+            public ValueCollection(SortedDictionary<TKey, TValue> dictionary) { }
+
             public int Count { get { throw null; } }
-            bool System.Collections.Generic.ICollection<TValue>.IsReadOnly { get { throw null; } }
-            bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-            object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+            bool ICollection<TValue>.IsReadOnly { get { throw null; } }
+
+            bool ICollection.IsSynchronized { get { throw null; } }
+
+            object ICollection.SyncRoot { get { throw null; } }
+
             public void CopyTo(TValue[] array, int index) { }
-            public System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
-            void System.Collections.Generic.ICollection<TValue>.Add(TValue item) { }
-            void System.Collections.Generic.ICollection<TValue>.Clear() { }
-            bool System.Collections.Generic.ICollection<TValue>.Contains(TValue item) { throw null; }
-            bool System.Collections.Generic.ICollection<TValue>.Remove(TValue item) { throw null; }
-            System.Collections.Generic.IEnumerator<TValue> System.Collections.Generic.IEnumerable<TValue>.GetEnumerator() { throw null; }
-            void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-            public partial struct Enumerator : System.Collections.Generic.IEnumerator<TValue>, System.Collections.IEnumerator, System.IDisposable
+
+            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+
+            void ICollection<TValue>.Add(TValue item) { }
+
+            void ICollection<TValue>.Clear() { }
+
+            bool ICollection<TValue>.Contains(TValue item) { throw null; }
+
+            bool ICollection<TValue>.Remove(TValue item) { throw null; }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() { throw null; }
+
+            void ICollection.CopyTo(Array array, int index) { }
+
+            IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+            public partial struct Enumerator : IEnumerator<TValue>, IEnumerator, IDisposable
             {
                 public TValue Current { get { throw null; } }
-                object System.Collections.IEnumerator.Current { get { throw null; } }
+
+                object IEnumerator.Current { get { throw null; } }
+
                 public void Dispose() { }
+
                 public bool MoveNext() { throw null; }
-                void System.Collections.IEnumerator.Reset() { }
+
+                void IEnumerator.Reset() { }
             }
         }
     }
-    public partial class SortedList<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable
+
+    public partial class SortedList<TKey, TValue> : ICollection<KeyValuePair<TKey, TValue>>, IEnumerable<KeyValuePair<TKey, TValue>>, IEnumerable, IDictionary<TKey, TValue>, IReadOnlyCollection<KeyValuePair<TKey, TValue>>, IReadOnlyDictionary<TKey, TValue>, ICollection, IDictionary
     {
         public SortedList() { }
-        public SortedList(System.Collections.Generic.IComparer<TKey> comparer) { }
-        public SortedList(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
-        public SortedList(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IComparer<TKey> comparer) { }
+
+        public SortedList(IComparer<TKey> comparer) { }
+
+        public SortedList(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer) { }
+
+        public SortedList(IDictionary<TKey, TValue> dictionary) { }
+
+        public SortedList(int capacity, IComparer<TKey> comparer) { }
+
         public SortedList(int capacity) { }
-        public SortedList(int capacity, System.Collections.Generic.IComparer<TKey> comparer) { }
+
         public int Capacity { get { throw null; } set { } }
-        public System.Collections.Generic.IComparer<TKey> Comparer { get { throw null; } }
+
+        public IComparer<TKey> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public TValue this[TKey key] { get { throw null; } set { } }
-        public System.Collections.Generic.IList<TKey> Keys { get { throw null; } }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.IsReadOnly { get { throw null; } }
-        System.Collections.Generic.ICollection<TKey> System.Collections.Generic.IDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.ICollection<TValue> System.Collections.Generic.IDictionary<TKey,TValue>.Values { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TKey> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Keys { get { throw null; } }
-        System.Collections.Generic.IEnumerable<TValue> System.Collections.Generic.IReadOnlyDictionary<TKey,TValue>.Values { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
-        bool System.Collections.IDictionary.IsFixedSize { get { throw null; } }
-        bool System.Collections.IDictionary.IsReadOnly { get { throw null; } }
-        object System.Collections.IDictionary.this[object key] { get { throw null; } set { } }
-        System.Collections.ICollection System.Collections.IDictionary.Keys { get { throw null; } }
-        System.Collections.ICollection System.Collections.IDictionary.Values { get { throw null; } }
-        public System.Collections.Generic.IList<TValue> Values { get { throw null; } }
+
+        public IList<TKey> Keys { get { throw null; } }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { throw null; } }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
+        bool IDictionary.IsFixedSize { get { throw null; } }
+
+        bool IDictionary.IsReadOnly { get { throw null; } }
+
+        object IDictionary.this[object key] { get { throw null; } set { } }
+
+        ICollection IDictionary.Keys { get { throw null; } }
+
+        ICollection IDictionary.Values { get { throw null; } }
+
+        public IList<TValue> Values { get { throw null; } }
+
         public void Add(TKey key, TValue value) { }
+
         public void Clear() { }
+
         public bool ContainsKey(TKey key) { throw null; }
+
         public bool ContainsValue(TValue value) { throw null; }
-        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() { throw null; }
+
         public int IndexOfKey(TKey key) { throw null; }
+
         public int IndexOfValue(TValue value) { throw null; }
+
         public bool Remove(TKey key) { throw null; }
+
         public void RemoveAt(int index) { }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        void System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
-        bool System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
-        System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        void System.Collections.IDictionary.Add(object key, object value) { }
-        bool System.Collections.IDictionary.Contains(object key) { throw null; }
-        System.Collections.IDictionaryEnumerator System.Collections.IDictionary.GetEnumerator() { throw null; }
-        void System.Collections.IDictionary.Remove(object key) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) { }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair) { throw null; }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        void IDictionary.Add(object key, object value) { }
+
+        bool IDictionary.Contains(object key) { throw null; }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() { throw null; }
+
+        void IDictionary.Remove(object key) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public void TrimExcess() { }
+
         public bool TryGetValue(TKey key, out TValue value) { throw null; }
     }
-    public partial class SortedSet<T> : System.Collections.Generic.ICollection<T>, System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.ISet<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class SortedSet<T> : ICollection<T>, IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ISet<T>, ICollection
     {
         public SortedSet() { }
-        public SortedSet(System.Collections.Generic.IComparer<T> comparer) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection) { }
-        public SortedSet(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IComparer<T> comparer) { }
-        public System.Collections.Generic.IComparer<T> Comparer { get { throw null; } }
+
+        public SortedSet(IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection, IComparer<T> comparer) { }
+
+        public SortedSet(IEnumerable<T> collection) { }
+
+        public IComparer<T> Comparer { get { throw null; } }
+
         public int Count { get { throw null; } }
+
         public T Max { get { throw null; } }
+
         public T Min { get { throw null; } }
-        bool System.Collections.Generic.ICollection<T>.IsReadOnly { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection<T>.IsReadOnly { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public bool Add(T item) { throw null; }
+
         public virtual void Clear() { }
+
         public virtual bool Contains(T item) { throw null; }
-        public void CopyTo(T[] array) { }
-        public void CopyTo(T[] array, int index) { }
+
         public void CopyTo(T[] array, int index, int count) { }
-        public void ExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public System.Collections.Generic.SortedSet<T>.Enumerator GetEnumerator() { throw null; }
-        public virtual System.Collections.Generic.SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
-        public virtual void IntersectWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public bool IsProperSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsProperSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSubsetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool IsSupersetOf(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public bool Overlaps(System.Collections.Generic.IEnumerable<T> other) { throw null; }
+
+        public void CopyTo(T[] array, int index) { }
+
+        public void CopyTo(T[] array) { }
+
+        public void ExceptWith(IEnumerable<T> other) { }
+
+        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+
+        public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
+
+        public virtual void IntersectWith(IEnumerable<T> other) { }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSubsetOf(IEnumerable<T> other) { throw null; }
+
+        public bool IsSupersetOf(IEnumerable<T> other) { throw null; }
+
+        public bool Overlaps(IEnumerable<T> other) { throw null; }
+
         public bool Remove(T item) { throw null; }
-        public int RemoveWhere(System.Predicate<T> match) { throw null; }
-        public System.Collections.Generic.IEnumerable<T> Reverse() { throw null; }
-        public bool SetEquals(System.Collections.Generic.IEnumerable<T> other) { throw null; }
-        public void SymmetricExceptWith(System.Collections.Generic.IEnumerable<T> other) { }
-        void System.Collections.Generic.ICollection<T>.Add(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int index) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
-        public void UnionWith(System.Collections.Generic.IEnumerable<T> other) { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public int RemoveWhere(Predicate<T> match) { throw null; }
+
+        public IEnumerable<T> Reverse() { throw null; }
+
+        public bool SetEquals(IEnumerable<T> other) { throw null; }
+
+        public void SymmetricExceptWith(IEnumerable<T> other) { }
+
+        void ICollection<T>.Add(T item) { }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int index) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
+        public void UnionWith(IEnumerable<T> other) { }
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
-    public partial class Stack<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.ICollection, System.Collections.IEnumerable
+
+    public partial class Stack<T> : IEnumerable<T>, IEnumerable, IReadOnlyCollection<T>, ICollection
     {
         public Stack() { }
-        public Stack(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public Stack(IEnumerable<T> collection) { }
+
         public Stack(int capacity) { }
+
         public int Count { get { throw null; } }
-        bool System.Collections.ICollection.IsSynchronized { get { throw null; } }
-        object System.Collections.ICollection.SyncRoot { get { throw null; } }
+
+        bool ICollection.IsSynchronized { get { throw null; } }
+
+        object ICollection.SyncRoot { get { throw null; } }
+
         public void Clear() { }
+
         public bool Contains(T item) { throw null; }
+
         public void CopyTo(T[] array, int arrayIndex) { }
-        public System.Collections.Generic.Stack<T>.Enumerator GetEnumerator() { throw null; }
+
+        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+
         public T Peek() { throw null; }
+
         public T Pop() { throw null; }
+
         public void Push(T item) { }
-        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
-        void System.Collections.ICollection.CopyTo(System.Array array, int arrayIndex) { }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { throw null; }
+
+        void ICollection.CopyTo(Array array, int arrayIndex) { }
+
+        IEnumerator IEnumerable.GetEnumerator() { throw null; }
+
         public T[] ToArray() { throw null; }
+
         public void TrimExcess() { }
-        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+
+        public partial struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable
         {
             public T Current { get { throw null; } }
-            object System.Collections.IEnumerator.Current { get { throw null; } }
+
+            object IEnumerator.Current { get { throw null; } }
+
             public void Dispose() { }
+
             public bool MoveNext() { throw null; }
-            void System.Collections.IEnumerator.Reset() { }
+
+            void IEnumerator.Reset() { }
         }
     }
 }

--- a/src/referencePackages/src/system.collections/4.3.0/system.collections.nuspec
+++ b/src/referencePackages/src/system.collections/4.3.0/system.collections.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>System.Collections</id>
@@ -28,13 +28,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
     <serviceable>true</serviceable>
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
-      <group targetFramework="MonoTouch1.0" />
-      <group targetFramework=".NETCore5.0">
-        <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
-        <dependency id="Microsoft.NETCore.Targets" version="1.1.0" />
-        <dependency id="System.Runtime" version="4.3.0" />
-      </group>
       <group targetFramework=".NETStandard1.0">
         <dependency id="Microsoft.NETCore.Platforms" version="1.1.0" />
         <dependency id="Microsoft.NETCore.Targets" version="1.1.0" />
@@ -45,14 +38,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.NETCore.Targets" version="1.1.0" />
         <dependency id="System.Runtime" version="4.3.0" />
       </group>
-      <group targetFramework=".NETPortable0.0-Profile259" />
-      <group targetFramework="Windows8.0" />
-      <group targetFramework="WindowsPhone8.0" />
-      <group targetFramework="WindowsPhoneApp8.1" />
-      <group targetFramework="Xamarin.iOS1.0" />
-      <group targetFramework="Xamarin.Mac2.0" />
-      <group targetFramework="Xamarin.TVOS1.0" />
-      <group targetFramework="Xamarin.WatchOS1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/referencePackages/src/system.collections/Directory.Build.props
+++ b/src/referencePackages/src/system.collections/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
-
-  <PropertyGroup>
-    <AssemblyName>System.Collections</AssemblyName>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3459

Regenerated the following packages:

- System.Collections.Specialized.4.3.0
- System.Collections.NonGeneric.4.3.0
- System.Collections.Immutable.1.2.0
- System.Collections.Immutable.1.3.0
- System.Collections.Immutable.1.3.1
- System.Collections.Concurrent.4.0.12
- System.Collections.Concurrent.4.3.0
- System.Collections.Immutable.1.5.0
- System.Collections.Immutable.5.0.0
- System.Collections.4.0.11
- System.Collections.4.3.0