### PR TITLE
Add dotnet9 package feeds and fix tests

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,8 @@
     <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/tests/GenerateScriptTests/GenerateScriptTests.cs
+++ b/tests/GenerateScriptTests/GenerateScriptTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/tests/GenerateScriptTests/GenerateScriptTests.cs
+++ b/tests/GenerateScriptTests/GenerateScriptTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -59,7 +60,7 @@ public class GenerateScriptTests
                 break;
         }
 
-        ExecuteHelper.ExecuteProcess(command, arguments, output);
+        ExecuteHelper.ExecuteProcessValidateExitCode(command, arguments, output);
         Assert.Empty(ExecuteHelper.ExecuteProcess("git", $"diff --no-index {packageSrcDirectory} {sandboxPackageGeneratedDirecotry}", output, true).StdOut);
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/source-build-reference-packages/pull/803 was the first flow from .NET 9.0.  This broke the generate tooling because the dotnet9 package feeds were missing from the nuget.config.  The generate tests failed to catch this however because of a bug in the tests where the exit code was not validated. 