### PR TITLE
Refactor test output to make diagnosing failures easier

### DIFF
--- a/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Build.NoTargets</AssemblyName>
+    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.Build.NoTargets</AssemblyName>
-    <ProjectTemplateVersion>2</ProjectTemplateVersion>
   </PropertyGroup>
 
 </Project>

--- a/tests/GenerateScriptTests/GenerateScriptTests.cs
+++ b/tests/GenerateScriptTests/GenerateScriptTests.cs
@@ -64,7 +64,7 @@ public class GenerateScriptTests
         string diff = ExecuteHelper.ExecuteProcess("git", $"diff --no-index {pkgSrcDirectory} {pkgSandboxDirectory}", output, true).StdOut;
         if (diff != string.Empty)
         {
-            Assert.Fail($"{Environment.NewLine}Regenerated package '{package}' does not match the checked-in content.  {Environment.NewLine}"
+            Assert.Fail($"Regenerated package '{package}' does not match the checked-in content.  {Environment.NewLine}"
                     + $"{diff}{Environment.NewLine}");
         }
     }

--- a/tests/GenerateScriptTests/GenerateScriptTests.cs
+++ b/tests/GenerateScriptTests/GenerateScriptTests.cs
@@ -45,29 +45,27 @@ public class GenerateScriptTests
     {
         string command = Path.Combine(RepoRoot, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "generate.cmd" : "generate.sh");
         string arguments = $"-p {package},{version} -x -d {SandboxDirectory}";
-        string packageSrcDirectory = string.Empty;
-        string sandboxPackageGeneratedDirectory = Path.Combine(SandboxDirectory, package.ToLower(), version);
+        string pkgSrcDirectory = string.Empty;
+        string pkgSandboxDirectory = Path.Combine(SandboxDirectory, package.ToLower(), version);
 
         switch (type)
         {
             case PackageType.Reference:
-                packageSrcDirectory = Path.Combine(RepoRoot, "src", "referencePackages", "src", package.ToLower(), version);
+                pkgSrcDirectory = Path.Combine(RepoRoot, "src", "referencePackages", "src", package.ToLower(), version);
                 break;
             case PackageType.Text:
                 arguments += " -t text";
-                packageSrcDirectory = Path.Combine(RepoRoot, "src", "textOnlyPackages", "src", package.ToLower(), version);
+                pkgSrcDirectory = Path.Combine(RepoRoot, "src", "textOnlyPackages", "src", package.ToLower(), version);
                 break;
         }
 
         ExecuteHelper.ExecuteProcessValidateExitCode(command, arguments, output);
 
-        string diff = ExecuteHelper.ExecuteProcess("git", $"diff --no-index {packageSrcDirectory} {sandboxPackageGeneratedDirectory}", output, true).StdOut;
+        string diff = ExecuteHelper.ExecuteProcess("git", $"diff --no-index {pkgSrcDirectory} {pkgSandboxDirectory}", output, true).StdOut;
         if (diff != string.Empty)
         {
-            string message = $"{Environment.NewLine}Regenerated package '{package}' does not match the checked-in content.  {Environment.NewLine}"
-                    + $"{diff}{Environment.NewLine}";
-
-            Assert.Fail(message);
+            Assert.Fail($"{Environment.NewLine}Regenerated package '{package}' does not match the checked-in content.  {Environment.NewLine}"
+                    + $"{diff}{Environment.NewLine}");
         }
     }
 }

--- a/tests/GenerateScriptTests/GenerateScriptTests.cs
+++ b/tests/GenerateScriptTests/GenerateScriptTests.cs
@@ -46,7 +46,7 @@ public class GenerateScriptTests
         string command = Path.Combine(RepoRoot, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "generate.cmd" : "generate.sh");
         string arguments = $"-p {package},{version} -x -d {SandboxDirectory}";
         string packageSrcDirectory = string.Empty;
-        string sandboxPackageGeneratedDirecotry = Path.Combine(SandboxDirectory, package.ToLower(), version);
+        string sandboxPackageGeneratedDirectory = Path.Combine(SandboxDirectory, package.ToLower(), version);
 
         switch (type)
         {
@@ -60,6 +60,14 @@ public class GenerateScriptTests
         }
 
         ExecuteHelper.ExecuteProcessValidateExitCode(command, arguments, output);
-        Assert.Empty(ExecuteHelper.ExecuteProcess("git", $"diff --no-index {packageSrcDirectory} {sandboxPackageGeneratedDirecotry}", output, true).StdOut);
+
+        string diff = ExecuteHelper.ExecuteProcess("git", $"diff --no-index {packageSrcDirectory} {sandboxPackageGeneratedDirectory}", output, true).StdOut;
+        if (diff != string.Empty)
+        {
+            string message = $"{Environment.NewLine}Regenerated package '{package}' does not match the checked-in content.  {Environment.NewLine}"
+                    + $"{diff}{Environment.NewLine}";
+
+            Assert.Fail(message);
+        }
     }
 }


### PR DESCRIPTION
This improves the UX so a failure message is emitted clearly calling out the package that fails the diff.  In AZDO the best UX is to still look at the attachments tab because it properly renders the line endings.