### PR TITLE
Update repo's referenced NuGet version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
     <!-- NuGet dependencies -->
-    <NuGetPackagingVersion>6.4.0</NuGetPackagingVersion>
+    <NuGetPackagingVersion>6.7.0</NuGetPackagingVersion>
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>


### PR DESCRIPTION
The repo currently reference NuGet version 6.4.0 which is a vulnerable version. More specifically, this version is used by the PackageSourceGeneratorTask project. This is causing a component governance alert. Updating this to the latest NuGet version.