### PR TITLE
Update Newtonsoft 13.0.1 referenced to 13.0.3

### DIFF
--- a/src/referencePackages/src/microsoft.extensions.dependencymodel/3.0.0/Microsoft.Extensions.DependencyModel.3.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.dependencymodel/3.0.0/Microsoft.Extensions.DependencyModel.3.0.0.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <!-- Manually updated version from 9.0.1 to address https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.AppContext" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
@@ -20,7 +20,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <!-- Manually updated version from 9.0.1 to address https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.AppContext" Version="4.1.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />

--- a/src/referencePackages/src/nuget.packaging/6.2.4/NuGet.Packaging.6.2.4.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.2.4/NuGet.Packaging.6.2.4.csproj
@@ -10,7 +10,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.2.4" />
     <PackageReference Include="NuGet.Versioning" Version="6.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
   </ItemGroup>
@@ -18,7 +19,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.2.4" />
     <PackageReference Include="NuGet.Versioning" Version="6.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
   </ItemGroup>

--- a/src/referencePackages/src/nuget.packaging/6.6.1/NuGet.Packaging.6.6.1.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.6.1/NuGet.Packaging.6.6.1.csproj
@@ -10,7 +10,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.6.1" />
     <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
   </ItemGroup>
@@ -18,7 +19,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.6.1" />
     <PackageReference Include="NuGet.Versioning" Version="6.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.0" />
   </ItemGroup>

--- a/src/referencePackages/src/nuget.packaging/6.7.0/NuGet.Packaging.6.7.0.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.7.0/NuGet.Packaging.6.7.0.csproj
@@ -10,14 +10,16 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.7.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NuGet.Configuration" Version="6.7.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- Manual updated version from 13.0.1 to the version included in source-build -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Newtonsoft 13.0.1 referenced to 13.0.3 to prevent online only prebuilts.  This is fallout from https://github.com/dotnet/source-build-externals/pull/195.