### PR TITLE
Add NuGet 6.7.0 packages

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -34,6 +34,11 @@
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.FileProviders.Abstractions.6.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.FileSystemGlobbing.6.0.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.LibraryModel.6.7.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.DependencyResolver.Core.6.7.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.ProjectModel.6.7.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Commands.6.7.0.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/nuget.commands/6.7.0/NuGet.Commands.6.7.0.csproj
+++ b/src/referencePackages/src/nuget.commands/6.7.0/NuGet.Commands.6.7.0.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.Commands</AssemblyName>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.Credentials" Version="6.7.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Credentials" Version="6.7.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.commands/6.7.0/lib/net5.0/NuGet.Commands.cs
+++ b/src/referencePackages/src/nuget.commands/6.7.0/lib/net5.0/NuGet.Commands.cs
@@ -1,0 +1,1739 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.SolutionRestoreManager.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.PackageManagement.VisualStudio.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = ".NET 5.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Complete commands common to command-line and GUI NuGet clients.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Commands")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Commands
+{
+    public partial class AddClientCertArgs : IClientCertArgsWithPackageSource, IClientCertArgsWithConfigFile, IClientCertArgsWithFileData, IClientCertArgsWithStoreData, IClientCertArgsWithForce
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string FindBy { get { throw null; } set { } }
+
+        public string FindValue { get { throw null; } set { } }
+
+        public bool Force { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string StoreLocation { get { throw null; } set { } }
+
+        public string StoreName { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+    }
+
+    public static partial class AddClientCertRunner
+    {
+        public static void Run(AddClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class AddSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+
+        public string Username { get { throw null; } set { } }
+
+        public string ValidAuthenticationTypes { get { throw null; } set { } }
+    }
+
+    public static partial class AddSourceRunner
+    {
+        public static void Run(AddSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public static partial class AssetTargetFallbackUtility
+    {
+        public static readonly string AssetTargetFallback;
+        public static void ApplyFramework(ProjectModel.TargetFrameworkInformation targetFrameworkInfo, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback) { }
+
+        public static void EnsureValidFallback(System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback, string filePath) { }
+
+        public static Frameworks.NuGetFramework GetFallbackFramework(Frameworks.NuGetFramework projectFramework, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback) { throw null; }
+
+        public static Common.RestoreLogMessage GetInvalidFallbackCombinationMessage(string path) { throw null; }
+    }
+
+    public static partial class BuildAssetsUtils
+    {
+        public static readonly string[] MacroCandidates;
+        public const string PropsExtension = ".props";
+        public const string TargetsExtension = ".targets";
+        public static void AddNuGetProperties(System.Xml.Linq.XDocument doc, System.Collections.Generic.IEnumerable<string> packageFolders, string repositoryRoot, ProjectModel.ProjectStyle projectStyle, string assetsFilePath, bool success) { }
+
+        public static void AddNuGetPropertiesToFirstImport(System.Collections.Generic.IEnumerable<MSBuildOutputFile> files, System.Collections.Generic.IEnumerable<string> packageFolders, string repositoryRoot, ProjectModel.ProjectStyle projectStyle, string assetsFilePath, bool success) { }
+
+        public static System.Xml.Linq.XElement GenerateContentFilesItem(string path, ProjectModel.LockFileContentFile item, string packageId, string packageVersion) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateEmptyImportsFile() { throw null; }
+
+        public static System.Xml.Linq.XElement GenerateImport(string path) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateMSBuildFile(System.Collections.Generic.List<MSBuildRestoreItemGroup> groups, ProjectModel.ProjectStyle outputType) { throw null; }
+
+        public static System.Collections.Generic.List<MSBuildOutputFile> GenerateMultiTargetFailureFiles(string targetsPath, string propsPath, ProjectModel.ProjectStyle restoreType) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateMultiTargetFrameworkWarning() { throw null; }
+
+        public static System.Xml.Linq.XElement GenerateProperty(string propertyName, string content) { throw null; }
+
+        public static string GetLanguage(string nugetLanguage) { throw null; }
+
+        public static string GetMSBuildFilePath(ProjectModel.PackageSpec project, string extension) { throw null; }
+
+        public static string GetMSBuildFilePathForPackageReferenceStyleProject(ProjectModel.PackageSpec project, string extension) { throw null; }
+
+        public static System.Collections.Generic.List<MSBuildOutputFile> GetMSBuildOutputFiles(ProjectModel.PackageSpec project, ProjectModel.LockFile assetsFile, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> repositories, RestoreRequest request, string assetsFilePath, bool restoreSuccess, Common.ILogger log) { throw null; }
+
+        public static string GetPathWithMacros(string absolutePath, string repositoryRoot) { throw null; }
+
+        public static bool HasChanges(System.Xml.Linq.XDocument newFile, string path, Common.ILogger log) { throw null; }
+
+        public static System.Xml.Linq.XDocument ReadExisting(string path, Common.ILogger log) { throw null; }
+
+        public static void WriteFiles(System.Collections.Generic.IEnumerable<MSBuildOutputFile> files, Common.ILogger log) { }
+
+        public static void WriteXML(string path, System.Xml.Linq.XDocument doc) { }
+    }
+
+    public static partial class ClientCertArgsExtensions
+    {
+        public static System.Security.Cryptography.X509Certificates.X509FindType? GetFindBy(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static System.Security.Cryptography.X509Certificates.StoreLocation? GetStoreLocation(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static System.Security.Cryptography.X509Certificates.StoreName? GetStoreName(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static bool IsFileCertSettingsProvided(this IClientCertArgsWithFileData args) { throw null; }
+
+        public static bool IsPackageSourceSettingProvided(this IClientCertArgsWithPackageSource args) { throw null; }
+
+        public static bool IsStoreCertSettingsProvided(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static void Validate(this AddClientCertArgs args) { }
+
+        public static void Validate(this RemoveClientCertArgs args) { }
+
+        public static void Validate(this UpdateClientCertArgs args) { }
+    }
+
+    public partial class CommandException : System.Exception
+    {
+        public CommandException() { }
+
+        protected CommandException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+
+        public CommandException(string message, System.Exception exception) { }
+
+        public CommandException(string format, params object[] args) { }
+
+        public CommandException(string message) { }
+    }
+
+    public partial class CompatibilityCheckResult
+    {
+        public CompatibilityCheckResult(RestoreTargetGraph graph, System.Collections.Generic.IEnumerable<CompatibilityIssue> issues) { }
+
+        public RestoreTargetGraph Graph { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<CompatibilityIssue> Issues { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+    }
+
+    public partial class CompatibilityIssue : System.IEquatable<CompatibilityIssue>
+    {
+        internal CompatibilityIssue() { }
+
+        public string AssemblyName { get { throw null; } }
+
+        public System.Collections.Generic.List<Frameworks.FrameworkRuntimePair> AvailableFrameworkRuntimePairs { get { throw null; } }
+
+        public System.Collections.Generic.List<Frameworks.NuGetFramework> AvailableFrameworks { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Package { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public CompatibilityIssueType Type { get { throw null; } }
+
+        public bool Equals(CompatibilityIssue other) { throw null; }
+
+        public string Format() { throw null; }
+
+        public static CompatibilityIssue IncompatiblePackage(Packaging.Core.PackageIdentity referenceAssemblyPackage, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageFrameworks) { throw null; }
+
+        public static CompatibilityIssue IncompatiblePackageWithDotnetTool(Packaging.Core.PackageIdentity referenceAssemblyPackage) { throw null; }
+
+        public static CompatibilityIssue IncompatibleProject(Packaging.Core.PackageIdentity project, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> projectFrameworks) { throw null; }
+
+        public static CompatibilityIssue IncompatibleProjectType(Packaging.Core.PackageIdentity project) { throw null; }
+
+        public static CompatibilityIssue IncompatibleToolsPackage(Packaging.Core.PackageIdentity packageIdentity, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.HashSet<Frameworks.FrameworkRuntimePair> available) { throw null; }
+
+        public static CompatibilityIssue ReferenceAssemblyNotImplemented(string assemblyName, Packaging.Core.PackageIdentity referenceAssemblyPackage, Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public static CompatibilityIssue ToolsPackageWithExtraPackageTypes(Packaging.Core.PackageIdentity referenceAssemblyPackage) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum CompatibilityIssueType
+    {
+        ReferenceAssemblyNotImplemented = 0,
+        PackageIncompatible = 1,
+        ProjectIncompatible = 2,
+        PackageToolsAssetsIncompatible = 3,
+        ProjectWithIncorrectDependencyCount = 4,
+        IncompatiblePackageWithDotnetTool = 5,
+        ToolsPackageWithExtraPackageTypes = 6,
+        PackageTypeIncompatible = 7
+    }
+
+    public partial struct ContentMetadata
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string BuildAction { get { throw null; } set { } }
+
+        public string CopyToOutput { get { throw null; } set { } }
+
+        public string Flatten { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public string Target { get { throw null; } set { } }
+    }
+
+    public static partial class DeleteRunner
+    {
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, string packageId, string packageVersion, string source, string apiKey, bool nonInteractive, bool noServiceEndpoint, System.Func<string, bool> confirmFunc, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class DependencyGraphFileRequestProvider : IRestoreRequestProvider
+    {
+        public DependencyGraphFileRequestProvider(RestoreCommandProvidersCache providerCache) { }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(string inputPath, RestoreArgs restoreContext) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> Supports(string path) { throw null; }
+    }
+
+    public partial class DependencyGraphSpecRequestProvider : IPreLoadedRestoreRequestProvider
+    {
+        public DependencyGraphSpecRequestProvider(RestoreCommandProvidersCache providerCache, ProjectModel.DependencyGraphSpec dgFile, Configuration.ISettings settings) { }
+
+        public DependencyGraphSpecRequestProvider(RestoreCommandProvidersCache providerCache, ProjectModel.DependencyGraphSpec dgFile) { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<ProjectModel.ExternalProjectReference> GetExternalClosure(ProjectModel.DependencyGraphSpec dgFile, string projectNameToRestore) { throw null; }
+    }
+
+    public static partial class DiagnosticUtility
+    {
+        public static string FormatDependency(string id, Versioning.VersionRange range) { throw null; }
+
+        public static string FormatExpectedIdentity(string id, Versioning.VersionRange range) { throw null; }
+
+        public static string FormatGraphName(RestoreTargetGraph graph) { throw null; }
+
+        public static string FormatIdentity(LibraryModel.LibraryIdentity identity) { throw null; }
+
+        public static string GetMultiLineMessage(System.Collections.Generic.IEnumerable<string> lines) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> MergeOnTargetGraph(System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> messages) { throw null; }
+    }
+
+    public partial class DisableSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class DisableSourceRunner
+    {
+        public static void Run(DisableSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class DownloadDependencyResolutionResult
+    {
+        internal DownloadDependencyResolutionResult() { }
+
+        public System.Collections.Generic.IList<System.Tuple<LibraryModel.LibraryRange, DependencyResolver.RemoteMatch>> Dependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get { throw null; } }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get { throw null; } }
+
+        public static DownloadDependencyResolutionResult Create(Frameworks.NuGetFramework framework, System.Collections.Generic.IList<System.Tuple<LibraryModel.LibraryRange, DependencyResolver.RemoteMatch>> dependencies, System.Collections.Generic.IList<DependencyResolver.IRemoteDependencyProvider> remoteDependencyProviders) { throw null; }
+    }
+
+    public partial class EnableSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class EnableSourceRunner
+    {
+        public static void Run(EnableSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial interface IClientCertArgsWithConfigFile
+    {
+        string Configfile { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithFileData
+    {
+        string Password { get; set; }
+
+        string Path { get; set; }
+
+        bool StorePasswordInClearText { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithForce
+    {
+        bool Force { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithPackageSource
+    {
+        string PackageSource { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithStoreData
+    {
+        string FindBy { get; set; }
+
+        string FindValue { get; set; }
+
+        string StoreLocation { get; set; }
+
+        string StoreName { get; set; }
+    }
+
+    public partial interface IListCommandRunner
+    {
+        System.Threading.Tasks.Task ExecuteCommand(ListArgs listArgs);
+    }
+
+    public partial interface ILocalsCommandRunner
+    {
+        void ExecuteCommand(LocalsArgs localsArgs);
+    }
+
+    public partial interface IMSBuildItem
+    {
+        string Identity { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> Properties { get; }
+
+        string GetProperty(string property, bool trim);
+        string GetProperty(string property);
+    }
+
+    public partial class IndexedRestoreTargetGraph
+    {
+        internal IndexedRestoreTargetGraph() { }
+
+        public IRestoreTargetGraph Graph { get { throw null; } }
+
+        public static IndexedRestoreTargetGraph Create(IRestoreTargetGraph graph) { throw null; }
+
+        public DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> GetItemById(string id, LibraryModel.LibraryType libraryType) { throw null; }
+
+        public DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> GetItemById(string id) { throw null; }
+
+        public bool HasErrors(string id) { throw null; }
+    }
+
+    public partial interface IPreLoadedRestoreRequestProvider
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(RestoreArgs restoreContext);
+    }
+
+    public partial interface IProjectFactory
+    {
+        Common.ILogger Logger { get; set; }
+
+        Packaging.PackageBuilder CreateBuilder(string basePath, Versioning.NuGetVersion version, string suffix, bool buildIfNeeded, Packaging.PackageBuilder builder = null);
+        System.Collections.Generic.Dictionary<string, string> GetProjectProperties();
+        ProjectModel.WarningProperties GetWarningPropertiesForProject();
+        void SetIncludeSymbols(bool includeSymbols);
+    }
+
+    public partial interface IRestoreProgressReporter
+    {
+        void EndProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles);
+        void StartProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles);
+    }
+
+    public partial interface IRestoreRequestProvider
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(string inputPath, RestoreArgs restoreContext);
+        System.Threading.Tasks.Task<bool> Supports(string path);
+    }
+
+    public partial interface IRestoreResult
+    {
+        ProjectModel.LockFile LockFile { get; }
+
+        string LockFilePath { get; }
+
+        System.Collections.Generic.IEnumerable<MSBuildOutputFile> MSBuildOutputFiles { get; }
+
+        ProjectModel.LockFile PreviousLockFile { get; }
+
+        bool Success { get; }
+    }
+
+    public partial interface IRestoreTargetGraph
+    {
+        DependencyResolver.AnalyzeResult<DependencyResolver.RemoteResolveResult> AnalyzeResult { get; }
+
+        System.Collections.Generic.IEnumerable<ResolverConflict> Conflicts { get; }
+
+        Client.ManagedCodeConventions Conventions { get; }
+
+        System.Collections.Generic.ISet<DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult>> Flattened { get; }
+
+        Frameworks.NuGetFramework Framework { get; }
+
+        System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> Graphs { get; }
+
+        bool InConflict { get; }
+
+        System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.ISet<ResolvedDependencyKey> ResolvedDependencies { get; }
+
+        RuntimeModel.RuntimeGraph RuntimeGraph { get; }
+
+        string RuntimeIdentifier { get; }
+
+        string TargetGraphName { get; }
+
+        System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get; }
+    }
+
+    public partial interface ISignCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(SignArgs signArgs);
+    }
+
+    public partial interface ITrustedSignersCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs);
+    }
+
+    public partial interface IVerifyCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(VerifyArgs verifyArgs);
+    }
+
+    public partial class ListArgs
+    {
+        public ListArgs(System.Collections.Generic.IList<string> arguments, System.Collections.Generic.IList<Configuration.PackageSource> listEndpoints, Configuration.ISettings settings, Common.ILogger logger, Log printJustified, bool isDetailedl, string listCommandNoPackages, string listCommandLicenseUrl, string listCommandListNotSupported, bool allVersions, bool includeDelisted, bool prerelease, System.Threading.CancellationToken token) { }
+
+        public bool AllVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> Arguments { get { throw null; } }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public bool IncludeDelisted { get { throw null; } }
+
+        public bool IsDetailed { get { throw null; } }
+
+        public string ListCommandLicenseUrl { get { throw null; } }
+
+        public string ListCommandListNotSupported { get { throw null; } }
+
+        public string ListCommandNoPackages { get { throw null; } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> ListEndpoints { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public bool Prerelease { get { throw null; } }
+
+        public Log PrintJustified { get { throw null; } }
+
+        public Configuration.ISettings Settings { get { throw null; } }
+
+        public delegate void Log(int startIndex, string message);
+    }
+
+    public partial class ListClientCertArgs : IClientCertArgsWithConfigFile
+    {
+        public string Configfile { get { throw null; } set { } }
+    }
+
+    public static partial class ListClientCertRunner
+    {
+        public static void Run(ListClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class ListCommandRunner : IListCommandRunner
+    {
+        public System.Threading.Tasks.Task ExecuteCommand(ListArgs listArgs) { throw null; }
+    }
+
+    public partial class ListSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Format { get { throw null; } set { } }
+    }
+
+    public static partial class ListSourceRunner
+    {
+        public static void Run(ListSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class LocalsArgs
+    {
+        public LocalsArgs(System.Collections.Generic.IList<string> arguments, Configuration.ISettings settings, Log logInformation, Log logError, bool clear, bool list) { }
+
+        public System.Collections.Generic.IList<string> Arguments { get { throw null; } }
+
+        public bool Clear { get { throw null; } }
+
+        public bool List { get { throw null; } }
+
+        public Log LogError { get { throw null; } }
+
+        public Log LogInformation { get { throw null; } }
+
+        public Configuration.ISettings Settings { get { throw null; } }
+
+        public delegate void Log(string message);
+    }
+
+    public partial class LocalsCommandRunner : ILocalsCommandRunner
+    {
+        public void ExecuteCommand(LocalsArgs localsArgs) { }
+    }
+
+    public partial class LockFileBuilder
+    {
+        public LockFileBuilder(int lockFileVersion, Common.ILogger logger, System.Collections.Generic.Dictionary<RestoreTargetGraph, System.Collections.Generic.Dictionary<string, LibraryModel.LibraryIncludeFlags>> includeFlagGraphs) { }
+
+        public ProjectModel.LockFile CreateLockFile(ProjectModel.LockFile previousLockFile, ProjectModel.PackageSpec project, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> localRepositories, DependencyResolver.RemoteWalkContext context, LockFileBuilderCache lockFileBuilderCache) { throw null; }
+
+        [System.Obsolete("Use method with LockFileBuilderCache parameter")]
+        public ProjectModel.LockFile CreateLockFile(ProjectModel.LockFile previousLockFile, ProjectModel.PackageSpec project, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> localRepositories, DependencyResolver.RemoteWalkContext context) { throw null; }
+    }
+
+    public partial class LockFileBuilderCache
+    {
+        public ContentModel.ContentItemCollection GetContentItems(ProjectModel.LockFileLibrary library, Repositories.LocalPackageInfo package) { throw null; }
+
+        public System.Collections.Generic.List<System.Collections.Generic.List<ContentModel.SelectionCriteria>> GetSelectionCriteria(RestoreTargetGraph graph, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public static partial class LockFileUtils
+    {
+        public static readonly string LIBANY;
+        public static ProjectModel.LockFileTargetLibrary CreateLockFileTargetLibrary(ProjectModel.LockFileLibrary library, Repositories.LocalPackageInfo package, RestoreTargetGraph targetGraph, LibraryModel.LibraryIncludeFlags dependencyType) { throw null; }
+
+        public static ProjectModel.LockFileTargetLibrary CreateLockFileTargetProject(DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> graphItem, LibraryModel.LibraryIdentity library, LibraryModel.LibraryIncludeFlags dependencyType, RestoreTargetGraph targetGraph, ProjectModel.ProjectStyle rootProjectStyle) { throw null; }
+
+        public static void ExcludeItems(ProjectModel.LockFileTargetLibrary lockFileLib, LibraryModel.LibraryIncludeFlags dependencyType) { }
+
+        public static string ToDirectorySeparator(string path) { throw null; }
+    }
+
+    public partial class MSBuildItem : IMSBuildItem
+    {
+        public MSBuildItem(string identity, System.Collections.Generic.IDictionary<string, string> metadata) { }
+
+        public string Identity { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Properties { get { throw null; } }
+
+        public string GetProperty(string property, bool trim) { throw null; }
+
+        public string GetProperty(string property) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class MSBuildOutputFile
+    {
+        public MSBuildOutputFile(string path, System.Xml.Linq.XDocument content) { }
+
+        public System.Xml.Linq.XDocument Content { get { throw null; } }
+
+        public string Path { get { throw null; } }
+    }
+
+    public partial class MSBuildPackTargetArgs
+    {
+        public System.Collections.Generic.HashSet<string> AllowedOutputExtensionsInPackageBuildOutputFolder { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get { throw null; } set { } }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public string[] BuildOutputFolder { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<ContentMetadata>> ContentFiles { get { throw null; } set { } }
+
+        public bool IncludeBuildOutput { get { throw null; } set { } }
+
+        public string NuspecOutputPath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, string> SourceFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Frameworks.NuGetFramework> TargetFrameworks { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<OutputLibFile> TargetPathsToAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<OutputLibFile> TargetPathsToSymbols { get { throw null; } set { } }
+    }
+
+    public partial class MSBuildProjectFactory : IProjectFactory
+    {
+        public bool Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<Packaging.ManifestFile> Files { get { throw null; } set { } }
+
+        public bool IncludeSymbols { get { throw null; } set { } }
+
+        public bool IsTool { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> ProjectProperties { get { throw null; } }
+
+        public Packaging.PackageBuilder CreateBuilder(string basePath, Versioning.NuGetVersion version, string suffix, bool buildIfNeeded, Packaging.PackageBuilder builder) { throw null; }
+
+        public System.Collections.Generic.Dictionary<string, string> GetProjectProperties() { throw null; }
+
+        public static string GetTargetPathForSourceFile(string sourcePath, string projectDirectory) { throw null; }
+
+        public ProjectModel.WarningProperties GetWarningPropertiesForProject() { throw null; }
+
+        public static IProjectFactory ProjectCreator(PackArgs packArgs, string path) { throw null; }
+
+        public void SetIncludeSymbols(bool includeSymbols) { }
+    }
+
+    public static partial class MSBuildProjectFrameworkUtility
+    {
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion, string clrSupport, string windowsTargetPlatformMinVersion) { throw null; }
+
+        [System.Obsolete("If you need ClrSupport support parameter to be accounted for in the calculation, the method with the windowsTargetPlatformMinVersion is the only correct one.")]
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion, string clrSupport) { throw null; }
+
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion) { throw null; }
+
+        public static Frameworks.NuGetFramework GetProjectFrameworkReplacement(Frameworks.NuGetFramework framework) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetProjectFrameworks(System.Collections.Generic.IEnumerable<string> frameworkStrings) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetProjectFrameworkStrings(string projectFilePath, string targetFrameworks, string targetFramework, string targetFrameworkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion, bool isXnaWindowsPhoneProject, bool isManagementPackProject) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetProjectFrameworkStrings(string projectFilePath, string targetFrameworks, string targetFramework, string targetFrameworkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion) { throw null; }
+    }
+
+    public partial class MSBuildRestoreItemGroup
+    {
+        public static readonly string ImportGroup;
+        public static readonly string ItemGroup;
+        public string Condition { get { throw null; } }
+
+        public System.Collections.Generic.List<string> Conditions { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<System.Xml.Linq.XElement> Items { get { throw null; } set { } }
+
+        public int Position { get { throw null; } set { } }
+
+        public string RootName { get { throw null; } set { } }
+
+        public static MSBuildRestoreItemGroup Create(string rootName, System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> items, int position, System.Collections.Generic.IEnumerable<string> conditions) { throw null; }
+    }
+
+    public static partial class MSBuildRestoreUtility
+    {
+        public static readonly string Clear;
+        public static System.Collections.Generic.IEnumerable<string> AggregateSources(System.Collections.Generic.IEnumerable<string> values, System.Collections.Generic.IEnumerable<string> excludeValues) { throw null; }
+
+        public static void ApplyIncludeFlags(LibraryModel.LibraryDependency dependency, string includeAssets, string excludeAssets, string privateAssets) { }
+
+        public static void ApplyIncludeFlags(ProjectModel.ProjectRestoreReference dependency, string includeAssets, string excludeAssets, string privateAssets) { }
+
+        public static bool ContainsClearKeyword(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static void Dump(System.Collections.Generic.IEnumerable<IMSBuildItem> items, Common.ILogger log) { }
+
+        public static string FixSourcePath(string s) { throw null; }
+
+        public static ProjectModel.DependencyGraphSpec GetDependencySpec(System.Collections.Generic.IEnumerable<IMSBuildItem> items) { throw null; }
+
+        public static ProjectModel.PackageSpec GetPackageSpec(System.Collections.Generic.IEnumerable<IMSBuildItem> items) { throw null; }
+
+        public static ProjectModel.RestoreAuditProperties GetRestoreAuditProperties(IMSBuildItem specItem) { throw null; }
+
+        public static Common.RestoreLogMessage GetWarningForUnsupportedProject(string path) { throw null; }
+
+        public static bool HasInvalidClear(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static bool LogErrorForClearIfInvalid(System.Collections.Generic.IEnumerable<string> values, string projectPath, Common.ILogger logger) { throw null; }
+
+        public static void NormalizePathCasings(System.Collections.Generic.Dictionary<string, string> paths, ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static void NormalizePathCasings(System.Collections.Generic.IDictionary<string, string> paths, ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static void RemoveMissingProjects(ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static System.Threading.Tasks.Task ReplayWarningsAndErrorsAsync(System.Collections.Generic.IEnumerable<ProjectModel.IAssetsLogMessage> messages, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class NoOpRestoreResult : RestoreResult
+    {
+        public NoOpRestoreResult(bool success, string lockFilePath, System.Lazy<ProjectModel.LockFile> lockFileLazy, ProjectModel.CacheFile cacheFile, string cacheFilePath, ProjectModel.ProjectStyle projectStyle, System.TimeSpan elapsedTime) : base(default, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default, default) { }
+
+        public override ProjectModel.LockFile LockFile { get { throw null; } }
+
+        public override ProjectModel.LockFile PreviousLockFile { get { throw null; } }
+
+        public override System.Threading.Tasks.Task CommitAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.ISet<LibraryModel.LibraryIdentity> GetAllInstalled() { throw null; }
+    }
+
+    public static partial class NoOpRestoreUtilities
+    {
+        public static string GetProjectCacheFilePath(string cacheRoot, string projectPath) { throw null; }
+
+        public static string GetProjectCacheFilePath(string cacheRoot) { throw null; }
+    }
+
+    public partial class OriginalCaseGlobalPackageFolder
+    {
+        public OriginalCaseGlobalPackageFolder(RestoreRequest request, System.Guid parentId) { }
+
+        public OriginalCaseGlobalPackageFolder(RestoreRequest request) { }
+
+        public System.Guid ParentId { get { throw null; } }
+
+        public void ConvertLockFileToOriginalCase(ProjectModel.LockFile lockFile) { }
+
+        public System.Threading.Tasks.Task CopyPackagesToOriginalCaseAsync(System.Collections.Generic.IEnumerable<RestoreTargetGraph> graphs, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial struct OutputLibFile
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string FinalOutputPath { get { throw null; } set { } }
+
+        public string TargetFramework { get { throw null; } set { } }
+
+        public string TargetPath { get { throw null; } set { } }
+    }
+
+    public partial class PackagesLockFileBuilder
+    {
+        public ProjectModel.PackagesLockFile CreateNuGetLockFile(ProjectModel.LockFile assetsFile) { throw null; }
+    }
+
+    public static partial class PackageSourceProviderExtensions
+    {
+        public static string ResolveAndValidateSource(this Configuration.IPackageSourceProvider sourceProvider, string source) { throw null; }
+
+        public static Configuration.PackageSource ResolveSource(System.Collections.Generic.IEnumerable<Configuration.PackageSource> availableSources, string source) { throw null; }
+    }
+
+    public partial class PackageSpecificWarningProperties : System.IEquatable<PackageSpecificWarningProperties>
+    {
+        public System.Collections.Generic.IDictionary<Common.NuGetLogCode, System.Collections.Generic.IDictionary<string, System.Collections.Generic.ISet<Frameworks.NuGetFramework>>> Properties { get { throw null; } }
+
+        public void Add(Common.NuGetLogCode code, string libraryId, Frameworks.NuGetFramework framework) { }
+
+        public void AddRangeOfCodes(System.Collections.Generic.IEnumerable<Common.NuGetLogCode> codes, string libraryId, Frameworks.NuGetFramework framework) { }
+
+        public void AddRangeOfFrameworks(Common.NuGetLogCode code, string libraryId, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworks) { }
+
+        public bool Contains(Common.NuGetLogCode code, string libraryId, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(ProjectModel.PackageSpec packageSpec, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(ProjectModel.PackageSpec packageSpec) { throw null; }
+
+        public bool Equals(PackageSpecificWarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackArgs
+    {
+        public System.Collections.Generic.IEnumerable<string> Arguments { get { throw null; } set { } }
+
+        public string BasePath { get { throw null; } set { } }
+
+        public bool Build { get { throw null; } set { } }
+
+        public string CurrentDirectory { get { throw null; } set { } }
+
+        public bool Deterministic { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Exclude { get { throw null; } set { } }
+
+        public bool ExcludeEmptyDirectories { get { throw null; } set { } }
+
+        public bool IncludeReferencedProjects { get { throw null; } set { } }
+
+        public bool InstallPackageToOutputPath { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Common.LogLevel LogLevel { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public System.Version MinClientVersion { get { throw null; } set { } }
+
+        public System.Lazy<string> MsBuildDirectory { get { throw null; } set { } }
+
+        public bool NoDefaultExcludes { get { throw null; } set { } }
+
+        public bool NoPackageAnalysis { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        public bool OutputFileNamesWithoutVersion { get { throw null; } set { } }
+
+        public string PackagesDirectory { get { throw null; } set { } }
+
+        public MSBuildPackTargetArgs PackTargetArgs { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> Properties { get { throw null; } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string SolutionDirectory { get { throw null; } set { } }
+
+        public string Suffix { get { throw null; } set { } }
+
+        public SymbolPackageFormat SymbolPackageFormat { get { throw null; } set { } }
+
+        public bool Symbols { get { throw null; } set { } }
+
+        public bool Tool { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        public ProjectModel.WarningProperties WarningProperties { get { throw null; } set { } }
+
+        public string GetPropertyValue(string propertyName) { throw null; }
+
+        public static SymbolPackageFormat GetSymbolPackageFormat(string symbolPackageFormat) { throw null; }
+    }
+
+    public partial class PackCollectorLogger : Common.LoggerBase
+    {
+        public PackCollectorLogger(Common.ILogger innerLogger, ProjectModel.WarningProperties warningProperties, PackCommand.PackageSpecificWarningProperties packageSpecificWarningProperties) { }
+
+        public PackCollectorLogger(Common.ILogger innerLogger, ProjectModel.WarningProperties warningProperties) { }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> Errors { get { throw null; } }
+
+        public ProjectModel.WarningProperties WarningProperties { get { throw null; } set { } }
+
+        public override void Log(Common.ILogMessage message) { }
+
+        public override System.Threading.Tasks.Task LogAsync(Common.ILogMessage message) { throw null; }
+    }
+
+    public partial class PackCommandRunner
+    {
+        public PackCommandRunner(PackArgs packArgs, CreateProjectFactory createProjectFactory, Packaging.PackageBuilder packageBuilder) { }
+
+        public PackCommandRunner(PackArgs packArgs, CreateProjectFactory createProjectFactory) { }
+
+        public bool GenerateNugetPackage { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.Rules.IPackageRule> Rules { get { throw null; } set { } }
+
+        public static void AddDependencyGroups(System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> dependencies, Frameworks.NuGetFramework framework, Packaging.PackageBuilder builder) { }
+
+        public static void AddLibraryDependency(LibraryModel.LibraryDependency dependency, System.Collections.Generic.ISet<LibraryModel.LibraryDependency> list) { }
+
+        public static void AddPackageDependency(Packaging.Core.PackageDependency dependency, System.Collections.Generic.ISet<Packaging.Core.PackageDependency> set) { }
+
+        [System.Obsolete("Do not use this. Use RunPackageBuild() instead as it accounts for the effects of package analysis to the complete operation status.")]
+        public void BuildPackage() { }
+
+        [System.Obsolete("Do not use this. Use RunPackageBuild() instead as it accounts for the effects of package analysis to the complete operation status.")]
+        public Packaging.PackageArchiveReader BuildPackage(Packaging.PackageBuilder builder, string outputPath = null) { throw null; }
+
+        public static string GetInputFile(PackArgs packArgs) { throw null; }
+
+        public static string GetOutputFileName(string packageId, Versioning.NuGetVersion version, bool isNupkg, bool symbols, SymbolPackageFormat symbolPackageFormat, bool excludeVersion = false) { throw null; }
+
+        public static string GetOutputPath(Packaging.PackageBuilder builder, PackArgs packArgs, bool symbols = false, Versioning.NuGetVersion nugetVersion = null, string outputDirectory = null, bool isNupkg = true) { throw null; }
+
+        [System.Obsolete]
+        public static bool ProcessProjectJsonFile(Packaging.PackageBuilder builder, string basePath, string id, Versioning.NuGetVersion version, string suffix, System.Func<string, string> propertyProvider) { throw null; }
+
+        public bool RunPackageBuild() { throw null; }
+
+        public static void SetupCurrentDirectory(PackArgs packArgs) { }
+
+        public delegate IProjectFactory CreateProjectFactory(PackArgs packArgs, string path);
+    }
+
+    public static partial class PushRunner
+    {
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, System.Collections.Generic.IList<string> packagePaths, string source, string apiKey, string symbolSource, string symbolApiKey, int timeoutSeconds, bool disableBuffering, bool noSymbols, bool noServiceEndpoint, bool skipDuplicate, Common.ILogger logger) { throw null; }
+
+        [System.Obsolete("Use Run method which takes multiple package paths.")]
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, string packagePath, string source, string apiKey, string symbolSource, string symbolApiKey, int timeoutSeconds, bool disableBuffering, bool noSymbols, bool noServiceEndpoint, bool skipDuplicate, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class RemoveClientCertArgs : IClientCertArgsWithConfigFile, IClientCertArgsWithPackageSource
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+    }
+
+    public static partial class RemoveClientCertRunner
+    {
+        public static void Run(RemoveClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class RemoveSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class RemoveSourceRunner
+    {
+        public static void Run(RemoveSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public static partial class RequestRuntimeUtility
+    {
+        public static System.Collections.Generic.IEnumerable<string> GetDefaultRestoreRuntimes(string os, string runtimeOsName) { throw null; }
+    }
+
+    public partial class ResolvedDependencyKey : System.IEquatable<ResolvedDependencyKey>
+    {
+        public ResolvedDependencyKey(LibraryModel.LibraryIdentity parent, Versioning.VersionRange range, LibraryModel.LibraryIdentity child) { }
+
+        public LibraryModel.LibraryIdentity Child { get { throw null; } }
+
+        public LibraryModel.LibraryIdentity Parent { get { throw null; } }
+
+        public Versioning.VersionRange Range { get { throw null; } }
+
+        public bool Equals(ResolvedDependencyKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ResolverConflict
+    {
+        public ResolverConflict(string name, System.Collections.Generic.IEnumerable<ResolverRequest> requests) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<ResolverRequest> Requests { get { throw null; } }
+    }
+
+    public partial class ResolverRequest
+    {
+        public ResolverRequest(LibraryModel.LibraryIdentity requestor, LibraryModel.LibraryRange request) { }
+
+        public LibraryModel.LibraryRange Request { get { throw null; } }
+
+        public LibraryModel.LibraryIdentity Requestor { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RestoreArgs
+    {
+        public System.Collections.Generic.IReadOnlyList<ProjectModel.IAssetsLogMessage> AdditionalMessages { get { throw null; } set { } }
+
+        public bool AllowNoOp { get { throw null; } set { } }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } set { } }
+
+        public Protocol.CachingSourceProvider CachingSourceProvider { get { throw null; } set { } }
+
+        public string ConfigFile { get { throw null; } set { } }
+
+        public bool DisableParallel { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> FallbackRuntimes { get { throw null; } set { } }
+
+        public string GlobalPackagesFolder { get { throw null; } set { } }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<string> Inputs { get { throw null; } set { } }
+
+        public bool? IsLowercaseGlobalPackagesFolder { get { throw null; } set { } }
+
+        public bool IsRestoreOriginalAction { get { throw null; } set { } }
+
+        public int? LockFileVersion { get { throw null; } set { } }
+
+        public Common.ILogger Log { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public Packaging.PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<IPreLoadedRestoreRequestProvider> PreLoadedRequestProviders { get { throw null; } set { } }
+
+        public IRestoreProgressReporter ProgressReporter { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<IRestoreRequestProvider> RequestProviders { get { throw null; } set { } }
+
+        public bool RestoreForceEvaluate { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> Runtimes { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<string> Sources { get { throw null; } set { } }
+
+        public bool? ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public void ApplyStandardProperties(RestoreRequest request) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetEffectiveFallbackPackageFolders(Configuration.ISettings settings) { throw null; }
+
+        public string GetEffectiveGlobalPackagesFolder(string rootDirectory, Configuration.ISettings settings) { throw null; }
+
+        public Configuration.ISettings GetSettings(string projectDirectory) { throw null; }
+    }
+
+    public partial class RestoreCollectorLogger : Common.LoggerBase, Common.ICollectorLogger, Common.ILogger
+    {
+        public RestoreCollectorLogger(Common.ILogger innerLogger, Common.LogLevel verbosity, bool hideWarningsAndErrors) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger, Common.LogLevel verbosity) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger, bool hideWarningsAndErrors) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger) { }
+
+        public System.Collections.Generic.IEnumerable<Common.IRestoreLogMessage> Errors { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } }
+
+        public WarningPropertiesCollection ProjectWarningPropertiesCollection { get { throw null; } set { } }
+
+        public WarningPropertiesCollection TransitiveWarningPropertiesCollection { get { throw null; } set { } }
+
+        public void ApplyRestoreInputs(ProjectModel.PackageSpec projectSpec) { }
+
+        public void ApplyRestoreOutput(System.Collections.Generic.IEnumerable<RestoreTargetGraph> restoreTargetGraphs) { }
+
+        protected bool DisplayMessage(Common.IRestoreLogMessage message) { throw null; }
+
+        public override void Log(Common.ILogMessage message) { }
+
+        public void Log(Common.IRestoreLogMessage message) { }
+
+        public override System.Threading.Tasks.Task LogAsync(Common.ILogMessage message) { throw null; }
+
+        public System.Threading.Tasks.Task LogAsync(Common.IRestoreLogMessage message) { throw null; }
+    }
+
+    public partial class RestoreCommand
+    {
+        public RestoreCommand(RestoreRequest request) { }
+
+        public System.Guid ParentId { get { throw null; } }
+
+        public System.Threading.Tasks.Task<RestoreResult> ExecuteAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<RestoreResult> ExecuteAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RestoreCommandException : System.Exception, Common.ILogMessageException
+    {
+        public RestoreCommandException(Common.IRestoreLogMessage logMessage) { }
+
+        public Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class RestoreCommandProviders
+    {
+        [System.Obsolete("Create via RestoreCommandProvidersCache")]
+        public RestoreCommandProviders(Repositories.NuGetv3LocalRepository globalPackages, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> fallbackPackageFolders, System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> localProviders, System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> remoteProviders, Protocol.LocalPackageFileCache packageFileCache) { }
+
+        public System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> FallbackPackageFolders { get { throw null; } }
+
+        public Repositories.NuGetv3LocalRepository GlobalPackages { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> LocalProviders { get { throw null; } }
+
+        public Protocol.LocalPackageFileCache PackageFileCache { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> RemoteProviders { get { throw null; } }
+
+        public static RestoreCommandProviders Create(string globalFolderPath, System.Collections.Generic.IEnumerable<string> fallbackPackageFolderPaths, System.Collections.Generic.IEnumerable<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Protocol.LocalPackageFileCache packageFileCache, Common.ILogger log) { throw null; }
+    }
+
+    public partial class RestoreCommandProvidersCache
+    {
+        public RestoreCommandProviders GetOrCreate(string globalPackagesPath, System.Collections.Generic.IReadOnlyList<string> fallbackPackagesPaths, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger log, bool updateLastAccess) { throw null; }
+
+        public RestoreCommandProviders GetOrCreate(string globalPackagesPath, System.Collections.Generic.IReadOnlyList<string> fallbackPackagesPaths, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger log) { throw null; }
+    }
+
+    public partial class RestoreRequest
+    {
+        public static readonly int DefaultDegreeOfConcurrency;
+        [System.Obsolete("Use constructor with LockFileBuilderCache parameter")]
+        public RestoreRequest(ProjectModel.PackageSpec project, RestoreCommandProviders dependencyProviders, Protocol.Core.Types.SourceCacheContext cacheContext, Packaging.Signing.ClientPolicyContext clientPolicyContext, Common.ILogger log) { }
+
+        public RestoreRequest(ProjectModel.PackageSpec project, RestoreCommandProviders dependencyProviders, Protocol.Core.Types.SourceCacheContext cacheContext, Packaging.Signing.ClientPolicyContext clientPolicyContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger log, LockFileBuilderCache lockFileBuilderCache) { }
+
+        public System.Collections.Generic.IReadOnlyList<ProjectModel.IAssetsLogMessage> AdditionalMessages { get { throw null; } set { } }
+
+        public bool AllowNoOp { get { throw null; } set { } }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } set { } }
+
+        public Packaging.Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Frameworks.FrameworkRuntimePair> CompatibilityProfiles { get { throw null; } }
+
+        public ProjectModel.DependencyGraphSpec DependencyGraphSpec { get { throw null; } set { } }
+
+        public RestoreCommandProviders DependencyProviders { get { throw null; } set { } }
+
+        public ProjectModel.LockFile ExistingLockFile { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectModel.ExternalProjectReference> ExternalProjects { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> FallbackRuntimes { get { throw null; } }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public bool IsLowercasePackagesDirectory { get { throw null; } set { } }
+
+        public bool IsRestoreOriginalAction { get { throw null; } set { } }
+
+        public string LockFilePath { get { throw null; } set { } }
+
+        public int LockFileVersion { get { throw null; } set { } }
+
+        public Common.ILogger Log { get { throw null; } set { } }
+
+        public int MaxDegreeOfConcurrency { get { throw null; } set { } }
+
+        public string MSBuildProjectExtensionsPath { get { throw null; } set { } }
+
+        public Packaging.PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public string PackagesDirectory { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public ProjectModel.PackageSpec Project { get { throw null; } }
+
+        public ProjectModel.ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> RequestedRuntimes { get { throw null; } }
+
+        public bool RestoreForceEvaluate { get { throw null; } set { } }
+
+        public string RestoreOutputPath { get { throw null; } set { } }
+
+        public bool UpdatePackageLastAccessTime { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public Packaging.XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+
+    public partial class RestoreResult : IRestoreResult
+    {
+        public RestoreResult(bool success, System.Collections.Generic.IEnumerable<RestoreTargetGraph> restoreGraphs, System.Collections.Generic.IEnumerable<CompatibilityCheckResult> compatibilityCheckResults, System.Collections.Generic.IEnumerable<MSBuildOutputFile> msbuildFiles, ProjectModel.LockFile lockFile, ProjectModel.LockFile previousLockFile, string lockFilePath, ProjectModel.CacheFile cacheFile, string cacheFilePath, string packagesLockFilePath, ProjectModel.PackagesLockFile packagesLockFile, string dependencyGraphSpecFilePath, ProjectModel.DependencyGraphSpec dependencyGraphSpec, ProjectModel.ProjectStyle projectStyle, System.TimeSpan elapsedTime) { }
+
+        protected string CacheFilePath { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<CompatibilityCheckResult> CompatibilityCheckResults { get { throw null; } }
+
+        public System.TimeSpan ElapsedTime { get { throw null; } }
+
+        public virtual ProjectModel.LockFile LockFile { get { throw null; } }
+
+        public string LockFilePath { get { throw null; } set { } }
+
+        public virtual System.Collections.Generic.IList<ProjectModel.IAssetsLogMessage> LogMessages { get { throw null; } internal set { } }
+
+        public System.Collections.Generic.IEnumerable<MSBuildOutputFile> MSBuildOutputFiles { get { throw null; } }
+
+        public virtual ProjectModel.LockFile PreviousLockFile { get { throw null; } }
+
+        public ProjectModel.ProjectStyle ProjectStyle { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<RestoreTargetGraph> RestoreGraphs { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task CommitAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Collections.Generic.ISet<LibraryModel.LibraryIdentity> GetAllInstalled() { throw null; }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> GetAllUnresolved() { throw null; }
+    }
+
+    public partial class RestoreResultPair
+    {
+        public RestoreResultPair(RestoreSummaryRequest request, RestoreResult result) { }
+
+        public RestoreResult Result { get { throw null; } }
+
+        public RestoreSummaryRequest SummaryRequest { get { throw null; } }
+    }
+
+    public static partial class RestoreRunner
+    {
+        public static System.Threading.Tasks.Task<RestoreSummary> CommitAsync(RestoreResultPair restoreResult, System.Threading.CancellationToken token) { throw null; }
+
+        public static string GetInvalidInputErrorMessage(string input) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> GetRequests(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummary>> RunAsync(RestoreArgs restoreContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummary>> RunAsync(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreResultPair>> RunWithoutCommit(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> restoreRequests, RestoreArgs restoreContext) { throw null; }
+    }
+
+    public partial class RestoreSpecException : System.Exception
+    {
+        internal RestoreSpecException() { }
+
+        public System.Collections.Generic.IEnumerable<string> Files { get { throw null; } }
+
+        public static RestoreSpecException Create(string message, System.Collections.Generic.IEnumerable<string> files, System.Exception innerException) { throw null; }
+
+        public static RestoreSpecException Create(string message, System.Collections.Generic.IEnumerable<string> files) { throw null; }
+    }
+
+    public partial class RestoreSummary
+    {
+        public RestoreSummary(RestoreResult result, string inputPath, System.Collections.Generic.IEnumerable<string> configFiles, System.Collections.Generic.IEnumerable<Protocol.Core.Types.SourceRepository> sourceRepositories, System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> errors) { }
+
+        public RestoreSummary(bool success, string inputPath, System.Collections.Generic.IReadOnlyList<string> configFiles, System.Collections.Generic.IReadOnlyList<string> feedsUsed, int installCount, System.Collections.Generic.IReadOnlyList<Common.IRestoreLogMessage> errors) { }
+
+        public RestoreSummary(bool success) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ConfigFiles { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Common.IRestoreLogMessage> Errors { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> FeedsUsed { get { throw null; } }
+
+        public string InputPath { get { throw null; } }
+
+        public int InstallCount { get { throw null; } }
+
+        public bool NoOpRestore { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+
+        public static void Log(Common.ILogger logger, System.Collections.Generic.IReadOnlyList<RestoreSummary> restoreSummaries, bool logErrors = false) { }
+    }
+
+    public partial class RestoreSummaryRequest
+    {
+        public RestoreSummaryRequest(RestoreRequest request, string inputPath, System.Collections.Generic.IEnumerable<string> configFiles, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources) { }
+
+        public System.Collections.Generic.IEnumerable<string> ConfigFiles { get { throw null; } }
+
+        public string InputPath { get { throw null; } }
+
+        public RestoreRequest Request { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> Sources { get { throw null; } }
+    }
+
+    public partial class RestoreTargetGraph : IRestoreTargetGraph
+    {
+        internal RestoreTargetGraph() { }
+
+        public DependencyResolver.AnalyzeResult<DependencyResolver.RemoteResolveResult> AnalyzeResult { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<ResolverConflict> Conflicts { get { throw null; } }
+
+        public Client.ManagedCodeConventions Conventions { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult>> Flattened { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> Graphs { get { throw null; } }
+
+        public bool InConflict { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.ISet<ResolvedDependencyKey> ResolvedDependencies { get { throw null; } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public string TargetGraphName { get { throw null; } }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get { throw null; } }
+
+        public static RestoreTargetGraph Create(RuntimeModel.RuntimeGraph runtimeGraph, System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> graphs, DependencyResolver.RemoteWalkContext context, Common.ILogger log, Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public static RestoreTargetGraph Create(System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> graphs, DependencyResolver.RemoteWalkContext context, Common.ILogger logger, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class SignArgs
+    {
+        public string CertificateFingerprint { get { throw null; } set { } }
+
+        public string CertificatePassword { get { throw null; } set { } }
+
+        public string CertificatePath { get { throw null; } set { } }
+
+        public System.Security.Cryptography.X509Certificates.StoreLocation CertificateStoreLocation { get { throw null; } set { } }
+
+        public System.Security.Cryptography.X509Certificates.StoreName CertificateStoreName { get { throw null; } set { } }
+
+        public string CertificateSubjectName { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public bool NonInteractive { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        [System.Obsolete("Use PackagePaths instead")]
+        public string PackagePath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackagePaths { get { throw null; } set { } }
+
+        public SignCommand.IPasswordProvider PasswordProvider { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName SignatureHashAlgorithm { get { throw null; } set { } }
+
+        public string Timestamper { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName TimestampHashAlgorithm { get { throw null; } set { } }
+
+        public System.Threading.CancellationToken Token { get { throw null; } set { } }
+    }
+
+    public sealed partial class SignCommandException : System.Exception, Common.ILogMessageException
+    {
+        public SignCommandException(Common.ILogMessage logMessage) { }
+
+        public Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class SignCommandRunner : ISignCommandRunner
+    {
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(SignArgs signArgs) { throw null; }
+
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(System.Collections.Generic.IEnumerable<string> packagesToSign, Packaging.Signing.SignPackageRequest signPackageRequest, string timestamper, Common.ILogger logger, string outputDirectory, bool overwrite, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SourceRepositoryDependencyProvider : DependencyResolver.IRemoteDependencyProvider
+    {
+        public SourceRepositoryDependencyProvider(Protocol.Core.Types.SourceRepository sourceRepository, Common.ILogger logger, Protocol.Core.Types.SourceCacheContext cacheContext, bool ignoreFailedSources, bool ignoreWarning, Protocol.LocalPackageFileCache fileCache, bool isFallbackFolderSource) { }
+
+        public SourceRepositoryDependencyProvider(Protocol.Core.Types.SourceRepository sourceRepository, Common.ILogger logger, Protocol.Core.Types.SourceCacheContext cacheContext, bool ignoreFailedSources, bool ignoreWarning) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public Protocol.Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public enum SourcesAction
+    {
+        None = 0,
+        List = 1,
+        Add = 2,
+        Remove = 3,
+        Enable = 4,
+        Disable = 5,
+        Update = 6
+    }
+
+    public enum SourcesListFormat
+    {
+        None = 0,
+        Detailed = 1,
+        Short = 2
+    }
+
+    public static partial class SpecValidationUtility
+    {
+        public static void ValidateDependencySpec(ProjectModel.DependencyGraphSpec spec, System.Collections.Generic.HashSet<string> projectsToSkip) { }
+
+        public static void ValidateDependencySpec(ProjectModel.DependencyGraphSpec spec) { }
+
+        public static void ValidateProjectSpec(ProjectModel.PackageSpec spec) { }
+    }
+
+    public enum SymbolPackageFormat
+    {
+        Snupkg = 0,
+        SymbolsNupkg = 1
+    }
+
+    public static partial class ToolRestoreUtility
+    {
+        public static ProjectModel.PackageSpec GetSpec(string projectFilePath, string id, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework, string packagesPath, System.Collections.Generic.IList<string> fallbackFolders, System.Collections.Generic.IList<Configuration.PackageSource> sources, ProjectModel.WarningProperties projectWideWarningProperties) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest> GetSubSetRequests(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> requestSummaries) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest> GetSubSetRequestsForSingleId(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> requests) { throw null; }
+
+        public static LibraryModel.LibraryDependency GetToolDependencyOrNullFromSpec(ProjectModel.PackageSpec spec) { throw null; }
+
+        public static string GetToolIdOrNullFromSpec(ProjectModel.PackageSpec spec) { throw null; }
+
+        public static ProjectModel.LockFileTargetLibrary GetToolTargetLibrary(ProjectModel.LockFile toolLockFile, string toolId) { throw null; }
+
+        public static string GetUniqueName(string id, string framework, Versioning.VersionRange versionRange) { throw null; }
+    }
+
+    public static partial class TransitiveNoWarnUtils
+    {
+        public static WarningPropertiesCollection CreateTransitiveWarningPropertiesCollection(System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, ProjectModel.PackageSpec parentProjectSpec) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> ExtractPackageSpecificNoWarnForFramework(PackageSpecificWarningProperties packageSpecificWarningProperties, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<Frameworks.NuGetFramework, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>>> ExtractPackageSpecificNoWarnPerFramework(PackageSpecificWarningProperties packageSpecificWarningProperties) { throw null; }
+
+        public static System.Collections.Generic.HashSet<Common.NuGetLogCode> ExtractPathNoWarnProperties(NodeWarningProperties nodeWarningProperties, string libraryId) { throw null; }
+
+        public static System.Collections.Generic.HashSet<Common.NuGetLogCode> MergeCodes(System.Collections.Generic.HashSet<Common.NuGetLogCode> first, System.Collections.Generic.HashSet<Common.NuGetLogCode> second) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> MergePackageSpecificNoWarn(System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> first, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> second) { throw null; }
+
+        public static PackageSpecificWarningProperties MergePackageSpecificWarningProperties(PackageSpecificWarningProperties first, PackageSpecificWarningProperties second) { throw null; }
+
+        public static bool TryMergeNullObjects<T>(T first, T second, out T merged)
+            where T : class { throw null; }
+
+        public partial class DependencyNode : System.IEquatable<DependencyNode>
+        {
+            public DependencyNode(string id, bool isProject, NodeWarningProperties nodeWarningProperties) { }
+
+            public DependencyNode(string id, bool isProject, System.Collections.Generic.HashSet<Common.NuGetLogCode> projectWideNoWarn, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> packageSpecificNoWarn) { }
+
+            public string Id { get { throw null; } }
+
+            public bool IsProject { get { throw null; } }
+
+            public NodeWarningProperties NodeWarningProperties { get { throw null; } }
+
+            public bool Equals(DependencyNode other) { throw null; }
+
+            public override bool Equals(object obj) { throw null; }
+
+            public override int GetHashCode() { throw null; }
+
+            public override string ToString() { throw null; }
+        }
+
+        public partial class NodeWarningProperties : System.IEquatable<NodeWarningProperties>
+        {
+            public NodeWarningProperties(System.Collections.Generic.HashSet<Common.NuGetLogCode> projectWide, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> packageSpecific) { }
+
+            public System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> PackageSpecific { get { throw null; } }
+
+            public System.Collections.Generic.HashSet<Common.NuGetLogCode> ProjectWide { get { throw null; } }
+
+            public bool Equals(NodeWarningProperties other) { throw null; }
+
+            public override bool Equals(object obj) { throw null; }
+
+            public override int GetHashCode() { throw null; }
+
+            public NodeWarningProperties GetIntersect(NodeWarningProperties other) { throw null; }
+
+            public bool IsSubSetOf(NodeWarningProperties other) { throw null; }
+        }
+    }
+
+    public sealed partial class TrustedSignerActionsProvider
+    {
+        public TrustedSignerActionsProvider(Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, Common.ILogger logger) { }
+
+        public void AddOrUpdateTrustedSigner(string name, string fingerprint, Common.HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot) { }
+
+        public System.Threading.Tasks.Task AddTrustedRepositoryAsync(string name, System.Uri serviceIndex, System.Collections.Generic.IEnumerable<string> owners, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task AddTrustedSignerAsync(string name, Packaging.Signing.ISignedPackageReader package, Packaging.Signing.VerificationTarget trustTarget, bool allowUntrustedRoot, System.Collections.Generic.IEnumerable<string> owners, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task SyncTrustedRepositoryAsync(string name, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class TrustedSignersArgs
+    {
+        public TrustedSignersAction Action { get { throw null; } set { } }
+
+        public bool AllowUntrustedRoot { get { throw null; } set { } }
+
+        public bool Author { get { throw null; } set { } }
+
+        public string CertificateFingerprint { get { throw null; } set { } }
+
+        public string FingerprintAlgorithm { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } set { } }
+
+        public string PackagePath { get { throw null; } set { } }
+
+        public bool Repository { get { throw null; } set { } }
+
+        public string ServiceIndex { get { throw null; } set { } }
+
+        public enum TrustedSignersAction
+        {
+            Add = 0,
+            List = 1,
+            Remove = 2,
+            Sync = 3
+        }
+    }
+
+    public partial class TrustedSignersCommandRunner : ITrustedSignersCommandRunner
+    {
+        public TrustedSignersCommandRunner(Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, Configuration.IPackageSourceProvider packageSourceProvider) { }
+
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs) { throw null; }
+    }
+
+    public static partial class UnexpectedDependencyMessages
+    {
+        public static bool DependencyRangeHasMissingExactMatch(ResolvedDependencyKey dependency) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetBumpedUpDependencies(System.Collections.Generic.List<IndexedRestoreTargetGraph> graphs, ProjectModel.PackageSpec project, System.Collections.Generic.ISet<string> ignoreIds) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetDependenciesAboveUpperBounds(System.Collections.Generic.List<IndexedRestoreTargetGraph> graphs, Common.ILogger logger) { throw null; }
+
+        public static Common.RestoreLogMessage GetMissingLowerBoundMessage(ResolvedDependencyKey dependency, params string[] targetGraphs) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetMissingLowerBounds(System.Collections.Generic.IEnumerable<IRestoreTargetGraph> graphs, System.Collections.Generic.ISet<string> ignoreIds) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetProjectDependenciesMissingLowerBounds(ProjectModel.PackageSpec project) { throw null; }
+
+        public static bool HasMissingLowerBound(Versioning.VersionRange range) { throw null; }
+
+        public static System.Threading.Tasks.Task LogAsync(System.Collections.Generic.IEnumerable<IRestoreTargetGraph> graphs, ProjectModel.PackageSpec project, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class UpdateClientCertArgs : IClientCertArgsWithPackageSource, IClientCertArgsWithConfigFile, IClientCertArgsWithFileData, IClientCertArgsWithStoreData, IClientCertArgsWithForce
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string FindBy { get { throw null; } set { } }
+
+        public string FindValue { get { throw null; } set { } }
+
+        public bool Force { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string StoreLocation { get { throw null; } set { } }
+
+        public string StoreName { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+    }
+
+    public static partial class UpdateClientCertRunner
+    {
+        public static void Run(UpdateClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class UpdateSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+
+        public string Username { get { throw null; } set { } }
+
+        public string ValidAuthenticationTypes { get { throw null; } set { } }
+    }
+
+    public static partial class UpdateSourceRunner
+    {
+        public static void Run(UpdateSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class VerifyArgs
+    {
+        public System.Collections.Generic.IEnumerable<string> CertificateFingerprint { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Common.LogLevel LogLevel { get { throw null; } set { } }
+
+        [System.Obsolete("Use PackagePaths instead")]
+        public string PackagePath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackagePaths { get { throw null; } set { } }
+
+        public Configuration.ISettings Settings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Verification> Verifications { get { throw null; } set { } }
+
+        public enum Verification
+        {
+            Unknown = 0,
+            All = 1,
+            Signatures = 2
+        }
+    }
+
+    public partial class VerifyCommandRunner : IVerifyCommandRunner
+    {
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(VerifyArgs verifyArgs) { throw null; }
+    }
+
+    public partial class WarningPropertiesCollection : System.IEquatable<WarningPropertiesCollection>
+    {
+        public WarningPropertiesCollection(ProjectModel.WarningProperties projectWideWarningProperties, PackageSpecificWarningProperties packageSpecificWarningProperties, System.Collections.Generic.IReadOnlyList<Frameworks.NuGetFramework> projectFrameworks) { }
+
+        public PackageSpecificWarningProperties PackageSpecificWarningProperties { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Frameworks.NuGetFramework> ProjectFrameworks { get { throw null; } }
+
+        public ProjectModel.WarningProperties ProjectWideWarningProperties { get { throw null; } }
+
+        public bool ApplyNoWarnProperties(Common.IRestoreLogMessage message) { throw null; }
+
+        public static bool ApplyProjectWideNoWarnProperties(Common.ILogMessage message, ProjectModel.WarningProperties warningProperties) { throw null; }
+
+        public static void ApplyProjectWideWarningsAsErrorProperties(Common.ILogMessage message, ProjectModel.WarningProperties warningProperties) { }
+
+        public void ApplyWarningAsErrorProperties(Common.IRestoreLogMessage message) { }
+
+        public bool ApplyWarningProperties(Common.IRestoreLogMessage message) { throw null; }
+
+        public bool Equals(WarningPropertiesCollection other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+}
+
+namespace NuGet.Commands.PackCommand
+{
+    public partial class PackageSpecificWarningProperties
+    {
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<(Common.NuGetLogCode, Frameworks.NuGetFramework)>> noWarnProperties) { throw null; }
+    }
+}
+
+namespace NuGet.Commands.SignCommand
+{
+    public partial interface IPasswordProvider
+    {
+    }
+}

--- a/src/referencePackages/src/nuget.commands/6.7.0/lib/netstandard2.0/NuGet.Commands.cs
+++ b/src/referencePackages/src/nuget.commands/6.7.0/lib/netstandard2.0/NuGet.Commands.cs
@@ -1,0 +1,1737 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test.Utility, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.SolutionRestoreManager.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.PackageManagement.VisualStudio.Test, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Complete commands common to command-line and GUI NuGet clients.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.Commands")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.Commands
+{
+    public partial class AddClientCertArgs : IClientCertArgsWithPackageSource, IClientCertArgsWithConfigFile, IClientCertArgsWithFileData, IClientCertArgsWithStoreData, IClientCertArgsWithForce
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string FindBy { get { throw null; } set { } }
+
+        public string FindValue { get { throw null; } set { } }
+
+        public bool Force { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string StoreLocation { get { throw null; } set { } }
+
+        public string StoreName { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+    }
+
+    public static partial class AddClientCertRunner
+    {
+        public static void Run(AddClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class AddSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+
+        public string Username { get { throw null; } set { } }
+
+        public string ValidAuthenticationTypes { get { throw null; } set { } }
+    }
+
+    public static partial class AddSourceRunner
+    {
+        public static void Run(AddSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public static partial class AssetTargetFallbackUtility
+    {
+        public static readonly string AssetTargetFallback;
+        public static void ApplyFramework(ProjectModel.TargetFrameworkInformation targetFrameworkInfo, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback) { }
+
+        public static void EnsureValidFallback(System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback, string filePath) { }
+
+        public static Frameworks.NuGetFramework GetFallbackFramework(Frameworks.NuGetFramework projectFramework, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageTargetFallback, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> assetTargetFallback) { throw null; }
+
+        public static Common.RestoreLogMessage GetInvalidFallbackCombinationMessage(string path) { throw null; }
+    }
+
+    public static partial class BuildAssetsUtils
+    {
+        public static readonly string[] MacroCandidates;
+        public const string PropsExtension = ".props";
+        public const string TargetsExtension = ".targets";
+        public static void AddNuGetProperties(System.Xml.Linq.XDocument doc, System.Collections.Generic.IEnumerable<string> packageFolders, string repositoryRoot, ProjectModel.ProjectStyle projectStyle, string assetsFilePath, bool success) { }
+
+        public static void AddNuGetPropertiesToFirstImport(System.Collections.Generic.IEnumerable<MSBuildOutputFile> files, System.Collections.Generic.IEnumerable<string> packageFolders, string repositoryRoot, ProjectModel.ProjectStyle projectStyle, string assetsFilePath, bool success) { }
+
+        public static System.Xml.Linq.XElement GenerateContentFilesItem(string path, ProjectModel.LockFileContentFile item, string packageId, string packageVersion) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateEmptyImportsFile() { throw null; }
+
+        public static System.Xml.Linq.XElement GenerateImport(string path) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateMSBuildFile(System.Collections.Generic.List<MSBuildRestoreItemGroup> groups, ProjectModel.ProjectStyle outputType) { throw null; }
+
+        public static System.Collections.Generic.List<MSBuildOutputFile> GenerateMultiTargetFailureFiles(string targetsPath, string propsPath, ProjectModel.ProjectStyle restoreType) { throw null; }
+
+        public static System.Xml.Linq.XDocument GenerateMultiTargetFrameworkWarning() { throw null; }
+
+        public static System.Xml.Linq.XElement GenerateProperty(string propertyName, string content) { throw null; }
+
+        public static string GetLanguage(string nugetLanguage) { throw null; }
+
+        public static string GetMSBuildFilePath(ProjectModel.PackageSpec project, string extension) { throw null; }
+
+        public static string GetMSBuildFilePathForPackageReferenceStyleProject(ProjectModel.PackageSpec project, string extension) { throw null; }
+
+        public static System.Collections.Generic.List<MSBuildOutputFile> GetMSBuildOutputFiles(ProjectModel.PackageSpec project, ProjectModel.LockFile assetsFile, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> repositories, RestoreRequest request, string assetsFilePath, bool restoreSuccess, Common.ILogger log) { throw null; }
+
+        public static string GetPathWithMacros(string absolutePath, string repositoryRoot) { throw null; }
+
+        public static bool HasChanges(System.Xml.Linq.XDocument newFile, string path, Common.ILogger log) { throw null; }
+
+        public static System.Xml.Linq.XDocument ReadExisting(string path, Common.ILogger log) { throw null; }
+
+        public static void WriteFiles(System.Collections.Generic.IEnumerable<MSBuildOutputFile> files, Common.ILogger log) { }
+
+        public static void WriteXML(string path, System.Xml.Linq.XDocument doc) { }
+    }
+
+    public static partial class ClientCertArgsExtensions
+    {
+        public static System.Security.Cryptography.X509Certificates.X509FindType? GetFindBy(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static System.Security.Cryptography.X509Certificates.StoreLocation? GetStoreLocation(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static System.Security.Cryptography.X509Certificates.StoreName? GetStoreName(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static bool IsFileCertSettingsProvided(this IClientCertArgsWithFileData args) { throw null; }
+
+        public static bool IsPackageSourceSettingProvided(this IClientCertArgsWithPackageSource args) { throw null; }
+
+        public static bool IsStoreCertSettingsProvided(this IClientCertArgsWithStoreData args) { throw null; }
+
+        public static void Validate(this AddClientCertArgs args) { }
+
+        public static void Validate(this RemoveClientCertArgs args) { }
+
+        public static void Validate(this UpdateClientCertArgs args) { }
+    }
+
+    public partial class CommandException : System.Exception
+    {
+        public CommandException() { }
+
+        protected CommandException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+
+        public CommandException(string message, System.Exception exception) { }
+
+        public CommandException(string format, params object[] args) { }
+
+        public CommandException(string message) { }
+    }
+
+    public partial class CompatibilityCheckResult
+    {
+        public CompatibilityCheckResult(RestoreTargetGraph graph, System.Collections.Generic.IEnumerable<CompatibilityIssue> issues) { }
+
+        public RestoreTargetGraph Graph { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<CompatibilityIssue> Issues { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+    }
+
+    public partial class CompatibilityIssue : System.IEquatable<CompatibilityIssue>
+    {
+        internal CompatibilityIssue() { }
+
+        public string AssemblyName { get { throw null; } }
+
+        public System.Collections.Generic.List<Frameworks.FrameworkRuntimePair> AvailableFrameworkRuntimePairs { get { throw null; } }
+
+        public System.Collections.Generic.List<Frameworks.NuGetFramework> AvailableFrameworks { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public Packaging.Core.PackageIdentity Package { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public CompatibilityIssueType Type { get { throw null; } }
+
+        public bool Equals(CompatibilityIssue other) { throw null; }
+
+        public string Format() { throw null; }
+
+        public static CompatibilityIssue IncompatiblePackage(Packaging.Core.PackageIdentity referenceAssemblyPackage, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> packageFrameworks) { throw null; }
+
+        public static CompatibilityIssue IncompatiblePackageWithDotnetTool(Packaging.Core.PackageIdentity referenceAssemblyPackage) { throw null; }
+
+        public static CompatibilityIssue IncompatibleProject(Packaging.Core.PackageIdentity project, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> projectFrameworks) { throw null; }
+
+        public static CompatibilityIssue IncompatibleProjectType(Packaging.Core.PackageIdentity project) { throw null; }
+
+        public static CompatibilityIssue IncompatibleToolsPackage(Packaging.Core.PackageIdentity packageIdentity, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.HashSet<Frameworks.FrameworkRuntimePair> available) { throw null; }
+
+        public static CompatibilityIssue ReferenceAssemblyNotImplemented(string assemblyName, Packaging.Core.PackageIdentity referenceAssemblyPackage, Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public static CompatibilityIssue ToolsPackageWithExtraPackageTypes(Packaging.Core.PackageIdentity referenceAssemblyPackage) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public enum CompatibilityIssueType
+    {
+        ReferenceAssemblyNotImplemented = 0,
+        PackageIncompatible = 1,
+        ProjectIncompatible = 2,
+        PackageToolsAssetsIncompatible = 3,
+        ProjectWithIncorrectDependencyCount = 4,
+        IncompatiblePackageWithDotnetTool = 5,
+        ToolsPackageWithExtraPackageTypes = 6,
+        PackageTypeIncompatible = 7
+    }
+
+    public partial struct ContentMetadata
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string BuildAction { get { throw null; } set { } }
+
+        public string CopyToOutput { get { throw null; } set { } }
+
+        public string Flatten { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public string Target { get { throw null; } set { } }
+    }
+
+    public static partial class DeleteRunner
+    {
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, string packageId, string packageVersion, string source, string apiKey, bool nonInteractive, bool noServiceEndpoint, System.Func<string, bool> confirmFunc, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class DependencyGraphFileRequestProvider : IRestoreRequestProvider
+    {
+        public DependencyGraphFileRequestProvider(RestoreCommandProvidersCache providerCache) { }
+
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(string inputPath, RestoreArgs restoreContext) { throw null; }
+
+        public virtual System.Threading.Tasks.Task<bool> Supports(string path) { throw null; }
+    }
+
+    public partial class DependencyGraphSpecRequestProvider : IPreLoadedRestoreRequestProvider
+    {
+        public DependencyGraphSpecRequestProvider(RestoreCommandProvidersCache providerCache, ProjectModel.DependencyGraphSpec dgFile, Configuration.ISettings settings) { }
+
+        public DependencyGraphSpecRequestProvider(RestoreCommandProvidersCache providerCache, ProjectModel.DependencyGraphSpec dgFile) { }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<ProjectModel.ExternalProjectReference> GetExternalClosure(ProjectModel.DependencyGraphSpec dgFile, string projectNameToRestore) { throw null; }
+    }
+
+    public static partial class DiagnosticUtility
+    {
+        public static string FormatDependency(string id, Versioning.VersionRange range) { throw null; }
+
+        public static string FormatExpectedIdentity(string id, Versioning.VersionRange range) { throw null; }
+
+        public static string FormatGraphName(RestoreTargetGraph graph) { throw null; }
+
+        public static string FormatIdentity(LibraryModel.LibraryIdentity identity) { throw null; }
+
+        public static string GetMultiLineMessage(System.Collections.Generic.IEnumerable<string> lines) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> MergeOnTargetGraph(System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> messages) { throw null; }
+    }
+
+    public partial class DisableSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class DisableSourceRunner
+    {
+        public static void Run(DisableSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class DownloadDependencyResolutionResult
+    {
+        internal DownloadDependencyResolutionResult() { }
+
+        public System.Collections.Generic.IList<System.Tuple<LibraryModel.LibraryRange, DependencyResolver.RemoteMatch>> Dependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get { throw null; } }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get { throw null; } }
+
+        public static DownloadDependencyResolutionResult Create(Frameworks.NuGetFramework framework, System.Collections.Generic.IList<System.Tuple<LibraryModel.LibraryRange, DependencyResolver.RemoteMatch>> dependencies, System.Collections.Generic.IList<DependencyResolver.IRemoteDependencyProvider> remoteDependencyProviders) { throw null; }
+    }
+
+    public partial class EnableSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class EnableSourceRunner
+    {
+        public static void Run(EnableSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial interface IClientCertArgsWithConfigFile
+    {
+        string Configfile { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithFileData
+    {
+        string Password { get; set; }
+
+        string Path { get; set; }
+
+        bool StorePasswordInClearText { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithForce
+    {
+        bool Force { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithPackageSource
+    {
+        string PackageSource { get; set; }
+    }
+
+    public partial interface IClientCertArgsWithStoreData
+    {
+        string FindBy { get; set; }
+
+        string FindValue { get; set; }
+
+        string StoreLocation { get; set; }
+
+        string StoreName { get; set; }
+    }
+
+    public partial interface IListCommandRunner
+    {
+        System.Threading.Tasks.Task ExecuteCommand(ListArgs listArgs);
+    }
+
+    public partial interface ILocalsCommandRunner
+    {
+        void ExecuteCommand(LocalsArgs localsArgs);
+    }
+
+    public partial interface IMSBuildItem
+    {
+        string Identity { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> Properties { get; }
+
+        string GetProperty(string property, bool trim);
+        string GetProperty(string property);
+    }
+
+    public partial class IndexedRestoreTargetGraph
+    {
+        internal IndexedRestoreTargetGraph() { }
+
+        public IRestoreTargetGraph Graph { get { throw null; } }
+
+        public static IndexedRestoreTargetGraph Create(IRestoreTargetGraph graph) { throw null; }
+
+        public DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> GetItemById(string id, LibraryModel.LibraryType libraryType) { throw null; }
+
+        public DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> GetItemById(string id) { throw null; }
+
+        public bool HasErrors(string id) { throw null; }
+    }
+
+    public partial interface IPreLoadedRestoreRequestProvider
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(RestoreArgs restoreContext);
+    }
+
+    public partial interface IProjectFactory
+    {
+        Common.ILogger Logger { get; set; }
+
+        Packaging.PackageBuilder CreateBuilder(string basePath, Versioning.NuGetVersion version, string suffix, bool buildIfNeeded, Packaging.PackageBuilder builder = null);
+        System.Collections.Generic.Dictionary<string, string> GetProjectProperties();
+        ProjectModel.WarningProperties GetWarningPropertiesForProject();
+        void SetIncludeSymbols(bool includeSymbols);
+    }
+
+    public partial interface IRestoreProgressReporter
+    {
+        void EndProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles);
+        void StartProjectUpdate(string projectPath, System.Collections.Generic.IReadOnlyList<string> updatedFiles);
+    }
+
+    public partial interface IRestoreRequestProvider
+    {
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> CreateRequests(string inputPath, RestoreArgs restoreContext);
+        System.Threading.Tasks.Task<bool> Supports(string path);
+    }
+
+    public partial interface IRestoreResult
+    {
+        ProjectModel.LockFile LockFile { get; }
+
+        string LockFilePath { get; }
+
+        System.Collections.Generic.IEnumerable<MSBuildOutputFile> MSBuildOutputFiles { get; }
+
+        ProjectModel.LockFile PreviousLockFile { get; }
+
+        bool Success { get; }
+    }
+
+    public partial interface IRestoreTargetGraph
+    {
+        DependencyResolver.AnalyzeResult<DependencyResolver.RemoteResolveResult> AnalyzeResult { get; }
+
+        System.Collections.Generic.IEnumerable<ResolverConflict> Conflicts { get; }
+
+        Client.ManagedCodeConventions Conventions { get; }
+
+        System.Collections.Generic.ISet<DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult>> Flattened { get; }
+
+        Frameworks.NuGetFramework Framework { get; }
+
+        System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> Graphs { get; }
+
+        bool InConflict { get; }
+
+        System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.ISet<ResolvedDependencyKey> ResolvedDependencies { get; }
+
+        RuntimeModel.RuntimeGraph RuntimeGraph { get; }
+
+        string RuntimeIdentifier { get; }
+
+        string TargetGraphName { get; }
+
+        System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get; }
+    }
+
+    public partial interface ISignCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(SignArgs signArgs);
+    }
+
+    public partial interface ITrustedSignersCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs);
+    }
+
+    public partial interface IVerifyCommandRunner
+    {
+        System.Threading.Tasks.Task<int> ExecuteCommandAsync(VerifyArgs verifyArgs);
+    }
+
+    public partial class ListArgs
+    {
+        public ListArgs(System.Collections.Generic.IList<string> arguments, System.Collections.Generic.IList<Configuration.PackageSource> listEndpoints, Configuration.ISettings settings, Common.ILogger logger, Log printJustified, bool isDetailedl, string listCommandNoPackages, string listCommandLicenseUrl, string listCommandListNotSupported, bool allVersions, bool includeDelisted, bool prerelease, System.Threading.CancellationToken token) { }
+
+        public bool AllVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> Arguments { get { throw null; } }
+
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+
+        public bool IncludeDelisted { get { throw null; } }
+
+        public bool IsDetailed { get { throw null; } }
+
+        public string ListCommandLicenseUrl { get { throw null; } }
+
+        public string ListCommandListNotSupported { get { throw null; } }
+
+        public string ListCommandNoPackages { get { throw null; } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> ListEndpoints { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public bool Prerelease { get { throw null; } }
+
+        public Log PrintJustified { get { throw null; } }
+
+        public Configuration.ISettings Settings { get { throw null; } }
+
+        public delegate void Log(int startIndex, string message);
+    }
+
+    public partial class ListClientCertArgs : IClientCertArgsWithConfigFile
+    {
+        public string Configfile { get { throw null; } set { } }
+    }
+
+    public static partial class ListClientCertRunner
+    {
+        public static void Run(ListClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class ListCommandRunner : IListCommandRunner
+    {
+        public System.Threading.Tasks.Task ExecuteCommand(ListArgs listArgs) { throw null; }
+    }
+
+    public partial class ListSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Format { get { throw null; } set { } }
+    }
+
+    public static partial class ListSourceRunner
+    {
+        public static void Run(ListSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class LocalsArgs
+    {
+        public LocalsArgs(System.Collections.Generic.IList<string> arguments, Configuration.ISettings settings, Log logInformation, Log logError, bool clear, bool list) { }
+
+        public System.Collections.Generic.IList<string> Arguments { get { throw null; } }
+
+        public bool Clear { get { throw null; } }
+
+        public bool List { get { throw null; } }
+
+        public Log LogError { get { throw null; } }
+
+        public Log LogInformation { get { throw null; } }
+
+        public Configuration.ISettings Settings { get { throw null; } }
+
+        public delegate void Log(string message);
+    }
+
+    public partial class LocalsCommandRunner : ILocalsCommandRunner
+    {
+        public void ExecuteCommand(LocalsArgs localsArgs) { }
+    }
+
+    public partial class LockFileBuilder
+    {
+        public LockFileBuilder(int lockFileVersion, Common.ILogger logger, System.Collections.Generic.Dictionary<RestoreTargetGraph, System.Collections.Generic.Dictionary<string, LibraryModel.LibraryIncludeFlags>> includeFlagGraphs) { }
+
+        public ProjectModel.LockFile CreateLockFile(ProjectModel.LockFile previousLockFile, ProjectModel.PackageSpec project, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> localRepositories, DependencyResolver.RemoteWalkContext context, LockFileBuilderCache lockFileBuilderCache) { throw null; }
+
+        [System.Obsolete("Use method with LockFileBuilderCache parameter")]
+        public ProjectModel.LockFile CreateLockFile(ProjectModel.LockFile previousLockFile, ProjectModel.PackageSpec project, System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> localRepositories, DependencyResolver.RemoteWalkContext context) { throw null; }
+    }
+
+    public partial class LockFileBuilderCache
+    {
+        public ContentModel.ContentItemCollection GetContentItems(ProjectModel.LockFileLibrary library, Repositories.LocalPackageInfo package) { throw null; }
+
+        public System.Collections.Generic.List<System.Collections.Generic.List<ContentModel.SelectionCriteria>> GetSelectionCriteria(RestoreTargetGraph graph, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public static partial class LockFileUtils
+    {
+        public static readonly string LIBANY;
+        public static ProjectModel.LockFileTargetLibrary CreateLockFileTargetLibrary(ProjectModel.LockFileLibrary library, Repositories.LocalPackageInfo package, RestoreTargetGraph targetGraph, LibraryModel.LibraryIncludeFlags dependencyType) { throw null; }
+
+        public static ProjectModel.LockFileTargetLibrary CreateLockFileTargetProject(DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult> graphItem, LibraryModel.LibraryIdentity library, LibraryModel.LibraryIncludeFlags dependencyType, RestoreTargetGraph targetGraph, ProjectModel.ProjectStyle rootProjectStyle) { throw null; }
+
+        public static void ExcludeItems(ProjectModel.LockFileTargetLibrary lockFileLib, LibraryModel.LibraryIncludeFlags dependencyType) { }
+
+        public static string ToDirectorySeparator(string path) { throw null; }
+    }
+
+    public partial class MSBuildItem : IMSBuildItem
+    {
+        public MSBuildItem(string identity, System.Collections.Generic.IDictionary<string, string> metadata) { }
+
+        public string Identity { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Properties { get { throw null; } }
+
+        public string GetProperty(string property, bool trim) { throw null; }
+
+        public string GetProperty(string property) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class MSBuildOutputFile
+    {
+        public MSBuildOutputFile(string path, System.Xml.Linq.XDocument content) { }
+
+        public System.Xml.Linq.XDocument Content { get { throw null; } }
+
+        public string Path { get { throw null; } }
+    }
+
+    public partial class MSBuildPackTargetArgs
+    {
+        public System.Collections.Generic.HashSet<string> AllowedOutputExtensionsInPackageBuildOutputFolder { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get { throw null; } set { } }
+
+        public string AssemblyName { get { throw null; } set { } }
+
+        public string[] BuildOutputFolder { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<ContentMetadata>> ContentFiles { get { throw null; } set { } }
+
+        public bool IncludeBuildOutput { get { throw null; } set { } }
+
+        public string NuspecOutputPath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, string> SourceFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Frameworks.NuGetFramework> TargetFrameworks { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<OutputLibFile> TargetPathsToAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<OutputLibFile> TargetPathsToSymbols { get { throw null; } set { } }
+    }
+
+    public partial class MSBuildProjectFactory : IProjectFactory
+    {
+        public bool Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.ICollection<Packaging.ManifestFile> Files { get { throw null; } set { } }
+
+        public bool IncludeSymbols { get { throw null; } set { } }
+
+        public bool IsTool { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> ProjectProperties { get { throw null; } }
+
+        public Packaging.PackageBuilder CreateBuilder(string basePath, Versioning.NuGetVersion version, string suffix, bool buildIfNeeded, Packaging.PackageBuilder builder) { throw null; }
+
+        public System.Collections.Generic.Dictionary<string, string> GetProjectProperties() { throw null; }
+
+        public static string GetTargetPathForSourceFile(string sourcePath, string projectDirectory) { throw null; }
+
+        public ProjectModel.WarningProperties GetWarningPropertiesForProject() { throw null; }
+
+        public static IProjectFactory ProjectCreator(PackArgs packArgs, string path) { throw null; }
+
+        public void SetIncludeSymbols(bool includeSymbols) { }
+    }
+
+    public static partial class MSBuildProjectFrameworkUtility
+    {
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion, string clrSupport, string windowsTargetPlatformMinVersion) { throw null; }
+
+        [System.Obsolete("If you need ClrSupport support parameter to be accounted for in the calculation, the method with the windowsTargetPlatformMinVersion is the only correct one.")]
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion, string clrSupport) { throw null; }
+
+        public static Frameworks.NuGetFramework GetProjectFramework(string projectFilePath, string targetFrameworkMoniker, string targetPlatformMoniker, string targetPlatformMinVersion) { throw null; }
+
+        public static Frameworks.NuGetFramework GetProjectFrameworkReplacement(Frameworks.NuGetFramework framework) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> GetProjectFrameworks(System.Collections.Generic.IEnumerable<string> frameworkStrings) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetProjectFrameworkStrings(string projectFilePath, string targetFrameworks, string targetFramework, string targetFrameworkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion, bool isXnaWindowsPhoneProject, bool isManagementPackProject) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<string> GetProjectFrameworkStrings(string projectFilePath, string targetFrameworks, string targetFramework, string targetFrameworkMoniker, string targetPlatformIdentifier, string targetPlatformVersion, string targetPlatformMinVersion) { throw null; }
+    }
+
+    public partial class MSBuildRestoreItemGroup
+    {
+        public static readonly string ImportGroup;
+        public static readonly string ItemGroup;
+        public string Condition { get { throw null; } }
+
+        public System.Collections.Generic.List<string> Conditions { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<System.Xml.Linq.XElement> Items { get { throw null; } set { } }
+
+        public int Position { get { throw null; } set { } }
+
+        public string RootName { get { throw null; } set { } }
+
+        public static MSBuildRestoreItemGroup Create(string rootName, System.Collections.Generic.IEnumerable<System.Xml.Linq.XElement> items, int position, System.Collections.Generic.IEnumerable<string> conditions) { throw null; }
+    }
+
+    public static partial class MSBuildRestoreUtility
+    {
+        public static readonly string Clear;
+        public static System.Collections.Generic.IEnumerable<string> AggregateSources(System.Collections.Generic.IEnumerable<string> values, System.Collections.Generic.IEnumerable<string> excludeValues) { throw null; }
+
+        public static void ApplyIncludeFlags(LibraryModel.LibraryDependency dependency, string includeAssets, string excludeAssets, string privateAssets) { }
+
+        public static void ApplyIncludeFlags(ProjectModel.ProjectRestoreReference dependency, string includeAssets, string excludeAssets, string privateAssets) { }
+
+        public static bool ContainsClearKeyword(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static void Dump(System.Collections.Generic.IEnumerable<IMSBuildItem> items, Common.ILogger log) { }
+
+        public static string FixSourcePath(string s) { throw null; }
+
+        public static ProjectModel.DependencyGraphSpec GetDependencySpec(System.Collections.Generic.IEnumerable<IMSBuildItem> items) { throw null; }
+
+        public static ProjectModel.PackageSpec GetPackageSpec(System.Collections.Generic.IEnumerable<IMSBuildItem> items) { throw null; }
+
+        public static ProjectModel.RestoreAuditProperties GetRestoreAuditProperties(IMSBuildItem specItem) { throw null; }
+
+        public static Common.RestoreLogMessage GetWarningForUnsupportedProject(string path) { throw null; }
+
+        public static bool HasInvalidClear(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static bool LogErrorForClearIfInvalid(System.Collections.Generic.IEnumerable<string> values, string projectPath, Common.ILogger logger) { throw null; }
+
+        public static void NormalizePathCasings(System.Collections.Generic.Dictionary<string, string> paths, ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static void NormalizePathCasings(System.Collections.Generic.IDictionary<string, string> paths, ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static void RemoveMissingProjects(ProjectModel.DependencyGraphSpec graphSpec) { }
+
+        public static System.Threading.Tasks.Task ReplayWarningsAndErrorsAsync(System.Collections.Generic.IEnumerable<ProjectModel.IAssetsLogMessage> messages, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class NoOpRestoreResult : RestoreResult
+    {
+        public NoOpRestoreResult(bool success, string lockFilePath, System.Lazy<ProjectModel.LockFile> lockFileLazy, ProjectModel.CacheFile cacheFile, string cacheFilePath, ProjectModel.ProjectStyle projectStyle, System.TimeSpan elapsedTime) : base(default, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default!, default, default) { }
+
+        public override ProjectModel.LockFile LockFile { get { throw null; } }
+
+        public override ProjectModel.LockFile PreviousLockFile { get { throw null; } }
+
+        public override System.Threading.Tasks.Task CommitAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public override System.Collections.Generic.ISet<LibraryModel.LibraryIdentity> GetAllInstalled() { throw null; }
+    }
+
+    public static partial class NoOpRestoreUtilities
+    {
+        public static string GetProjectCacheFilePath(string cacheRoot, string projectPath) { throw null; }
+
+        public static string GetProjectCacheFilePath(string cacheRoot) { throw null; }
+    }
+
+    public partial class OriginalCaseGlobalPackageFolder
+    {
+        public OriginalCaseGlobalPackageFolder(RestoreRequest request, System.Guid parentId) { }
+
+        public OriginalCaseGlobalPackageFolder(RestoreRequest request) { }
+
+        public System.Guid ParentId { get { throw null; } }
+
+        public void ConvertLockFileToOriginalCase(ProjectModel.LockFile lockFile) { }
+
+        public System.Threading.Tasks.Task CopyPackagesToOriginalCaseAsync(System.Collections.Generic.IEnumerable<RestoreTargetGraph> graphs, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial struct OutputLibFile
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string FinalOutputPath { get { throw null; } set { } }
+
+        public string TargetFramework { get { throw null; } set { } }
+
+        public string TargetPath { get { throw null; } set { } }
+    }
+
+    public partial class PackagesLockFileBuilder
+    {
+        public ProjectModel.PackagesLockFile CreateNuGetLockFile(ProjectModel.LockFile assetsFile) { throw null; }
+    }
+
+    public static partial class PackageSourceProviderExtensions
+    {
+        public static string ResolveAndValidateSource(this Configuration.IPackageSourceProvider sourceProvider, string source) { throw null; }
+
+        public static Configuration.PackageSource ResolveSource(System.Collections.Generic.IEnumerable<Configuration.PackageSource> availableSources, string source) { throw null; }
+    }
+
+    public partial class PackageSpecificWarningProperties : System.IEquatable<PackageSpecificWarningProperties>
+    {
+        public System.Collections.Generic.IDictionary<Common.NuGetLogCode, System.Collections.Generic.IDictionary<string, System.Collections.Generic.ISet<Frameworks.NuGetFramework>>> Properties { get { throw null; } }
+
+        public void Add(Common.NuGetLogCode code, string libraryId, Frameworks.NuGetFramework framework) { }
+
+        public void AddRangeOfCodes(System.Collections.Generic.IEnumerable<Common.NuGetLogCode> codes, string libraryId, Frameworks.NuGetFramework framework) { }
+
+        public void AddRangeOfFrameworks(Common.NuGetLogCode code, string libraryId, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworks) { }
+
+        public bool Contains(Common.NuGetLogCode code, string libraryId, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(ProjectModel.PackageSpec packageSpec, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(ProjectModel.PackageSpec packageSpec) { throw null; }
+
+        public bool Equals(PackageSpecificWarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackArgs
+    {
+        public System.Collections.Generic.IEnumerable<string> Arguments { get { throw null; } set { } }
+
+        public string BasePath { get { throw null; } set { } }
+
+        public bool Build { get { throw null; } set { } }
+
+        public string CurrentDirectory { get { throw null; } set { } }
+
+        public bool Deterministic { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Exclude { get { throw null; } set { } }
+
+        public bool ExcludeEmptyDirectories { get { throw null; } set { } }
+
+        public bool IncludeReferencedProjects { get { throw null; } set { } }
+
+        public bool InstallPackageToOutputPath { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Common.LogLevel LogLevel { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public System.Version MinClientVersion { get { throw null; } set { } }
+
+        public System.Lazy<string> MsBuildDirectory { get { throw null; } set { } }
+
+        public bool NoDefaultExcludes { get { throw null; } set { } }
+
+        public bool NoPackageAnalysis { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        public bool OutputFileNamesWithoutVersion { get { throw null; } set { } }
+
+        public string PackagesDirectory { get { throw null; } set { } }
+
+        public MSBuildPackTargetArgs PackTargetArgs { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.Dictionary<string, string> Properties { get { throw null; } }
+
+        public bool Serviceable { get { throw null; } set { } }
+
+        public string SolutionDirectory { get { throw null; } set { } }
+
+        public string Suffix { get { throw null; } set { } }
+
+        public SymbolPackageFormat SymbolPackageFormat { get { throw null; } set { } }
+
+        public bool Symbols { get { throw null; } set { } }
+
+        public bool Tool { get { throw null; } set { } }
+
+        public string Version { get { throw null; } set { } }
+
+        public ProjectModel.WarningProperties WarningProperties { get { throw null; } set { } }
+
+        public string GetPropertyValue(string propertyName) { throw null; }
+
+        public static SymbolPackageFormat GetSymbolPackageFormat(string symbolPackageFormat) { throw null; }
+    }
+
+    public partial class PackCollectorLogger : Common.LoggerBase
+    {
+        public PackCollectorLogger(Common.ILogger innerLogger, ProjectModel.WarningProperties warningProperties, PackCommand.PackageSpecificWarningProperties packageSpecificWarningProperties) { }
+
+        public PackCollectorLogger(Common.ILogger innerLogger, ProjectModel.WarningProperties warningProperties) { }
+
+        public System.Collections.Generic.IEnumerable<Common.ILogMessage> Errors { get { throw null; } }
+
+        public ProjectModel.WarningProperties WarningProperties { get { throw null; } set { } }
+
+        public override void Log(Common.ILogMessage message) { }
+
+        public override System.Threading.Tasks.Task LogAsync(Common.ILogMessage message) { throw null; }
+    }
+
+    public partial class PackCommandRunner
+    {
+        public PackCommandRunner(PackArgs packArgs, CreateProjectFactory createProjectFactory, Packaging.PackageBuilder packageBuilder) { }
+
+        public PackCommandRunner(PackArgs packArgs, CreateProjectFactory createProjectFactory) { }
+
+        public bool GenerateNugetPackage { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Packaging.Rules.IPackageRule> Rules { get { throw null; } set { } }
+
+        public static void AddDependencyGroups(System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> dependencies, Frameworks.NuGetFramework framework, Packaging.PackageBuilder builder) { }
+
+        public static void AddLibraryDependency(LibraryModel.LibraryDependency dependency, System.Collections.Generic.ISet<LibraryModel.LibraryDependency> list) { }
+
+        public static void AddPackageDependency(Packaging.Core.PackageDependency dependency, System.Collections.Generic.ISet<Packaging.Core.PackageDependency> set) { }
+
+        [System.Obsolete("Do not use this. Use RunPackageBuild() instead as it accounts for the effects of package analysis to the complete operation status.")]
+        public void BuildPackage() { }
+
+        [System.Obsolete("Do not use this. Use RunPackageBuild() instead as it accounts for the effects of package analysis to the complete operation status.")]
+        public Packaging.PackageArchiveReader BuildPackage(Packaging.PackageBuilder builder, string outputPath = null) { throw null; }
+
+        public static string GetInputFile(PackArgs packArgs) { throw null; }
+
+        public static string GetOutputFileName(string packageId, Versioning.NuGetVersion version, bool isNupkg, bool symbols, SymbolPackageFormat symbolPackageFormat, bool excludeVersion = false) { throw null; }
+
+        public static string GetOutputPath(Packaging.PackageBuilder builder, PackArgs packArgs, bool symbols = false, Versioning.NuGetVersion nugetVersion = null, string outputDirectory = null, bool isNupkg = true) { throw null; }
+
+        [System.Obsolete]
+        public static bool ProcessProjectJsonFile(Packaging.PackageBuilder builder, string basePath, string id, Versioning.NuGetVersion version, string suffix, System.Func<string, string> propertyProvider) { throw null; }
+
+        public bool RunPackageBuild() { throw null; }
+
+        public static void SetupCurrentDirectory(PackArgs packArgs) { }
+
+        public delegate IProjectFactory CreateProjectFactory(PackArgs packArgs, string path);
+    }
+
+    public static partial class PushRunner
+    {
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, System.Collections.Generic.IList<string> packagePaths, string source, string apiKey, string symbolSource, string symbolApiKey, int timeoutSeconds, bool disableBuffering, bool noSymbols, bool noServiceEndpoint, bool skipDuplicate, Common.ILogger logger) { throw null; }
+
+        [System.Obsolete("Use Run method which takes multiple package paths.")]
+        public static System.Threading.Tasks.Task Run(Configuration.ISettings settings, Configuration.IPackageSourceProvider sourceProvider, string packagePath, string source, string apiKey, string symbolSource, string symbolApiKey, int timeoutSeconds, bool disableBuffering, bool noSymbols, bool noServiceEndpoint, bool skipDuplicate, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class RemoveClientCertArgs : IClientCertArgsWithConfigFile, IClientCertArgsWithPackageSource
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+    }
+
+    public static partial class RemoveClientCertRunner
+    {
+        public static void Run(RemoveClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class RemoveSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+    }
+
+    public static partial class RemoveSourceRunner
+    {
+        public static void Run(RemoveSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public static partial class RequestRuntimeUtility
+    {
+        public static System.Collections.Generic.IEnumerable<string> GetDefaultRestoreRuntimes(string os, string runtimeOsName) { throw null; }
+    }
+
+    public partial class ResolvedDependencyKey : System.IEquatable<ResolvedDependencyKey>
+    {
+        public ResolvedDependencyKey(LibraryModel.LibraryIdentity parent, Versioning.VersionRange range, LibraryModel.LibraryIdentity child) { }
+
+        public LibraryModel.LibraryIdentity Child { get { throw null; } }
+
+        public LibraryModel.LibraryIdentity Parent { get { throw null; } }
+
+        public Versioning.VersionRange Range { get { throw null; } }
+
+        public bool Equals(ResolvedDependencyKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ResolverConflict
+    {
+        public ResolverConflict(string name, System.Collections.Generic.IEnumerable<ResolverRequest> requests) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<ResolverRequest> Requests { get { throw null; } }
+    }
+
+    public partial class ResolverRequest
+    {
+        public ResolverRequest(LibraryModel.LibraryIdentity requestor, LibraryModel.LibraryRange request) { }
+
+        public LibraryModel.LibraryRange Request { get { throw null; } }
+
+        public LibraryModel.LibraryIdentity Requestor { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class RestoreArgs
+    {
+        public System.Collections.Generic.IReadOnlyList<ProjectModel.IAssetsLogMessage> AdditionalMessages { get { throw null; } set { } }
+
+        public bool AllowNoOp { get { throw null; } set { } }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } set { } }
+
+        public Protocol.CachingSourceProvider CachingSourceProvider { get { throw null; } set { } }
+
+        public string ConfigFile { get { throw null; } set { } }
+
+        public bool DisableParallel { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> FallbackRuntimes { get { throw null; } set { } }
+
+        public string GlobalPackagesFolder { get { throw null; } set { } }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<string> Inputs { get { throw null; } set { } }
+
+        public bool? IsLowercaseGlobalPackagesFolder { get { throw null; } set { } }
+
+        public bool IsRestoreOriginalAction { get { throw null; } set { } }
+
+        public int? LockFileVersion { get { throw null; } set { } }
+
+        public Common.ILogger Log { get { throw null; } set { } }
+
+        public Configuration.IMachineWideSettings MachineWideSettings { get { throw null; } set { } }
+
+        public Packaging.PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<IPreLoadedRestoreRequestProvider> PreLoadedRequestProviders { get { throw null; } set { } }
+
+        public IRestoreProgressReporter ProgressReporter { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<IRestoreRequestProvider> RequestProviders { get { throw null; } set { } }
+
+        public bool RestoreForceEvaluate { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> Runtimes { get { throw null; } set { } }
+
+        public System.Collections.Generic.List<string> Sources { get { throw null; } set { } }
+
+        public bool? ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public void ApplyStandardProperties(RestoreRequest request) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetEffectiveFallbackPackageFolders(Configuration.ISettings settings) { throw null; }
+
+        public string GetEffectiveGlobalPackagesFolder(string rootDirectory, Configuration.ISettings settings) { throw null; }
+
+        public Configuration.ISettings GetSettings(string projectDirectory) { throw null; }
+    }
+
+    public partial class RestoreCollectorLogger : Common.LoggerBase, Common.ICollectorLogger, Common.ILogger
+    {
+        public RestoreCollectorLogger(Common.ILogger innerLogger, Common.LogLevel verbosity, bool hideWarningsAndErrors) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger, Common.LogLevel verbosity) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger, bool hideWarningsAndErrors) { }
+
+        public RestoreCollectorLogger(Common.ILogger innerLogger) { }
+
+        public System.Collections.Generic.IEnumerable<Common.IRestoreLogMessage> Errors { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } }
+
+        public WarningPropertiesCollection ProjectWarningPropertiesCollection { get { throw null; } set { } }
+
+        public WarningPropertiesCollection TransitiveWarningPropertiesCollection { get { throw null; } set { } }
+
+        public void ApplyRestoreInputs(ProjectModel.PackageSpec projectSpec) { }
+
+        public void ApplyRestoreOutput(System.Collections.Generic.IEnumerable<RestoreTargetGraph> restoreTargetGraphs) { }
+
+        protected bool DisplayMessage(Common.IRestoreLogMessage message) { throw null; }
+
+        public override void Log(Common.ILogMessage message) { }
+
+        public void Log(Common.IRestoreLogMessage message) { }
+
+        public override System.Threading.Tasks.Task LogAsync(Common.ILogMessage message) { throw null; }
+
+        public System.Threading.Tasks.Task LogAsync(Common.IRestoreLogMessage message) { throw null; }
+    }
+
+    public partial class RestoreCommand
+    {
+        public RestoreCommand(RestoreRequest request) { }
+
+        public System.Guid ParentId { get { throw null; } }
+
+        public System.Threading.Tasks.Task<RestoreResult> ExecuteAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<RestoreResult> ExecuteAsync(System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class RestoreCommandException : System.Exception, Common.ILogMessageException
+    {
+        public RestoreCommandException(Common.IRestoreLogMessage logMessage) { }
+
+        public Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class RestoreCommandProviders
+    {
+        [System.Obsolete("Create via RestoreCommandProvidersCache")]
+        public RestoreCommandProviders(Repositories.NuGetv3LocalRepository globalPackages, System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> fallbackPackageFolders, System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> localProviders, System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> remoteProviders, Protocol.LocalPackageFileCache packageFileCache) { }
+
+        public System.Collections.Generic.IReadOnlyList<Repositories.NuGetv3LocalRepository> FallbackPackageFolders { get { throw null; } }
+
+        public Repositories.NuGetv3LocalRepository GlobalPackages { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> LocalProviders { get { throw null; } }
+
+        public Protocol.LocalPackageFileCache PackageFileCache { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<DependencyResolver.IRemoteDependencyProvider> RemoteProviders { get { throw null; } }
+
+        public static RestoreCommandProviders Create(string globalFolderPath, System.Collections.Generic.IEnumerable<string> fallbackPackageFolderPaths, System.Collections.Generic.IEnumerable<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Protocol.LocalPackageFileCache packageFileCache, Common.ILogger log) { throw null; }
+    }
+
+    public partial class RestoreCommandProvidersCache
+    {
+        public RestoreCommandProviders GetOrCreate(string globalPackagesPath, System.Collections.Generic.IReadOnlyList<string> fallbackPackagesPaths, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger log, bool updateLastAccess) { throw null; }
+
+        public RestoreCommandProviders GetOrCreate(string globalPackagesPath, System.Collections.Generic.IReadOnlyList<string> fallbackPackagesPaths, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger log) { throw null; }
+    }
+
+    public partial class RestoreRequest
+    {
+        public static readonly int DefaultDegreeOfConcurrency;
+        [System.Obsolete("Use constructor with LockFileBuilderCache parameter")]
+        public RestoreRequest(ProjectModel.PackageSpec project, RestoreCommandProviders dependencyProviders, Protocol.Core.Types.SourceCacheContext cacheContext, Packaging.Signing.ClientPolicyContext clientPolicyContext, Common.ILogger log) { }
+
+        public RestoreRequest(ProjectModel.PackageSpec project, RestoreCommandProviders dependencyProviders, Protocol.Core.Types.SourceCacheContext cacheContext, Packaging.Signing.ClientPolicyContext clientPolicyContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger log, LockFileBuilderCache lockFileBuilderCache) { }
+
+        public System.Collections.Generic.IReadOnlyList<ProjectModel.IAssetsLogMessage> AdditionalMessages { get { throw null; } set { } }
+
+        public bool AllowNoOp { get { throw null; } set { } }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } set { } }
+
+        public Packaging.Signing.ClientPolicyContext ClientPolicyContext { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Frameworks.FrameworkRuntimePair> CompatibilityProfiles { get { throw null; } }
+
+        public ProjectModel.DependencyGraphSpec DependencyGraphSpec { get { throw null; } set { } }
+
+        public RestoreCommandProviders DependencyProviders { get { throw null; } set { } }
+
+        public ProjectModel.LockFile ExistingLockFile { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectModel.ExternalProjectReference> ExternalProjects { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> FallbackRuntimes { get { throw null; } }
+
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public bool IsLowercasePackagesDirectory { get { throw null; } set { } }
+
+        public bool IsRestoreOriginalAction { get { throw null; } set { } }
+
+        public string LockFilePath { get { throw null; } set { } }
+
+        public int LockFileVersion { get { throw null; } set { } }
+
+        public Common.ILogger Log { get { throw null; } set { } }
+
+        public int MaxDegreeOfConcurrency { get { throw null; } set { } }
+
+        public string MSBuildProjectExtensionsPath { get { throw null; } set { } }
+
+        public Packaging.PackageSaveMode PackageSaveMode { get { throw null; } set { } }
+
+        public string PackagesDirectory { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Guid ParentId { get { throw null; } set { } }
+
+        public ProjectModel.PackageSpec Project { get { throw null; } }
+
+        public ProjectModel.ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<string> RequestedRuntimes { get { throw null; } }
+
+        public bool RestoreForceEvaluate { get { throw null; } set { } }
+
+        public string RestoreOutputPath { get { throw null; } set { } }
+
+        public bool UpdatePackageLastAccessTime { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public Packaging.XmlDocFileSaveMode XmlDocFileSaveMode { get { throw null; } set { } }
+    }
+
+    public partial class RestoreResult : IRestoreResult
+    {
+        public RestoreResult(bool success, System.Collections.Generic.IEnumerable<RestoreTargetGraph> restoreGraphs, System.Collections.Generic.IEnumerable<CompatibilityCheckResult> compatibilityCheckResults, System.Collections.Generic.IEnumerable<MSBuildOutputFile> msbuildFiles, ProjectModel.LockFile lockFile, ProjectModel.LockFile previousLockFile, string lockFilePath, ProjectModel.CacheFile cacheFile, string cacheFilePath, string packagesLockFilePath, ProjectModel.PackagesLockFile packagesLockFile, string dependencyGraphSpecFilePath, ProjectModel.DependencyGraphSpec dependencyGraphSpec, ProjectModel.ProjectStyle projectStyle, System.TimeSpan elapsedTime) { }
+
+        protected string CacheFilePath { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<CompatibilityCheckResult> CompatibilityCheckResults { get { throw null; } }
+
+        public System.TimeSpan ElapsedTime { get { throw null; } }
+
+        public virtual ProjectModel.LockFile LockFile { get { throw null; } }
+
+        public string LockFilePath { get { throw null; } set { } }
+
+        public virtual System.Collections.Generic.IList<ProjectModel.IAssetsLogMessage> LogMessages { get { throw null; } internal set { } }
+
+        public System.Collections.Generic.IEnumerable<MSBuildOutputFile> MSBuildOutputFiles { get { throw null; } }
+
+        public virtual ProjectModel.LockFile PreviousLockFile { get { throw null; } }
+
+        public ProjectModel.ProjectStyle ProjectStyle { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<RestoreTargetGraph> RestoreGraphs { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+
+        public virtual System.Threading.Tasks.Task CommitAsync(Common.ILogger log, System.Threading.CancellationToken token) { throw null; }
+
+        public virtual System.Collections.Generic.ISet<LibraryModel.LibraryIdentity> GetAllInstalled() { throw null; }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> GetAllUnresolved() { throw null; }
+    }
+
+    public partial class RestoreResultPair
+    {
+        public RestoreResultPair(RestoreSummaryRequest request, RestoreResult result) { }
+
+        public RestoreResult Result { get { throw null; } }
+
+        public RestoreSummaryRequest SummaryRequest { get { throw null; } }
+    }
+
+    public static partial class RestoreRunner
+    {
+        public static System.Threading.Tasks.Task<RestoreSummary> CommitAsync(RestoreResultPair restoreResult, System.Threading.CancellationToken token) { throw null; }
+
+        public static string GetInvalidInputErrorMessage(string input) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest>> GetRequests(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummary>> RunAsync(RestoreArgs restoreContext, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreSummary>> RunAsync(RestoreArgs restoreContext) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<RestoreResultPair>> RunWithoutCommit(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> restoreRequests, RestoreArgs restoreContext) { throw null; }
+    }
+
+    public partial class RestoreSpecException : System.Exception
+    {
+        internal RestoreSpecException() { }
+
+        public System.Collections.Generic.IEnumerable<string> Files { get { throw null; } }
+
+        public static RestoreSpecException Create(string message, System.Collections.Generic.IEnumerable<string> files, System.Exception innerException) { throw null; }
+
+        public static RestoreSpecException Create(string message, System.Collections.Generic.IEnumerable<string> files) { throw null; }
+    }
+
+    public partial class RestoreSummary
+    {
+        public RestoreSummary(RestoreResult result, string inputPath, System.Collections.Generic.IEnumerable<string> configFiles, System.Collections.Generic.IEnumerable<Protocol.Core.Types.SourceRepository> sourceRepositories, System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> errors) { }
+
+        public RestoreSummary(bool success, string inputPath, System.Collections.Generic.IReadOnlyList<string> configFiles, System.Collections.Generic.IReadOnlyList<string> feedsUsed, int installCount, System.Collections.Generic.IReadOnlyList<Common.IRestoreLogMessage> errors) { }
+
+        public RestoreSummary(bool success) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ConfigFiles { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Common.IRestoreLogMessage> Errors { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> FeedsUsed { get { throw null; } }
+
+        public string InputPath { get { throw null; } }
+
+        public int InstallCount { get { throw null; } }
+
+        public bool NoOpRestore { get { throw null; } }
+
+        public bool Success { get { throw null; } }
+
+        public static void Log(Common.ILogger logger, System.Collections.Generic.IReadOnlyList<RestoreSummary> restoreSummaries, bool logErrors = false) { }
+    }
+
+    public partial class RestoreSummaryRequest
+    {
+        public RestoreSummaryRequest(RestoreRequest request, string inputPath, System.Collections.Generic.IEnumerable<string> configFiles, System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> sources) { }
+
+        public System.Collections.Generic.IEnumerable<string> ConfigFiles { get { throw null; } }
+
+        public string InputPath { get { throw null; } }
+
+        public RestoreRequest Request { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Protocol.Core.Types.SourceRepository> Sources { get { throw null; } }
+    }
+
+    public partial class RestoreTargetGraph : IRestoreTargetGraph
+    {
+        internal RestoreTargetGraph() { }
+
+        public DependencyResolver.AnalyzeResult<DependencyResolver.RemoteResolveResult> AnalyzeResult { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<ResolverConflict> Conflicts { get { throw null; } }
+
+        public Client.ManagedCodeConventions Conventions { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.GraphItem<DependencyResolver.RemoteResolveResult>> Flattened { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> Graphs { get { throw null; } }
+
+        public bool InConflict { get { throw null; } }
+
+        public System.Collections.Generic.ISet<DependencyResolver.RemoteMatch> Install { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.ISet<ResolvedDependencyKey> ResolvedDependencies { get { throw null; } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public string TargetGraphName { get { throw null; } }
+
+        public System.Collections.Generic.ISet<LibraryModel.LibraryRange> Unresolved { get { throw null; } }
+
+        public static RestoreTargetGraph Create(RuntimeModel.RuntimeGraph runtimeGraph, System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> graphs, DependencyResolver.RemoteWalkContext context, Common.ILogger log, Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public static RestoreTargetGraph Create(System.Collections.Generic.IEnumerable<DependencyResolver.GraphNode<DependencyResolver.RemoteResolveResult>> graphs, DependencyResolver.RemoteWalkContext context, Common.ILogger logger, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class SignArgs
+    {
+        public string CertificateFingerprint { get { throw null; } set { } }
+
+        public string CertificatePassword { get { throw null; } set { } }
+
+        public string CertificatePath { get { throw null; } set { } }
+
+        public System.Security.Cryptography.X509Certificates.StoreLocation CertificateStoreLocation { get { throw null; } set { } }
+
+        public System.Security.Cryptography.X509Certificates.StoreName CertificateStoreName { get { throw null; } set { } }
+
+        public string CertificateSubjectName { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public bool NonInteractive { get { throw null; } set { } }
+
+        public string OutputDirectory { get { throw null; } set { } }
+
+        public bool Overwrite { get { throw null; } set { } }
+
+        [System.Obsolete("Use PackagePaths instead")]
+        public string PackagePath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackagePaths { get { throw null; } set { } }
+
+        public SignCommand.IPasswordProvider PasswordProvider { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName SignatureHashAlgorithm { get { throw null; } set { } }
+
+        public string Timestamper { get { throw null; } set { } }
+
+        public Common.HashAlgorithmName TimestampHashAlgorithm { get { throw null; } set { } }
+
+        public System.Threading.CancellationToken Token { get { throw null; } set { } }
+    }
+
+    public sealed partial class SignCommandException : System.Exception, Common.ILogMessageException
+    {
+        public SignCommandException(Common.ILogMessage logMessage) { }
+
+        public Common.ILogMessage AsLogMessage() { throw null; }
+    }
+
+    public partial class SignCommandRunner : ISignCommandRunner
+    {
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(SignArgs signArgs) { throw null; }
+
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(System.Collections.Generic.IEnumerable<string> packagesToSign, Packaging.Signing.SignPackageRequest signPackageRequest, string timestamper, Common.ILogger logger, string outputDirectory, bool overwrite, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class SourceRepositoryDependencyProvider : DependencyResolver.IRemoteDependencyProvider
+    {
+        public SourceRepositoryDependencyProvider(Protocol.Core.Types.SourceRepository sourceRepository, Common.ILogger logger, Protocol.Core.Types.SourceCacheContext cacheContext, bool ignoreFailedSources, bool ignoreWarning, Protocol.LocalPackageFileCache fileCache, bool isFallbackFolderSource) { }
+
+        public SourceRepositoryDependencyProvider(Protocol.Core.Types.SourceRepository sourceRepository, Common.ILogger logger, Protocol.Core.Types.SourceCacheContext cacheContext, bool ignoreFailedSources, bool ignoreWarning) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public Protocol.Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public enum SourcesAction
+    {
+        None = 0,
+        List = 1,
+        Add = 2,
+        Remove = 3,
+        Enable = 4,
+        Disable = 5,
+        Update = 6
+    }
+
+    public enum SourcesListFormat
+    {
+        None = 0,
+        Detailed = 1,
+        Short = 2
+    }
+
+    public static partial class SpecValidationUtility
+    {
+        public static void ValidateDependencySpec(ProjectModel.DependencyGraphSpec spec, System.Collections.Generic.HashSet<string> projectsToSkip) { }
+
+        public static void ValidateDependencySpec(ProjectModel.DependencyGraphSpec spec) { }
+
+        public static void ValidateProjectSpec(ProjectModel.PackageSpec spec) { }
+    }
+
+    public enum SymbolPackageFormat
+    {
+        Snupkg = 0,
+        SymbolsNupkg = 1
+    }
+
+    public static partial class ToolRestoreUtility
+    {
+        public static ProjectModel.PackageSpec GetSpec(string projectFilePath, string id, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework, string packagesPath, System.Collections.Generic.IList<string> fallbackFolders, System.Collections.Generic.IList<Configuration.PackageSource> sources, ProjectModel.WarningProperties projectWideWarningProperties) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest> GetSubSetRequests(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> requestSummaries) { throw null; }
+
+        public static System.Collections.Generic.IReadOnlyList<RestoreSummaryRequest> GetSubSetRequestsForSingleId(System.Collections.Generic.IEnumerable<RestoreSummaryRequest> requests) { throw null; }
+
+        public static LibraryModel.LibraryDependency GetToolDependencyOrNullFromSpec(ProjectModel.PackageSpec spec) { throw null; }
+
+        public static string GetToolIdOrNullFromSpec(ProjectModel.PackageSpec spec) { throw null; }
+
+        public static ProjectModel.LockFileTargetLibrary GetToolTargetLibrary(ProjectModel.LockFile toolLockFile, string toolId) { throw null; }
+
+        public static string GetUniqueName(string id, string framework, Versioning.VersionRange versionRange) { throw null; }
+    }
+
+    public static partial class TransitiveNoWarnUtils
+    {
+        public static WarningPropertiesCollection CreateTransitiveWarningPropertiesCollection(System.Collections.Generic.IEnumerable<RestoreTargetGraph> targetGraphs, ProjectModel.PackageSpec parentProjectSpec) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> ExtractPackageSpecificNoWarnForFramework(PackageSpecificWarningProperties packageSpecificWarningProperties, Frameworks.NuGetFramework framework) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<Frameworks.NuGetFramework, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>>> ExtractPackageSpecificNoWarnPerFramework(PackageSpecificWarningProperties packageSpecificWarningProperties) { throw null; }
+
+        public static System.Collections.Generic.HashSet<Common.NuGetLogCode> ExtractPathNoWarnProperties(NodeWarningProperties nodeWarningProperties, string libraryId) { throw null; }
+
+        public static System.Collections.Generic.HashSet<Common.NuGetLogCode> MergeCodes(System.Collections.Generic.HashSet<Common.NuGetLogCode> first, System.Collections.Generic.HashSet<Common.NuGetLogCode> second) { throw null; }
+
+        public static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> MergePackageSpecificNoWarn(System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> first, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> second) { throw null; }
+
+        public static PackageSpecificWarningProperties MergePackageSpecificWarningProperties(PackageSpecificWarningProperties first, PackageSpecificWarningProperties second) { throw null; }
+
+        public static bool TryMergeNullObjects<T>(T first, T second, out T merged)
+            where T : class { throw null; }
+
+        public partial class DependencyNode : System.IEquatable<DependencyNode>
+        {
+            public DependencyNode(string id, bool isProject, NodeWarningProperties nodeWarningProperties) { }
+
+            public DependencyNode(string id, bool isProject, System.Collections.Generic.HashSet<Common.NuGetLogCode> projectWideNoWarn, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> packageSpecificNoWarn) { }
+
+            public string Id { get { throw null; } }
+
+            public bool IsProject { get { throw null; } }
+
+            public NodeWarningProperties NodeWarningProperties { get { throw null; } }
+
+            public bool Equals(DependencyNode other) { throw null; }
+
+            public override bool Equals(object obj) { throw null; }
+
+            public override int GetHashCode() { throw null; }
+
+            public override string ToString() { throw null; }
+        }
+
+        public partial class NodeWarningProperties : System.IEquatable<NodeWarningProperties>
+        {
+            public NodeWarningProperties(System.Collections.Generic.HashSet<Common.NuGetLogCode> projectWide, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> packageSpecific) { }
+
+            public System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<Common.NuGetLogCode>> PackageSpecific { get { throw null; } }
+
+            public System.Collections.Generic.HashSet<Common.NuGetLogCode> ProjectWide { get { throw null; } }
+
+            public bool Equals(NodeWarningProperties other) { throw null; }
+
+            public override bool Equals(object obj) { throw null; }
+
+            public override int GetHashCode() { throw null; }
+
+            public NodeWarningProperties GetIntersect(NodeWarningProperties other) { throw null; }
+
+            public bool IsSubSetOf(NodeWarningProperties other) { throw null; }
+        }
+    }
+
+    public sealed partial class TrustedSignerActionsProvider
+    {
+        public TrustedSignerActionsProvider(Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, Common.ILogger logger) { }
+
+        public void AddOrUpdateTrustedSigner(string name, string fingerprint, Common.HashAlgorithmName hashAlgorithm, bool allowUntrustedRoot) { }
+
+        public System.Threading.Tasks.Task AddTrustedRepositoryAsync(string name, System.Uri serviceIndex, System.Collections.Generic.IEnumerable<string> owners, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task SyncTrustedRepositoryAsync(string name, System.Threading.CancellationToken token) { throw null; }
+    }
+
+    public partial class TrustedSignersArgs
+    {
+        public TrustedSignersAction Action { get { throw null; } set { } }
+
+        public bool AllowUntrustedRoot { get { throw null; } set { } }
+
+        public bool Author { get { throw null; } set { } }
+
+        public string CertificateFingerprint { get { throw null; } set { } }
+
+        public string FingerprintAlgorithm { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<string> Owners { get { throw null; } set { } }
+
+        public string PackagePath { get { throw null; } set { } }
+
+        public bool Repository { get { throw null; } set { } }
+
+        public string ServiceIndex { get { throw null; } set { } }
+
+        public enum TrustedSignersAction
+        {
+            Add = 0,
+            List = 1,
+            Remove = 2,
+            Sync = 3
+        }
+    }
+
+    public partial class TrustedSignersCommandRunner : ITrustedSignersCommandRunner
+    {
+        public TrustedSignersCommandRunner(Packaging.Signing.ITrustedSignersProvider trustedSignersProvider, Configuration.IPackageSourceProvider packageSourceProvider) { }
+
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(TrustedSignersArgs trustedSignersArgs) { throw null; }
+    }
+
+    public static partial class UnexpectedDependencyMessages
+    {
+        public static bool DependencyRangeHasMissingExactMatch(ResolvedDependencyKey dependency) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetBumpedUpDependencies(System.Collections.Generic.List<IndexedRestoreTargetGraph> graphs, ProjectModel.PackageSpec project, System.Collections.Generic.ISet<string> ignoreIds) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetDependenciesAboveUpperBounds(System.Collections.Generic.List<IndexedRestoreTargetGraph> graphs, Common.ILogger logger) { throw null; }
+
+        public static Common.RestoreLogMessage GetMissingLowerBoundMessage(ResolvedDependencyKey dependency, params string[] targetGraphs) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetMissingLowerBounds(System.Collections.Generic.IEnumerable<IRestoreTargetGraph> graphs, System.Collections.Generic.ISet<string> ignoreIds) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Common.RestoreLogMessage> GetProjectDependenciesMissingLowerBounds(ProjectModel.PackageSpec project) { throw null; }
+
+        public static bool HasMissingLowerBound(Versioning.VersionRange range) { throw null; }
+
+        public static System.Threading.Tasks.Task LogAsync(System.Collections.Generic.IEnumerable<IRestoreTargetGraph> graphs, ProjectModel.PackageSpec project, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class UpdateClientCertArgs : IClientCertArgsWithPackageSource, IClientCertArgsWithConfigFile, IClientCertArgsWithFileData, IClientCertArgsWithStoreData, IClientCertArgsWithForce
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string FindBy { get { throw null; } set { } }
+
+        public string FindValue { get { throw null; } set { } }
+
+        public bool Force { get { throw null; } set { } }
+
+        public string PackageSource { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string StoreLocation { get { throw null; } set { } }
+
+        public string StoreName { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+    }
+
+    public static partial class UpdateClientCertRunner
+    {
+        public static void Run(UpdateClientCertArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class UpdateSourceArgs
+    {
+        public string Configfile { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Password { get { throw null; } set { } }
+
+        public string Source { get { throw null; } set { } }
+
+        public bool StorePasswordInClearText { get { throw null; } set { } }
+
+        public string Username { get { throw null; } set { } }
+
+        public string ValidAuthenticationTypes { get { throw null; } set { } }
+    }
+
+    public static partial class UpdateSourceRunner
+    {
+        public static void Run(UpdateSourceArgs args, System.Func<Common.ILogger> getLogger) { }
+    }
+
+    public partial class VerifyArgs
+    {
+        public System.Collections.Generic.IEnumerable<string> CertificateFingerprint { get { throw null; } set { } }
+
+        public Common.ILogger Logger { get { throw null; } set { } }
+
+        public Common.LogLevel LogLevel { get { throw null; } set { } }
+
+        [System.Obsolete("Use PackagePaths instead")]
+        public string PackagePath { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> PackagePaths { get { throw null; } set { } }
+
+        public Configuration.ISettings Settings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Verification> Verifications { get { throw null; } set { } }
+
+        public enum Verification
+        {
+            Unknown = 0,
+            All = 1,
+            Signatures = 2
+        }
+    }
+
+    public partial class VerifyCommandRunner : IVerifyCommandRunner
+    {
+        public System.Threading.Tasks.Task<int> ExecuteCommandAsync(VerifyArgs verifyArgs) { throw null; }
+    }
+
+    public partial class WarningPropertiesCollection : System.IEquatable<WarningPropertiesCollection>
+    {
+        public WarningPropertiesCollection(ProjectModel.WarningProperties projectWideWarningProperties, PackageSpecificWarningProperties packageSpecificWarningProperties, System.Collections.Generic.IReadOnlyList<Frameworks.NuGetFramework> projectFrameworks) { }
+
+        public PackageSpecificWarningProperties PackageSpecificWarningProperties { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<Frameworks.NuGetFramework> ProjectFrameworks { get { throw null; } }
+
+        public ProjectModel.WarningProperties ProjectWideWarningProperties { get { throw null; } }
+
+        public bool ApplyNoWarnProperties(Common.IRestoreLogMessage message) { throw null; }
+
+        public static bool ApplyProjectWideNoWarnProperties(Common.ILogMessage message, ProjectModel.WarningProperties warningProperties) { throw null; }
+
+        public static void ApplyProjectWideWarningsAsErrorProperties(Common.ILogMessage message, ProjectModel.WarningProperties warningProperties) { }
+
+        public void ApplyWarningAsErrorProperties(Common.IRestoreLogMessage message) { }
+
+        public bool ApplyWarningProperties(Common.IRestoreLogMessage message) { throw null; }
+
+        public bool Equals(WarningPropertiesCollection other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+}
+
+namespace NuGet.Commands.PackCommand
+{
+    public partial class PackageSpecificWarningProperties
+    {
+        public static PackageSpecificWarningProperties CreatePackageSpecificWarningProperties(System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<(Common.NuGetLogCode, Frameworks.NuGetFramework)>> noWarnProperties) { throw null; }
+    }
+}
+
+namespace NuGet.Commands.SignCommand
+{
+    public partial interface IPasswordProvider
+    {
+    }
+}

--- a/src/referencePackages/src/nuget.commands/6.7.0/nuget.commands.nuspec
+++ b/src/referencePackages/src/nuget.commands/6.7.0/nuget.commands.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.Commands</id>
+    <version>6.7.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>Complete commands common to command-line and GUI NuGet clients.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="b46f5f64159a81d930ac8cdfde96e76f90796c62" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.Credentials" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.ProjectModel" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.FileProviders.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.FileSystemGlobbing" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Credentials" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.ProjectModel" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.FileProviders.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.FileSystemGlobbing" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/NuGet.DependencyResolver.Core.6.7.0.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/NuGet.DependencyResolver.Core.6.7.0.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.DependencyResolver.Core</AssemblyName>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.7.0" />
+    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Configuration" Version="6.7.0" />
+    <PackageReference Include="NuGet.LibraryModel" Version="6.7.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/lib/net5.0/NuGet.DependencyResolver.Core.cs
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/lib/net5.0/NuGet.DependencyResolver.Core.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.DependencyResolver.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = ".NET 5.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's PackageReference dependency resolver implementation.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.DependencyResolver.Core")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.DependencyResolver
+{
+    public partial class AnalyzeResult<TItem>
+    {
+        public System.Collections.Generic.List<GraphNode<TItem>> Cycles { get { throw null; } }
+
+        public System.Collections.Generic.List<DowngradeResult<TItem>> Downgrades { get { throw null; } }
+
+        public System.Collections.Generic.List<VersionConflictResult<TItem>> VersionConflicts { get { throw null; } }
+
+        public void Combine(AnalyzeResult<TItem> result) { }
+    }
+
+    public enum Disposition
+    {
+        Acceptable = 0,
+        Rejected = 1,
+        Accepted = 2,
+        PotentiallyDowngraded = 3,
+        Cycle = 4
+    }
+
+    public partial class DowngradeResult<TItem>
+    {
+        public GraphNode<TItem> DowngradedFrom { get { throw null; } set { } }
+
+        public GraphNode<TItem> DowngradedTo { get { throw null; } set { } }
+    }
+
+    public partial class GraphEdge<TItem>
+    {
+        public GraphEdge(GraphEdge<TItem> outerEdge, GraphItem<TItem> item, LibraryModel.LibraryDependency edge) { }
+
+        public LibraryModel.LibraryDependency Edge { get { throw null; } }
+
+        public GraphItem<TItem> Item { get { throw null; } }
+
+        public GraphEdge<TItem> OuterEdge { get { throw null; } }
+    }
+
+    public sealed partial class GraphItemKeyComparer<T> : System.Collections.Generic.IEqualityComparer<GraphItem<T>>
+    {
+        internal GraphItemKeyComparer() { }
+
+        public static GraphItemKeyComparer<T> Instance { get { throw null; } }
+
+        public bool Equals(GraphItem<T> x, GraphItem<T> y) { throw null; }
+
+        public int GetHashCode(GraphItem<T> obj) { throw null; }
+    }
+
+    public partial class GraphItem<TItem> : System.IEquatable<GraphItem<TItem>>
+    {
+        public GraphItem(LibraryModel.LibraryIdentity key) { }
+
+        public TItem Data { get { throw null; } set { } }
+
+        public bool IsCentralTransitive { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIdentity Key { get { throw null; } set { } }
+
+        public bool Equals(GraphItem<TItem> other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class GraphNode<TItem>
+    {
+        public GraphNode(LibraryModel.LibraryRange key) { }
+
+        public Disposition Disposition { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> InnerNodes { get { throw null; } set { } }
+
+        public GraphItem<TItem> Item { get { throw null; } set { } }
+
+        public LibraryModel.LibraryRange Key { get { throw null; } set { } }
+
+        public GraphNode<TItem> OuterNode { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> ParentNodes { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class GraphOperations
+    {
+        public static AnalyzeResult<RemoteResolveResult> Analyze(this GraphNode<RemoteResolveResult> root) { throw null; }
+
+        public static void Dump<TItem>(this GraphNode<TItem> root, System.Action<string> write) { }
+
+        public static void ForEach<TItem>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem>(this System.Collections.Generic.IEnumerable<GraphNode<TItem>> roots, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem, TContext>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>, TContext> visitor, TContext context) { }
+
+        public static string GetId<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndVersionOrRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPath<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPathWithLastRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionOrDefault<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.VersionRange GetVersionRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static bool IsPackage<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static GraphNode<TItem> Path<TItem>(this GraphNode<TItem> node, params string[] path) { throw null; }
+
+        public static void ReleaseDowngradesDictionary(System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> dictionary) { }
+
+        public static System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> RentDowngradesDictionary() { throw null; }
+    }
+
+    public partial interface IDependencyProvider
+    {
+        LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework);
+        bool SupportsType(LibraryModel.LibraryDependencyTarget libraryTypeFlag);
+    }
+
+    public partial interface IRemoteDependencyProvider
+    {
+        bool IsHttp { get; }
+
+        Configuration.PackageSource Source { get; }
+
+        Protocol.Core.Types.SourceRepository SourceRepository { get; }
+
+        System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public readonly partial struct LibraryRangeCacheKey : System.IEquatable<LibraryRangeCacheKey>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public LibraryRangeCacheKey(LibraryModel.LibraryRange range, Frameworks.NuGetFramework framework) { }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryModel.LibraryRange LibraryRange { get { throw null; } }
+
+        public readonly bool Equals(LibraryRangeCacheKey other) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryRangeCacheKey left, LibraryRangeCacheKey right) { throw null; }
+
+        public static bool operator !=(LibraryRangeCacheKey left, LibraryRangeCacheKey right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class LocalDependencyProvider : IRemoteDependencyProvider
+    {
+        public LocalDependencyProvider(IDependencyProvider dependencyProvider) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public Protocol.Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalMatch : RemoteMatch
+    {
+        public LibraryModel.Library LocalLibrary { get { throw null; } set { } }
+
+        public IDependencyProvider LocalProvider { get { throw null; } set { } }
+    }
+
+    public partial class LockFileCacheKey : System.IEquatable<LockFileCacheKey>
+    {
+        public LockFileCacheKey(Frameworks.NuGetFramework framework, string runtimeIdentifier) { }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(LockFileCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class PackagingUtility
+    {
+        public static LibraryModel.LibraryDependency GetLibraryDependencyFromNuspec(Packaging.Core.PackageDependency dependency) { throw null; }
+    }
+
+    public partial class RemoteDependencyWalker
+    {
+        public RemoteDependencyWalker(RemoteWalkContext context) { }
+
+        public static bool IsGreaterThanOrEqualTo(Versioning.VersionRange nearVersion, Versioning.VersionRange farVersion) { throw null; }
+
+        public System.Threading.Tasks.Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryModel.LibraryRange library, Frameworks.NuGetFramework framework, string runtimeIdentifier, RuntimeModel.RuntimeGraph runtimeGraph, bool recursive) { throw null; }
+    }
+
+    public partial class RemoteMatch : System.IEquatable<RemoteMatch>
+    {
+        public LibraryModel.LibraryIdentity Library { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public IRemoteDependencyProvider Provider { get { throw null; } set { } }
+
+        public bool Equals(RemoteMatch other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class RemoteResolveResult
+    {
+        public System.Collections.Generic.List<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public RemoteMatch Match { get { throw null; } set { } }
+    }
+
+    public partial class RemoteWalkContext
+    {
+        public RemoteWalkContext(Protocol.Core.Types.SourceCacheContext cacheContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger logger) { }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } }
+
+        public System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> FindLibraryEntryCache { get { throw null; } }
+
+        public bool IsMsBuildBased { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> LocalLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> LockFileLibraries { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Collections.Generic.IList<IDependencyProvider> ProjectLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> RemoteLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> FilterDependencyProvidersForLibrary(LibraryModel.LibraryRange libraryRange) { throw null; }
+    }
+
+    public static partial class ResolverUtility
+    {
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryByVersionAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> providers, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> cache, LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> remoteProviders, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> localProviders, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> lockFileLibraries, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>> FindPackageLibraryMatchCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryModel.LibraryRange, System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>>> cache, LibraryModel.LibraryRange libraryRange, RemoteWalkContext remoteWalkContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindProjectMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class Tracker<TItem>
+    {
+        public System.Collections.Generic.IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) { throw null; }
+
+        public bool IsAmbiguous(GraphItem<TItem> item) { throw null; }
+
+        public bool IsBestVersion(GraphItem<TItem> item) { throw null; }
+
+        public bool IsDisputed(GraphItem<TItem> item) { throw null; }
+
+        public void MarkAmbiguous(GraphItem<TItem> item) { }
+
+        public void Track(GraphItem<TItem> item) { }
+    }
+
+    public partial class VersionConflictResult<TItem>
+    {
+        public GraphNode<TItem> Conflicting { get { throw null; } set { } }
+
+        public GraphNode<TItem> Selected { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/lib/netstandard2.0/NuGet.DependencyResolver.Core.cs
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/lib/netstandard2.0/NuGet.DependencyResolver.Core.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.DependencyResolver.Core.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's PackageReference dependency resolver implementation.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.DependencyResolver.Core")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.DependencyResolver
+{
+    public partial class AnalyzeResult<TItem>
+    {
+        public System.Collections.Generic.List<GraphNode<TItem>> Cycles { get { throw null; } }
+
+        public System.Collections.Generic.List<DowngradeResult<TItem>> Downgrades { get { throw null; } }
+
+        public System.Collections.Generic.List<VersionConflictResult<TItem>> VersionConflicts { get { throw null; } }
+
+        public void Combine(AnalyzeResult<TItem> result) { }
+    }
+
+    public enum Disposition
+    {
+        Acceptable = 0,
+        Rejected = 1,
+        Accepted = 2,
+        PotentiallyDowngraded = 3,
+        Cycle = 4
+    }
+
+    public partial class DowngradeResult<TItem>
+    {
+        public GraphNode<TItem> DowngradedFrom { get { throw null; } set { } }
+
+        public GraphNode<TItem> DowngradedTo { get { throw null; } set { } }
+    }
+
+    public partial class GraphEdge<TItem>
+    {
+        public GraphEdge(GraphEdge<TItem> outerEdge, GraphItem<TItem> item, LibraryModel.LibraryDependency edge) { }
+
+        public LibraryModel.LibraryDependency Edge { get { throw null; } }
+
+        public GraphItem<TItem> Item { get { throw null; } }
+
+        public GraphEdge<TItem> OuterEdge { get { throw null; } }
+    }
+
+    public sealed partial class GraphItemKeyComparer<T> : System.Collections.Generic.IEqualityComparer<GraphItem<T>>
+    {
+        internal GraphItemKeyComparer() { }
+
+        public static GraphItemKeyComparer<T> Instance { get { throw null; } }
+
+        public bool Equals(GraphItem<T> x, GraphItem<T> y) { throw null; }
+
+        public int GetHashCode(GraphItem<T> obj) { throw null; }
+    }
+
+    public partial class GraphItem<TItem> : System.IEquatable<GraphItem<TItem>>
+    {
+        public GraphItem(LibraryModel.LibraryIdentity key) { }
+
+        public TItem Data { get { throw null; } set { } }
+
+        public bool IsCentralTransitive { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIdentity Key { get { throw null; } set { } }
+
+        public bool Equals(GraphItem<TItem> other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class GraphNode<TItem>
+    {
+        public GraphNode(LibraryModel.LibraryRange key) { }
+
+        public Disposition Disposition { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> InnerNodes { get { throw null; } set { } }
+
+        public GraphItem<TItem> Item { get { throw null; } set { } }
+
+        public LibraryModel.LibraryRange Key { get { throw null; } set { } }
+
+        public GraphNode<TItem> OuterNode { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<GraphNode<TItem>> ParentNodes { get { throw null; } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class GraphOperations
+    {
+        public static AnalyzeResult<RemoteResolveResult> Analyze(this GraphNode<RemoteResolveResult> root) { throw null; }
+
+        public static void Dump<TItem>(this GraphNode<TItem> root, System.Action<string> write) { }
+
+        public static void ForEach<TItem>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem>(this System.Collections.Generic.IEnumerable<GraphNode<TItem>> roots, System.Action<GraphNode<TItem>> visitor) { }
+
+        public static void ForEach<TItem, TContext>(this GraphNode<TItem> root, System.Action<GraphNode<TItem>, TContext> visitor, TContext context) { }
+
+        public static string GetId<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetIdAndVersionOrRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPath<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static string GetPathWithLastRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.NuGetVersion GetVersionOrDefault<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static Versioning.VersionRange GetVersionRange<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static bool IsPackage<TItem>(this GraphNode<TItem> node) { throw null; }
+
+        public static GraphNode<TItem> Path<TItem>(this GraphNode<TItem> node, params string[] path) { throw null; }
+
+        public static void ReleaseDowngradesDictionary(System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> dictionary) { }
+
+        public static System.Collections.Generic.Dictionary<GraphNode<RemoteResolveResult>, GraphNode<RemoteResolveResult>> RentDowngradesDictionary() { throw null; }
+    }
+
+    public partial interface IDependencyProvider
+    {
+        LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework);
+        bool SupportsType(LibraryModel.LibraryDependencyTarget libraryTypeFlag);
+    }
+
+    public partial interface IRemoteDependencyProvider
+    {
+        bool IsHttp { get; }
+
+        Configuration.PackageSource Source { get; }
+
+        Protocol.Core.Types.SourceRepository SourceRepository { get; }
+
+        System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token);
+        System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken);
+    }
+
+    public readonly partial struct LibraryRangeCacheKey : System.IEquatable<LibraryRangeCacheKey>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public LibraryRangeCacheKey(LibraryModel.LibraryRange range, Frameworks.NuGetFramework framework) { }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryModel.LibraryRange LibraryRange { get { throw null; } }
+
+        public readonly bool Equals(LibraryRangeCacheKey other) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryRangeCacheKey left, LibraryRangeCacheKey right) { throw null; }
+
+        public static bool operator !=(LibraryRangeCacheKey left, LibraryRangeCacheKey right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class LocalDependencyProvider : IRemoteDependencyProvider
+    {
+        public LocalDependencyProvider(IDependencyProvider dependencyProvider) { }
+
+        public bool IsHttp { get { throw null; } }
+
+        public Configuration.PackageSource Source { get { throw null; } }
+
+        public Protocol.Core.Types.SourceRepository SourceRepository { get { throw null; } }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryIdentity> FindLibraryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Versioning.NuGetVersion>> GetAllVersionsAsync(string id, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public System.Threading.Tasks.Task<LibraryModel.LibraryDependencyInfo> GetDependenciesAsync(LibraryModel.LibraryIdentity libraryIdentity, Frameworks.NuGetFramework targetFramework, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public System.Threading.Tasks.Task<Packaging.IPackageDownloader> GetPackageDownloaderAsync(Packaging.Core.PackageIdentity packageIdentity, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class LocalMatch : RemoteMatch
+    {
+        public LibraryModel.Library LocalLibrary { get { throw null; } set { } }
+
+        public IDependencyProvider LocalProvider { get { throw null; } set { } }
+    }
+
+    public partial class LockFileCacheKey : System.IEquatable<LockFileCacheKey>
+    {
+        public LockFileCacheKey(Frameworks.NuGetFramework framework, string runtimeIdentifier) { }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } }
+
+        public bool Equals(LockFileCacheKey other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class PackagingUtility
+    {
+        public static LibraryModel.LibraryDependency GetLibraryDependencyFromNuspec(Packaging.Core.PackageDependency dependency) { throw null; }
+    }
+
+    public partial class RemoteDependencyWalker
+    {
+        public RemoteDependencyWalker(RemoteWalkContext context) { }
+
+        public static bool IsGreaterThanOrEqualTo(Versioning.VersionRange nearVersion, Versioning.VersionRange farVersion) { throw null; }
+
+        public System.Threading.Tasks.Task<GraphNode<RemoteResolveResult>> WalkAsync(LibraryModel.LibraryRange library, Frameworks.NuGetFramework framework, string runtimeIdentifier, RuntimeModel.RuntimeGraph runtimeGraph, bool recursive) { throw null; }
+    }
+
+    public partial class RemoteMatch : System.IEquatable<RemoteMatch>
+    {
+        public LibraryModel.LibraryIdentity Library { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public IRemoteDependencyProvider Provider { get { throw null; } set { } }
+
+        public bool Equals(RemoteMatch other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class RemoteResolveResult
+    {
+        public System.Collections.Generic.List<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public RemoteMatch Match { get { throw null; } set { } }
+    }
+
+    public partial class RemoteWalkContext
+    {
+        public RemoteWalkContext(Protocol.Core.Types.SourceCacheContext cacheContext, Configuration.PackageSourceMapping packageSourceMapping, Common.ILogger logger) { }
+
+        public Protocol.Core.Types.SourceCacheContext CacheContext { get { throw null; } }
+
+        public System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> FindLibraryEntryCache { get { throw null; } }
+
+        public bool IsMsBuildBased { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> LocalLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> LockFileLibraries { get { throw null; } }
+
+        public Common.ILogger Logger { get { throw null; } }
+
+        public Configuration.PackageSourceMapping PackageSourceMapping { get { throw null; } }
+
+        public System.Collections.Generic.IList<IDependencyProvider> ProjectLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> RemoteLibraryProviders { get { throw null; } }
+
+        public System.Collections.Generic.IList<IRemoteDependencyProvider> FilterDependencyProvidersForLibrary(LibraryModel.LibraryRange libraryRange) { throw null; }
+    }
+
+    public static partial class ResolverUtility
+    {
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryByVersionAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> providers, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken token) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryRangeCacheKey, System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>>> cache, LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<GraphItem<RemoteResolveResult>> FindLibraryEntryAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, RemoteWalkContext context, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindLibraryMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, string runtimeIdentifier, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> remoteProviders, System.Collections.Generic.IEnumerable<IRemoteDependencyProvider> localProviders, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Collections.Generic.IDictionary<LockFileCacheKey, System.Collections.Generic.IList<LibraryModel.LibraryIdentity>> lockFileLibraries, Protocol.Core.Types.SourceCacheContext cacheContext, Common.ILogger logger, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>> FindPackageLibraryMatchCachedAsync(System.Collections.Concurrent.ConcurrentDictionary<LibraryModel.LibraryRange, System.Threading.Tasks.Task<System.Tuple<LibraryModel.LibraryRange, RemoteMatch>>> cache, LibraryModel.LibraryRange libraryRange, RemoteWalkContext remoteWalkContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.Task<RemoteMatch> FindProjectMatchAsync(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<IDependencyProvider> projectProviders, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+
+    public partial class Tracker<TItem>
+    {
+        public System.Collections.Generic.IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) { throw null; }
+
+        public bool IsAmbiguous(GraphItem<TItem> item) { throw null; }
+
+        public bool IsBestVersion(GraphItem<TItem> item) { throw null; }
+
+        public bool IsDisputed(GraphItem<TItem> item) { throw null; }
+
+        public void MarkAmbiguous(GraphItem<TItem> item) { }
+
+        public void Track(GraphItem<TItem> item) { }
+    }
+
+    public partial class VersionConflictResult<TItem>
+    {
+        public GraphNode<TItem> Conflicting { get { throw null; } set { } }
+
+        public GraphNode<TItem> Selected { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/nuget.dependencyresolver.core.nuspec
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.7.0/nuget.dependencyresolver.core.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.DependencyResolver.Core</id>
+    <version>6.7.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's PackageReference dependency resolver implementation.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="b46f5f64159a81d930ac8cdfde96e76f90796c62" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.Configuration" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.LibraryModel" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Protocol" version="6.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Configuration" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.LibraryModel" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Protocol" version="6.7.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.librarymodel/6.7.0/NuGet.LibraryModel.6.7.0.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/6.7.0/NuGet.LibraryModel.6.7.0.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.LibraryModel</AssemblyName>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.Common" Version="6.7.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.librarymodel/6.7.0/lib/netstandard2.0/NuGet.LibraryModel.cs
+++ b/src/referencePackages/src/nuget.librarymodel/6.7.0/lib/netstandard2.0/NuGet.LibraryModel.cs
@@ -1,0 +1,359 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.Commands.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's types and interfaces for understanding dependencies.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.LibraryModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.LibraryModel
+{
+    public sealed partial class CentralPackageVersion : System.IEquatable<CentralPackageVersion>
+    {
+        public CentralPackageVersion(string name, Versioning.VersionRange versionRange) { }
+
+        public string Name { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public bool Equals(CentralPackageVersion other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CentralPackageVersionNameComparer : System.Collections.Generic.IEqualityComparer<CentralPackageVersion>
+    {
+        internal CentralPackageVersionNameComparer() { }
+
+        public static CentralPackageVersionNameComparer Default { get { throw null; } }
+
+        public bool Equals(CentralPackageVersion x, CentralPackageVersion y) { throw null; }
+
+        public int GetHashCode(CentralPackageVersion obj) { throw null; }
+    }
+
+    public partial class DownloadDependency : System.IEquatable<DownloadDependency>, System.IComparable<DownloadDependency>
+    {
+        public DownloadDependency(string name, Versioning.VersionRange versionRange) { }
+
+        public string Name { get { throw null; } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } }
+
+        public DownloadDependency Clone() { throw null; }
+
+        public int CompareTo(DownloadDependency other) { throw null; }
+
+        public bool Equals(DownloadDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static implicit operator LibraryRange(DownloadDependency library) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class FrameworkDependency : System.IEquatable<FrameworkDependency>, System.IComparable<FrameworkDependency>
+    {
+        public FrameworkDependency(string name, FrameworkDependencyFlags privateAssets) { }
+
+        public string Name { get { throw null; } }
+
+        public FrameworkDependencyFlags PrivateAssets { get { throw null; } }
+
+        public int CompareTo(FrameworkDependency other) { throw null; }
+
+        public bool Equals(FrameworkDependency other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    [System.Flags]
+    public enum FrameworkDependencyFlags : ushort
+    {
+        None = 0,
+        All = ushort.MaxValue
+    }
+
+    public static partial class FrameworkDependencyFlagsUtils
+    {
+        public static readonly FrameworkDependencyFlags Default;
+        public static FrameworkDependencyFlags GetFlags(System.Collections.Generic.IEnumerable<string> values) { throw null; }
+
+        public static FrameworkDependencyFlags GetFlags(string flags) { throw null; }
+
+        public static string GetFlagString(FrameworkDependencyFlags flags) { throw null; }
+    }
+
+    public static partial class KnownLibraryProperties
+    {
+        public static readonly string AssemblyPath;
+        public static readonly string FrameworkAssemblies;
+        public static readonly string FrameworkReferences;
+        public static readonly string LockFileLibrary;
+        public static readonly string LockFileTargetLibrary;
+        public static readonly string MSBuildProjectPath;
+        public static readonly string PackageSpec;
+        public static readonly string ProjectFrameworks;
+        public static readonly string ProjectRestoreMetadataFiles;
+        public static readonly string ProjectStyle;
+        public static readonly string TargetFrameworkInformation;
+    }
+
+    public partial class Library
+    {
+        public static readonly System.Collections.Generic.IEqualityComparer<Library> IdentityComparer;
+        public System.Collections.Generic.IEnumerable<LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public LibraryIdentity Identity { get { throw null; } set { } }
+
+        public object this[string key] { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, object> Items { get { throw null; } set { } }
+
+        public LibraryRange LibraryRange { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public bool Resolved { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LibraryDependency : System.IEquatable<LibraryDependency>
+    {
+        public string Aliases { get { throw null; } set { } }
+
+        public bool AutoReferenced { get { throw null; } set { } }
+
+        public bool GeneratePathProperty { get { throw null; } set { } }
+
+        public LibraryIncludeFlags IncludeType { get { throw null; } set { } }
+
+        public LibraryRange LibraryRange { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IList<Common.NuGetLogCode> NoWarn { get { throw null; } set { } }
+
+        public LibraryDependencyReferenceType ReferenceType { get { throw null; } set { } }
+
+        public LibraryIncludeFlags SuppressParent { get { throw null; } set { } }
+
+        public bool VersionCentrallyManaged { get { throw null; } set { } }
+
+        public Versioning.VersionRange VersionOverride { get { throw null; } set { } }
+
+        public static void ApplyCentralVersionInformation(System.Collections.Generic.IList<LibraryDependency> packageReferences, System.Collections.Generic.IDictionary<string, CentralPackageVersion> centralPackageVersions) { }
+
+        public LibraryDependency Clone() { throw null; }
+
+        public bool Equals(LibraryDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LibraryDependencyInfo
+    {
+        public LibraryDependencyInfo(LibraryIdentity library, bool resolved, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryDependency> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<LibraryDependency> Dependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework Framework { get { throw null; } }
+
+        public LibraryIdentity Library { get { throw null; } }
+
+        public bool Resolved { get { throw null; } }
+
+        public static LibraryDependencyInfo Create(LibraryIdentity library, Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryDependency> dependencies) { throw null; }
+
+        public static LibraryDependencyInfo CreateUnresolved(LibraryIdentity library, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public enum LibraryDependencyReferenceType
+    {
+        None = 0,
+        Transitive = 1,
+        Direct = 2
+    }
+
+    [System.Flags]
+    public enum LibraryDependencyTarget : ushort
+    {
+        None = 0,
+        Package = 1,
+        Project = 2,
+        ExternalProject = 4,
+        PackageProjectExternal = 7,
+        Assembly = 8,
+        Reference = 16,
+        WinMD = 32,
+        All = 63
+    }
+
+    public static partial class LibraryDependencyTargetUtils
+    {
+        public static string AsString(this LibraryDependencyTarget includeFlags) { throw null; }
+
+        public static string GetFlagString(LibraryDependencyTarget flags) { throw null; }
+
+        public static LibraryDependencyTarget Parse(string flag) { throw null; }
+    }
+
+    public static partial class LibraryExtensions
+    {
+        public static T GetItem<T>(this Library library, string key) { throw null; }
+
+        public static T GetRequiredItem<T>(this Library library, string key) { throw null; }
+
+        public static bool IsEclipsedBy(this LibraryRange library, LibraryRange other) { throw null; }
+    }
+
+    public partial class LibraryIdentity : System.IEquatable<LibraryIdentity>, System.IComparable<LibraryIdentity>
+    {
+        public LibraryIdentity() { }
+
+        public LibraryIdentity(string name, Versioning.NuGetVersion version, LibraryType type) { }
+
+        public string Name { get { throw null; } set { } }
+
+        public LibraryType Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public int CompareTo(LibraryIdentity other) { throw null; }
+
+        public bool Equals(LibraryIdentity other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryIdentity left, LibraryIdentity right) { throw null; }
+
+        public static implicit operator LibraryRange(LibraryIdentity library) { throw null; }
+
+        public static bool operator !=(LibraryIdentity left, LibraryIdentity right) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    [System.Flags]
+    public enum LibraryIncludeFlags : ushort
+    {
+        None = 0,
+        Runtime = 1,
+        Compile = 2,
+        Build = 4,
+        Native = 8,
+        ContentFiles = 16,
+        Analyzers = 32,
+        BuildTransitive = 64,
+        All = 127
+    }
+
+    public static partial class LibraryIncludeFlagUtils
+    {
+        public static readonly LibraryIncludeFlags DefaultSuppressParent;
+        public static readonly LibraryIncludeFlags NoContent;
+        public static string AsString(this LibraryIncludeFlags includeFlags) { throw null; }
+
+        public static LibraryIncludeFlags GetFlags(System.Collections.Generic.IEnumerable<string> flags) { throw null; }
+
+        public static LibraryIncludeFlags GetFlags(string flags, LibraryIncludeFlags defaultFlags) { throw null; }
+
+        public static string GetFlagString(LibraryIncludeFlags flags) { throw null; }
+    }
+
+    public partial class LibraryRange : System.IEquatable<LibraryRange>
+    {
+        public LibraryRange() { }
+
+        public LibraryRange(string name, LibraryDependencyTarget typeConstraint) { }
+
+        public LibraryRange(string name, Versioning.VersionRange versionRange, LibraryDependencyTarget typeConstraint) { }
+
+        public string Name { get { throw null; } set { } }
+
+        public LibraryDependencyTarget TypeConstraint { get { throw null; } set { } }
+
+        public Versioning.VersionRange VersionRange { get { throw null; } set { } }
+
+        public bool Equals(LibraryRange other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryRange left, LibraryRange right) { throw null; }
+
+        public static bool operator !=(LibraryRange left, LibraryRange right) { throw null; }
+
+        public string ToLockFileDependencyGroupString() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TypeConstraintAllows(LibraryDependencyTarget flag) { throw null; }
+
+        public bool TypeConstraintAllowsAnyOf(LibraryDependencyTarget flag) { throw null; }
+    }
+
+    public partial struct LibraryType : System.IEquatable<LibraryType>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly LibraryType Assembly;
+        public static readonly LibraryType ExternalProject;
+        public static readonly LibraryType Package;
+        public static readonly LibraryType Project;
+        public static readonly LibraryType Reference;
+        public static readonly LibraryType Unresolved;
+        public static readonly LibraryType WinMD;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(LibraryType other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(LibraryType left, LibraryType right) { throw null; }
+
+        public static implicit operator string(LibraryType libraryType) { throw null; }
+
+        public static bool operator !=(LibraryType left, LibraryType right) { throw null; }
+
+        public static LibraryType Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.librarymodel/6.7.0/nuget.librarymodel.nuspec
+++ b/src/referencePackages/src/nuget.librarymodel/6.7.0/nuget.librarymodel.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.LibraryModel</id>
+    <version>6.7.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's types and interfaces for understanding dependencies.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="b46f5f64159a81d930ac8cdfde96e76f90796c62" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.Common" version="6.7.0" exclude="Build,Analyzers" />
+        <dependency id="NuGet.Versioning" version="6.7.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/nuget.projectmodel/6.7.0/NuGet.ProjectModel.6.7.0.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/6.7.0/NuGet.ProjectModel.6.7.0.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NuGet.ProjectModel</AssemblyName>
+    <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="NuGet.DependencyResolver.Core" Version="6.7.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NuGet.DependencyResolver.Core" Version="6.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/nuget.projectmodel/6.7.0/lib/net5.0/NuGet.ProjectModel.cs
+++ b/src/referencePackages/src/nuget.projectmodel/6.7.0/lib/net5.0/NuGet.ProjectModel.cs
@@ -1,0 +1,1222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v5.0", FrameworkDisplayName = ".NET 5.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.ProjectModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.ProjectModel
+{
+    public partial class AssetsLogMessage : IAssetsLogMessage, System.IEquatable<IAssetsLogMessage>
+    {
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString, string targetGraph) { }
+
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static IAssetsLogMessage Create(Common.IRestoreLogMessage logMessage) { throw null; }
+
+        public bool Equals(IAssetsLogMessage other) { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial struct BuildAction : System.IEquatable<BuildAction>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly BuildAction AndroidAsset;
+        public static readonly BuildAction AndroidResource;
+        public static readonly BuildAction ApplicationDefinition;
+        public static readonly BuildAction BundleResource;
+        public static readonly BuildAction CodeAnalysisDictionary;
+        public static readonly BuildAction Compile;
+        public static readonly BuildAction Content;
+        public static readonly BuildAction DesignData;
+        public static readonly BuildAction DesignDataWithDesignTimeCreatableTypes;
+        public static readonly BuildAction EmbeddedResource;
+        public static readonly BuildAction None;
+        public static readonly BuildAction Page;
+        public static readonly BuildAction Resource;
+        public static readonly BuildAction SplashScreen;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(BuildAction other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildAction left, BuildAction right) { throw null; }
+
+        public static bool operator !=(BuildAction left, BuildAction right) { throw null; }
+
+        public static BuildAction Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildOptions : System.IEquatable<BuildOptions>
+    {
+        public string OutputName { get { throw null; } set { } }
+
+        public BuildOptions Clone() { throw null; }
+
+        public bool Equals(BuildOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class CacheFile : System.IEquatable<CacheFile>
+    {
+        public CacheFile(string dgSpecHash) { }
+
+        public string DgSpecHash { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> ExpectedPackageFilePaths { get { throw null; } set { } }
+
+        public bool HasAnyMissingPackageFiles { get { throw null; } set { } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public string ProjectFilePath { get { throw null; } set { } }
+
+        public bool Success { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(CacheFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class CacheFileFormat
+    {
+        public static CacheFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static void Write(System.IO.Stream stream, CacheFile cacheFile) { }
+
+        public static void Write(string filePath, CacheFile lockFile) { }
+    }
+
+    public partial class CentralTransitiveDependencyGroup : System.IEquatable<CentralTransitiveDependencyGroup>
+    {
+        public CentralTransitiveDependencyGroup(Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> transitiveDependencies) { }
+
+        public string FrameworkName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> TransitiveDependencies { get { throw null; } }
+
+        public bool Equals(CentralTransitiveDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class DependencyGraphSpec
+    {
+        public DependencyGraphSpec() { }
+
+        public DependencyGraphSpec(bool isReadOnly) { }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> Projects { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Restore { get { throw null; } }
+
+        public void AddProject(PackageSpec projectSpec) { }
+
+        public void AddRestore(string projectUniqueName) { }
+
+        public DependencyGraphSpec CreateFromClosure(string projectUniqueName, System.Collections.Generic.IReadOnlyList<PackageSpec> closure) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> GetClosure(string rootUniqueName) { throw null; }
+
+        public static string GetDGSpecFileName(string projectName) { throw null; }
+
+        public string GetHash() { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetParents(string rootUniqueName) { throw null; }
+
+        public PackageSpec GetProjectSpec(string projectUniqueName) { throw null; }
+
+        public static DependencyGraphSpec Load(string path) { throw null; }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public void Save(string path) { }
+
+        public static System.Collections.Generic.IReadOnlyList<PackageSpec> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<PackageSpec> packages) { throw null; }
+
+        public static DependencyGraphSpec Union(System.Collections.Generic.IEnumerable<DependencyGraphSpec> dgSpecs) { throw null; }
+
+        public DependencyGraphSpec WithoutRestores() { throw null; }
+
+        public DependencyGraphSpec WithoutTools() { throw null; }
+
+        public DependencyGraphSpec WithPackageSpecs(System.Collections.Generic.IEnumerable<PackageSpec> packageSpecs) { throw null; }
+
+        public DependencyGraphSpec WithProjectClosure(string projectUniqueName) { throw null; }
+
+        public DependencyGraphSpec WithReplacedSpec(PackageSpec project) { throw null; }
+    }
+
+    public partial class ExternalProjectReference : System.IEquatable<ExternalProjectReference>, System.IComparable<ExternalProjectReference>
+    {
+        public ExternalProjectReference(string uniqueName, PackageSpec packageSpec, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public ExternalProjectReference(string uniqueName, string packageSpecProjectName, string packageSpecPath, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExternalProjectReferences { get { throw null; } }
+
+        public string MSBuildProjectPath { get { throw null; } }
+
+        public PackageSpec PackageSpec { get { throw null; } }
+
+        public string PackageSpecProjectName { get { throw null; } }
+
+        public string ProjectJsonPath { get { throw null; } }
+
+        public string ProjectName { get { throw null; } }
+
+        public string UniqueName { get { throw null; } }
+
+        public int CompareTo(ExternalProjectReference other) { throw null; }
+
+        public bool Equals(ExternalProjectReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FileFormatException : System.Exception
+    {
+        public FileFormatException(string message, System.Exception innerException) { }
+
+        public FileFormatException(string message) { }
+
+        public int Column { get { throw null; } }
+
+        public int Line { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public static FileFormatException Create(System.Exception exception, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+
+        public static FileFormatException Create(string message, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+    }
+
+    public sealed partial class HashObjectWriter : RuntimeModel.IObjectWriter, System.IDisposable
+    {
+        public HashObjectWriter(Packaging.IHashFunction hashFunc) { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public partial interface IAssetsLogMessage
+    {
+        Common.NuGetLogCode Code { get; }
+
+        int EndColumnNumber { get; }
+
+        int EndLineNumber { get; }
+
+        string FilePath { get; }
+
+        Common.LogLevel Level { get; }
+
+        string LibraryId { get; }
+
+        string Message { get; }
+
+        string ProjectPath { get; }
+
+        int StartColumnNumber { get; }
+
+        int StartLineNumber { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get; }
+
+        Common.WarningLevel WarningLevel { get; }
+    }
+
+    public partial interface IExternalProjectReferenceProvider
+    {
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetEntryPoints();
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetReferences(string entryPointPath);
+    }
+
+    public partial class IncludeExcludeFiles : System.IEquatable<IncludeExcludeFiles>
+    {
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> IncludeFiles { get { throw null; } set { } }
+
+        public IncludeExcludeFiles Clone() { throw null; }
+
+        public bool Equals(IncludeExcludeFiles other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool HandleIncludeExcludeFiles(Newtonsoft.Json.Linq.JObject jsonObject) { throw null; }
+    }
+
+    public static partial class JsonPackageSpecReader
+    {
+        public static readonly string Files;
+        public static readonly string HideWarningsAndErrors;
+        public static readonly string PackageType;
+        public static readonly string PackOptions;
+        public static readonly string RestoreOptions;
+        public static readonly string RestoreSettings;
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject rawPackageSpec, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject json) { throw null; }
+
+        public static PackageSpec GetPackageSpec(System.IO.Stream stream, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath) { throw null; }
+    }
+
+    public static partial class JTokenExtensions
+    {
+        public static T GetValue<T>(this Newtonsoft.Json.Linq.JToken token, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken) { throw null; }
+    }
+
+    public partial class LockFile : System.IEquatable<LockFile>
+    {
+        public static readonly char DirectorySeparatorChar;
+        public static readonly Frameworks.NuGetFramework ToolFramework;
+        public System.Collections.Generic.IList<CentralTransitiveDependencyGroup> CentralTransitiveDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileLibrary> Libraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> PackageFolders { get { throw null; } set { } }
+
+        public PackageSpec PackageSpec { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(LockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public LockFileLibrary GetLibrary(string name, Versioning.NuGetVersion version) { throw null; }
+
+        public LockFileTarget GetTarget(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public LockFileTarget GetTarget(string frameworkAlias, string runtimeIdentifier) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec, int requestLockFileVersion) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec) { throw null; }
+    }
+
+    public partial class LockFileContentFile : LockFileItem
+    {
+        public static readonly string BuildActionProperty;
+        public static readonly string CodeLanguageProperty;
+        public static readonly string CopyToOutputProperty;
+        public static readonly string OutputPathProperty;
+        public static readonly string PPOutputPathProperty;
+        public LockFileContentFile(string path) : base(default!) { }
+
+        public BuildAction BuildAction { get { throw null; } set { } }
+
+        public string CodeLanguage { get { throw null; } set { } }
+
+        public bool CopyToOutput { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PPOutputPath { get { throw null; } set { } }
+    }
+
+    public partial class LockFileDependency : System.IEquatable<LockFileDependency>
+    {
+        public string ContentHash { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public Versioning.VersionRange RequestedVersion { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion ResolvedVersion { get { throw null; } set { } }
+
+        public PackageDependencyType Type { get { throw null; } set { } }
+
+        public bool Equals(LockFileDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileDependencyIdVersionComparer : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyIdVersionComparer Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+
+    [System.Obsolete("This is an unused class and will be removed in a future version.")]
+    public partial class LockFileDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public LockFileDependencyProvider(LockFile lockFile) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class LockFileExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<LockFileTarget> GetTargetGraphs(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LockFileTargetLibrary> GetTargetLibraries(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static LockFileTargetLibrary GetTargetLibrary(this LockFileTarget target, string libraryId) { throw null; }
+    }
+
+    public partial class LockFileFormat
+    {
+        public static readonly string AssetsFileName;
+        public static readonly string LockFileName;
+        public static readonly int Version;
+        public LockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, string path) { throw null; }
+
+        public LockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public LockFile Read(string filePath) { throw null; }
+
+        public string Render(LockFile lockFile) { throw null; }
+
+        public void Write(System.IO.Stream stream, LockFile lockFile) { }
+
+        public void Write(System.IO.TextWriter textWriter, LockFile lockFile) { }
+
+        public void Write(string filePath, LockFile lockFile) { }
+    }
+
+    public partial class LockFileItem : System.IEquatable<LockFileItem>
+    {
+        public static readonly string AliasesProperty;
+        public LockFileItem(string path) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } }
+
+        public bool Equals(LockFileItem other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        protected string GetProperty(string name) { throw null; }
+
+        public static implicit operator LockFileItem(string path) { throw null; }
+
+        protected void SetProperty(string name, string value) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LockFileLibrary : System.IEquatable<LockFileLibrary>
+    {
+        public System.Collections.Generic.IList<string> Files { get { throw null; } set { } }
+
+        public bool HasTools { get { throw null; } set { } }
+
+        public bool IsServiceable { get { throw null; } set { } }
+
+        public string MSBuildProject { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string Sha512 { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public LockFileLibrary Clone() { throw null; }
+
+        public bool Equals(LockFileLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileRuntimeTarget : LockFileItem
+    {
+        public static readonly string AssetTypeProperty;
+        public static readonly string RidProperty;
+        public LockFileRuntimeTarget(string path, string runtime, string assetType) : base(default!) { }
+
+        public LockFileRuntimeTarget(string path) : base(default!) { }
+
+        public string AssetType { get { throw null; } set { } }
+
+        public string Runtime { get { throw null; } set { } }
+    }
+
+    public partial class LockFileTarget : System.IEquatable<LockFileTarget>
+    {
+        public System.Collections.Generic.IList<LockFileTargetLibrary> Libraries { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(LockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileTargetLibrary : System.IEquatable<LockFileTargetLibrary>
+    {
+        public System.Collections.Generic.IList<LockFileItem> Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> BuildMultiTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> CompileTimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileContentFile> ContentFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> EmbedAssemblies { get { throw null; } set { } }
+
+        public string Framework { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkReferences { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> NativeLibraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ResourceAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> RuntimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileRuntimeTarget> RuntimeTargets { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ToolsAssemblies { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public bool Equals(LockFileTargetLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class LockFileUtilities
+    {
+        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class LockFileValidationResult
+    {
+        public LockFileValidationResult(bool isValid, System.Collections.Generic.IReadOnlyList<string> invalidReasons) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InvalidReasons { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+    }
+
+    public enum PackageDependencyType
+    {
+        Direct = 0,
+        Transitive = 1,
+        Project = 2,
+        CentralTransitive = 3
+    }
+
+    public partial class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        public string PackagesConfigPath { get { throw null; } set { } }
+
+        public string RepositoryPath { get { throw null; } set { } }
+
+        public override ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackagesLockFile : System.IEquatable<PackagesLockFile>
+    {
+        public PackagesLockFile() { }
+
+        public PackagesLockFile(int version) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<PackagesLockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileFormat
+    {
+        public static readonly string LockFileName;
+        public static readonly int PackagesLockFileVersion;
+        public static readonly int Version;
+        public static PackagesLockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static PackagesLockFile Read(string filePath) { throw null; }
+
+        public static string Render(PackagesLockFile lockFile) { throw null; }
+
+        public static void Write(System.IO.Stream stream, PackagesLockFile lockFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, PackagesLockFile lockFile) { }
+
+        public static void Write(string filePath, PackagesLockFile lockFile) { }
+    }
+
+    public partial class PackagesLockFileTarget : System.IEquatable<PackagesLockFileTarget>
+    {
+        public System.Collections.Generic.IList<LockFileDependency> Dependencies { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileUtilities
+    {
+        public static string GetNuGetLockFilePath(PackageSpec project) { throw null; }
+
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName) { throw null; }
+
+        [System.Obsolete("This method is obsolete. Call IsLockFileValid instead.")]
+        public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static LockFileValidityWithMatchedResults IsLockFileStillValid(PackagesLockFile expected, PackagesLockFile actual) { throw null; }
+
+        public static LockFileValidationResult IsLockFileValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static bool IsNuGetLockFileEnabled(PackageSpec project) { throw null; }
+
+        public partial class LockFileValidityWithMatchedResults
+        {
+            public static readonly LockFileValidityWithMatchedResults Invalid;
+            public LockFileValidityWithMatchedResults(bool isValid, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> matchedDependencies) { }
+
+            public bool IsValid { get { throw null; } }
+
+            public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> MatchedDependencies { get { throw null; } }
+        }
+    }
+
+    public partial class PackageSpec
+    {
+        public static readonly Versioning.NuGetVersion DefaultVersion;
+        public static readonly string PackageSpecFileName;
+        public PackageSpec() { }
+
+        public PackageSpec(System.Collections.Generic.IList<TargetFrameworkInformation> frameworks) { }
+
+        [System.Obsolete]
+        public string[] Authors { get { throw null; } set { } }
+
+        public string BaseDirectory { get { throw null; } }
+
+        [System.Obsolete]
+        public BuildOptions BuildOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IList<string> ContentFiles { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Description { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool HasVersionSnapshot { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string IconUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool IsDefaultVersion { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Language { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string LicenseUrl { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Owners { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, string> PackInclude { get { throw null; } }
+
+        [System.Obsolete]
+        public PackOptions PackOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ProjectUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public ProjectRestoreMetadata RestoreMetadata { get { throw null; } set { } }
+
+        public ProjectRestoreSettings RestoreSettings { get { throw null; } set { } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<string>> Scripts { get { throw null; } }
+
+        [System.Obsolete]
+        public string Summary { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Tags { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<TargetFrameworkInformation> TargetFrameworks { get { throw null; } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public PackageSpec Clone() { throw null; }
+
+        public bool Equals(PackageSpec other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackageSpecExtensions
+    {
+        public static ProjectRestoreMetadataFrameworkInfo GetRestoreMetadataFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+    }
+
+    public static partial class PackageSpecOperations
+    {
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity) { }
+
+        public static bool HasPackage(PackageSpec spec, string packageId) { throw null; }
+
+        public static void RemoveDependency(PackageSpec spec, string packageId) { }
+    }
+
+    public partial class PackageSpecReferenceDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public PackageSpecReferenceDependencyProvider(System.Collections.Generic.IEnumerable<ExternalProjectReference> externalProjects, Common.ILogger logger) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class PackageSpecUtility
+    {
+        public static bool IsSnapshotVersion(string version) { throw null; }
+
+        public static Versioning.NuGetVersion SpecifySnapshot(string version, string snapshotValue) { throw null; }
+    }
+
+    public sealed partial class PackageSpecWriter
+    {
+        public static void Write(PackageSpec packageSpec, RuntimeModel.IObjectWriter writer) { }
+
+        public static void WriteToFile(PackageSpec packageSpec, string filePath) { }
+    }
+
+    public partial class PackOptions : System.IEquatable<PackOptions>
+    {
+        public IncludeExcludeFiles IncludeExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, IncludeExcludeFiles> Mappings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public PackOptions Clone() { throw null; }
+
+        public bool Equals(PackOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectFileDependencyGroup : System.IEquatable<ProjectFileDependencyGroup>
+    {
+        public ProjectFileDependencyGroup(string frameworkName, System.Collections.Generic.IEnumerable<string> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<string> Dependencies { get { throw null; } }
+
+        public string FrameworkName { get { throw null; } }
+
+        public bool Equals(ProjectFileDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadata : System.IEquatable<ProjectRestoreMetadata>
+    {
+        public string CacheFilePath { get { throw null; } set { } }
+
+        public bool CentralPackageTransitivePinningEnabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionOverrideDisabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionsEnabled { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> ConfigFilePaths { get { throw null; } set { } }
+
+        public bool CrossTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FallbackFolders { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFile> Files { get { throw null; } set { } }
+
+        public bool LegacyPackagesDirectory { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> OriginalTargetFrameworks { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PackagesPath { get { throw null; } set { } }
+
+        public string ProjectJsonPath { get { throw null; } set { } }
+
+        public string ProjectName { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public WarningProperties ProjectWideWarningProperties { get { throw null; } set { } }
+
+        public RestoreAuditProperties RestoreAuditProperties { get { throw null; } set { } }
+
+        public RestoreLockProperties RestoreLockProperties { get { throw null; } set { } }
+
+        public bool SkipContentFileWrite { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> Sources { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFrameworkInfo> TargetFrameworks { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public virtual ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        protected void FillClone(ProjectRestoreMetadata clone) { }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFile : System.IEquatable<ProjectRestoreMetadataFile>, System.IComparable<ProjectRestoreMetadataFile>
+    {
+        public ProjectRestoreMetadataFile(string packagePath, string absolutePath) { }
+
+        public string AbsolutePath { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public ProjectRestoreMetadataFile Clone() { throw null; }
+
+        public int CompareTo(ProjectRestoreMetadataFile other) { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFrameworkInfo : System.IEquatable<ProjectRestoreMetadataFrameworkInfo>
+    {
+        public ProjectRestoreMetadataFrameworkInfo() { }
+
+        public ProjectRestoreMetadataFrameworkInfo(Frameworks.NuGetFramework frameworkName) { }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreReference> ProjectReferences { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public ProjectRestoreMetadataFrameworkInfo Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFrameworkInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreReference : System.IEquatable<ProjectRestoreReference>
+    {
+        public LibraryModel.LibraryIncludeFlags ExcludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags IncludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags PrivateAssets { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public ProjectRestoreReference Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreSettings
+    {
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public ProjectRestoreSettings Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreSettings other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum ProjectStyle : ushort
+    {
+        Unknown = 0,
+        ProjectJson = 1,
+        PackageReference = 2,
+        DotnetCliTool = 3,
+        Standalone = 4,
+        PackagesConfig = 5,
+        DotnetToolReference = 6
+    }
+
+    public partial class RestoreAuditProperties : System.IEquatable<RestoreAuditProperties>
+    {
+        public string? AuditLevel { get { throw null; } set { } }
+
+        public string? AuditMode { get { throw null; } set { } }
+
+        public string? EnableAudit { get { throw null; } set { } }
+
+        public bool Equals(RestoreAuditProperties? other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(RestoreAuditProperties? x, RestoreAuditProperties? y) { throw null; }
+
+        public static bool operator !=(RestoreAuditProperties? x, RestoreAuditProperties? y) { throw null; }
+    }
+
+    public partial class RestoreLockProperties : System.IEquatable<RestoreLockProperties>
+    {
+        public RestoreLockProperties() { }
+
+        public RestoreLockProperties(string restorePackagesWithLockFile, string nuGetLockFilePath, bool restoreLockedMode) { }
+
+        public string NuGetLockFilePath { get { throw null; } }
+
+        public bool RestoreLockedMode { get { throw null; } }
+
+        public string RestorePackagesWithLockFile { get { throw null; } }
+
+        public RestoreLockProperties Clone() { throw null; }
+
+        public bool Equals(RestoreLockProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class TargetFrameworkInformation : System.IEquatable<TargetFrameworkInformation>
+    {
+        public bool AssetTargetFallback { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, LibraryModel.CentralPackageVersion> CentralPackageVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.DownloadDependency> DownloadDependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<LibraryModel.FrameworkDependency> FrameworkReferences { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> Imports { get { throw null; } set { } }
+
+        public string RuntimeIdentifierGraphPath { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public bool Warn { get { throw null; } set { } }
+
+        public TargetFrameworkInformation Clone() { throw null; }
+
+        public bool Equals(TargetFrameworkInformation other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ToolPathResolver
+    {
+        public ToolPathResolver(string packagesDirectory, bool isLowercase) { }
+
+        public ToolPathResolver(string packagesDirectory) { }
+
+        public string GetBestToolDirectoryPath(string packageId, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string toolDirectory) { throw null; }
+
+        public string GetToolDirectoryPath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class WarningProperties : System.IEquatable<WarningProperties>
+    {
+        public WarningProperties() { }
+
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> warningsNotAsErrors) { }
+
+        [System.Obsolete("Use the constructor with 4 instead.")]
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors) { }
+
+        public bool AllWarningsAsErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> NoWarn { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsAsErrors { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsNotAsErrors { get { throw null; } }
+
+        public WarningProperties Clone() { throw null; }
+
+        public bool Equals(WarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsNotAsErrors) { throw null; }
+
+        [System.Obsolete]
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn) { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn, string warningsNotAsErrors) { throw null; }
+
+        [System.Obsolete]
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn) { throw null; }
+    }
+}
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public partial class LockFileDependencyComparerWithoutContentHash : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyComparerWithoutContentHash Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.projectmodel/6.7.0/lib/netstandard2.0/NuGet.ProjectModel.cs
+++ b/src/referencePackages/src/nuget.projectmodel/6.7.0/lib/netstandard2.0/NuGet.ProjectModel.cs
@@ -1,0 +1,1222 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NuGet.ProjectModel.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyConfiguration("release")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.")]
+[assembly: System.Reflection.AssemblyFileVersion("6.7.0.127")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.7.0+b46f5f64159a81d930ac8cdfde96e76f90796c62.b46f5f64159a81d930ac8cdfde96e76f90796c62")]
+[assembly: System.Reflection.AssemblyProduct("NuGet")]
+[assembly: System.Reflection.AssemblyTitle("NuGet.ProjectModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/NuGet/NuGet.Client")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.7.0.127")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace NuGet.ProjectModel
+{
+    public partial class AssetsLogMessage : IAssetsLogMessage, System.IEquatable<IAssetsLogMessage>
+    {
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString, string targetGraph) { }
+
+        public AssetsLogMessage(Common.LogLevel logLevel, Common.NuGetLogCode errorCode, string errorString) { }
+
+        public Common.NuGetLogCode Code { get { throw null; } }
+
+        public int EndColumnNumber { get { throw null; } set { } }
+
+        public int EndLineNumber { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        public Common.LogLevel Level { get { throw null; } }
+
+        public string LibraryId { get { throw null; } set { } }
+
+        public string Message { get { throw null; } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public int StartColumnNumber { get { throw null; } set { } }
+
+        public int StartLineNumber { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get { throw null; } set { } }
+
+        public Common.WarningLevel WarningLevel { get { throw null; } set { } }
+
+        public static IAssetsLogMessage Create(Common.IRestoreLogMessage logMessage) { throw null; }
+
+        public bool Equals(IAssetsLogMessage other) { throw null; }
+
+        public override bool Equals(object other) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial struct BuildAction : System.IEquatable<BuildAction>
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public static readonly BuildAction AndroidAsset;
+        public static readonly BuildAction AndroidResource;
+        public static readonly BuildAction ApplicationDefinition;
+        public static readonly BuildAction BundleResource;
+        public static readonly BuildAction CodeAnalysisDictionary;
+        public static readonly BuildAction Compile;
+        public static readonly BuildAction Content;
+        public static readonly BuildAction DesignData;
+        public static readonly BuildAction DesignDataWithDesignTimeCreatableTypes;
+        public static readonly BuildAction EmbeddedResource;
+        public static readonly BuildAction None;
+        public static readonly BuildAction Page;
+        public static readonly BuildAction Resource;
+        public static readonly BuildAction SplashScreen;
+        public bool IsKnown { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(BuildAction other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(BuildAction left, BuildAction right) { throw null; }
+
+        public static bool operator !=(BuildAction left, BuildAction right) { throw null; }
+
+        public static BuildAction Parse(string value) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class BuildOptions : System.IEquatable<BuildOptions>
+    {
+        public string OutputName { get { throw null; } set { } }
+
+        public BuildOptions Clone() { throw null; }
+
+        public bool Equals(BuildOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class CacheFile : System.IEquatable<CacheFile>
+    {
+        public CacheFile(string dgSpecHash) { }
+
+        public string DgSpecHash { get { throw null; } }
+
+        public System.Collections.Generic.IList<string> ExpectedPackageFilePaths { get { throw null; } set { } }
+
+        public bool HasAnyMissingPackageFiles { get { throw null; } set { } }
+
+        public bool IsValid { get { throw null; } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public string ProjectFilePath { get { throw null; } set { } }
+
+        public bool Success { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(CacheFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class CacheFileFormat
+    {
+        public static CacheFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static void Write(System.IO.Stream stream, CacheFile cacheFile) { }
+
+        public static void Write(string filePath, CacheFile lockFile) { }
+    }
+
+    public partial class CentralTransitiveDependencyGroup : System.IEquatable<CentralTransitiveDependencyGroup>
+    {
+        public CentralTransitiveDependencyGroup(Frameworks.NuGetFramework framework, System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> transitiveDependencies) { }
+
+        public string FrameworkName { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<LibraryModel.LibraryDependency> TransitiveDependencies { get { throw null; } }
+
+        public bool Equals(CentralTransitiveDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class DependencyGraphSpec
+    {
+        public DependencyGraphSpec() { }
+
+        public DependencyGraphSpec(bool isReadOnly) { }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> Projects { get { throw null; } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Restore { get { throw null; } }
+
+        public void AddProject(PackageSpec projectSpec) { }
+
+        public void AddRestore(string projectUniqueName) { }
+
+        public DependencyGraphSpec CreateFromClosure(string projectUniqueName, System.Collections.Generic.IReadOnlyList<PackageSpec> closure) { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<PackageSpec> GetClosure(string rootUniqueName) { throw null; }
+
+        public static string GetDGSpecFileName(string projectName) { throw null; }
+
+        public string GetHash() { throw null; }
+
+        public System.Collections.Generic.IReadOnlyList<string> GetParents(string rootUniqueName) { throw null; }
+
+        public PackageSpec GetProjectSpec(string projectUniqueName) { throw null; }
+
+        public static DependencyGraphSpec Load(string path) { throw null; }
+
+        public void Save(System.IO.Stream stream) { }
+
+        public void Save(string path) { }
+
+        public static System.Collections.Generic.IReadOnlyList<PackageSpec> SortPackagesByDependencyOrder(System.Collections.Generic.IEnumerable<PackageSpec> packages) { throw null; }
+
+        public static DependencyGraphSpec Union(System.Collections.Generic.IEnumerable<DependencyGraphSpec> dgSpecs) { throw null; }
+
+        public DependencyGraphSpec WithoutRestores() { throw null; }
+
+        public DependencyGraphSpec WithoutTools() { throw null; }
+
+        public DependencyGraphSpec WithPackageSpecs(System.Collections.Generic.IEnumerable<PackageSpec> packageSpecs) { throw null; }
+
+        public DependencyGraphSpec WithProjectClosure(string projectUniqueName) { throw null; }
+
+        public DependencyGraphSpec WithReplacedSpec(PackageSpec project) { throw null; }
+    }
+
+    public partial class ExternalProjectReference : System.IEquatable<ExternalProjectReference>, System.IComparable<ExternalProjectReference>
+    {
+        public ExternalProjectReference(string uniqueName, PackageSpec packageSpec, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public ExternalProjectReference(string uniqueName, string packageSpecProjectName, string packageSpecPath, string msbuildProjectPath, System.Collections.Generic.IEnumerable<string> projectReferences) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExternalProjectReferences { get { throw null; } }
+
+        public string MSBuildProjectPath { get { throw null; } }
+
+        public PackageSpec PackageSpec { get { throw null; } }
+
+        public string PackageSpecProjectName { get { throw null; } }
+
+        public string ProjectJsonPath { get { throw null; } }
+
+        public string ProjectName { get { throw null; } }
+
+        public string UniqueName { get { throw null; } }
+
+        public int CompareTo(ExternalProjectReference other) { throw null; }
+
+        public bool Equals(ExternalProjectReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class FileFormatException : System.Exception
+    {
+        public FileFormatException(string message, System.Exception innerException) { }
+
+        public FileFormatException(string message) { }
+
+        public int Column { get { throw null; } }
+
+        public int Line { get { throw null; } }
+
+        public string Path { get { throw null; } }
+
+        public static FileFormatException Create(System.Exception exception, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+
+        public static FileFormatException Create(string message, Newtonsoft.Json.Linq.JToken value, string path) { throw null; }
+    }
+
+    public sealed partial class HashObjectWriter : RuntimeModel.IObjectWriter, System.IDisposable
+    {
+        public HashObjectWriter(Packaging.IHashFunction hashFunc) { }
+
+        public void Dispose() { }
+
+        public string GetHash() { throw null; }
+
+        public void WriteArrayEnd() { }
+
+        public void WriteArrayStart(string name) { }
+
+        public void WriteNameArray(string name, System.Collections.Generic.IEnumerable<string> values) { }
+
+        public void WriteNameValue(string name, bool value) { }
+
+        public void WriteNameValue(string name, int value) { }
+
+        public void WriteNameValue(string name, string value) { }
+
+        public void WriteObjectEnd() { }
+
+        public void WriteObjectStart() { }
+
+        public void WriteObjectStart(string name) { }
+    }
+
+    public partial interface IAssetsLogMessage
+    {
+        Common.NuGetLogCode Code { get; }
+
+        int EndColumnNumber { get; }
+
+        int EndLineNumber { get; }
+
+        string FilePath { get; }
+
+        Common.LogLevel Level { get; }
+
+        string LibraryId { get; }
+
+        string Message { get; }
+
+        string ProjectPath { get; }
+
+        int StartColumnNumber { get; }
+
+        int StartLineNumber { get; }
+
+        System.Collections.Generic.IReadOnlyList<string> TargetGraphs { get; }
+
+        Common.WarningLevel WarningLevel { get; }
+    }
+
+    public partial interface IExternalProjectReferenceProvider
+    {
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetEntryPoints();
+        System.Collections.Generic.IReadOnlyList<ExternalProjectReference> GetReferences(string entryPointPath);
+    }
+
+    public partial class IncludeExcludeFiles : System.IEquatable<IncludeExcludeFiles>
+    {
+        public System.Collections.Generic.IReadOnlyList<string> Exclude { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> ExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> Include { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<string> IncludeFiles { get { throw null; } set { } }
+
+        public IncludeExcludeFiles Clone() { throw null; }
+
+        public bool Equals(IncludeExcludeFiles other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public bool HandleIncludeExcludeFiles(Newtonsoft.Json.Linq.JObject jsonObject) { throw null; }
+    }
+
+    public static partial class JsonPackageSpecReader
+    {
+        public static readonly string Files;
+        public static readonly string HideWarningsAndErrors;
+        public static readonly string PackageType;
+        public static readonly string PackOptions;
+        public static readonly string RestoreOptions;
+        public static readonly string RestoreSettings;
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject rawPackageSpec, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        [System.Obsolete("This method is obsolete and will be removed in a future release.")]
+        public static PackageSpec GetPackageSpec(Newtonsoft.Json.Linq.JObject json) { throw null; }
+
+        public static PackageSpec GetPackageSpec(System.IO.Stream stream, string name, string packageSpecPath, string snapshotValue) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath) { throw null; }
+
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath) { throw null; }
+    }
+
+    public static partial class JTokenExtensions
+    {
+        public static T GetValue<T>(this Newtonsoft.Json.Linq.JToken token, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken, string name) { throw null; }
+
+        public static T[] ValueAsArray<T>(this Newtonsoft.Json.Linq.JToken jToken) { throw null; }
+    }
+
+    public partial class LockFile : System.IEquatable<LockFile>
+    {
+        public static readonly char DirectorySeparatorChar;
+        public static readonly Frameworks.NuGetFramework ToolFramework;
+        public System.Collections.Generic.IList<CentralTransitiveDependencyGroup> CentralTransitiveDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileLibrary> Libraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<IAssetsLogMessage> LogMessages { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> PackageFolders { get { throw null; } set { } }
+
+        public PackageSpec PackageSpec { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectFileDependencyGroup> ProjectFileDependencyGroups { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(LockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public LockFileLibrary GetLibrary(string name, Versioning.NuGetVersion version) { throw null; }
+
+        public LockFileTarget GetTarget(Frameworks.NuGetFramework framework, string runtimeIdentifier) { throw null; }
+
+        public LockFileTarget GetTarget(string frameworkAlias, string runtimeIdentifier) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec, int requestLockFileVersion) { throw null; }
+
+        public bool IsValidForPackageSpec(PackageSpec spec) { throw null; }
+    }
+
+    public partial class LockFileContentFile : LockFileItem
+    {
+        public static readonly string BuildActionProperty;
+        public static readonly string CodeLanguageProperty;
+        public static readonly string CopyToOutputProperty;
+        public static readonly string OutputPathProperty;
+        public static readonly string PPOutputPathProperty;
+        public LockFileContentFile(string path) : base(default!) { }
+
+        public BuildAction BuildAction { get { throw null; } set { } }
+
+        public string CodeLanguage { get { throw null; } set { } }
+
+        public bool CopyToOutput { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PPOutputPath { get { throw null; } set { } }
+    }
+
+    public partial class LockFileDependency : System.IEquatable<LockFileDependency>
+    {
+        public string ContentHash { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public string Id { get { throw null; } set { } }
+
+        public Versioning.VersionRange RequestedVersion { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion ResolvedVersion { get { throw null; } set { } }
+
+        public PackageDependencyType Type { get { throw null; } set { } }
+
+        public bool Equals(LockFileDependency other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileDependencyIdVersionComparer : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyIdVersionComparer Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+
+    [System.Obsolete("This is an unused class and will be removed in a future version.")]
+    public partial class LockFileDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public LockFileDependencyProvider(LockFile lockFile) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class LockFileExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<LockFileTarget> GetTargetGraphs(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<LockFileTargetLibrary> GetTargetLibraries(this IAssetsLogMessage message, LockFile assetsFile) { throw null; }
+
+        public static LockFileTargetLibrary GetTargetLibrary(this LockFileTarget target, string libraryId) { throw null; }
+    }
+
+    public partial class LockFileFormat
+    {
+        public static readonly string AssetsFileName;
+        public static readonly string LockFileName;
+        public static readonly int Version;
+        public LockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.Stream stream, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public LockFile Read(System.IO.TextReader reader, string path) { throw null; }
+
+        public LockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public LockFile Read(string filePath) { throw null; }
+
+        public string Render(LockFile lockFile) { throw null; }
+
+        public void Write(System.IO.Stream stream, LockFile lockFile) { }
+
+        public void Write(System.IO.TextWriter textWriter, LockFile lockFile) { }
+
+        public void Write(string filePath, LockFile lockFile) { }
+    }
+
+    public partial class LockFileItem : System.IEquatable<LockFileItem>
+    {
+        public static readonly string AliasesProperty;
+        public LockFileItem(string path) { }
+
+        public string Path { get { throw null; } }
+
+        public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } }
+
+        public bool Equals(LockFileItem other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        protected string GetProperty(string name) { throw null; }
+
+        public static implicit operator LockFileItem(string path) { throw null; }
+
+        protected void SetProperty(string name, string value) { }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class LockFileLibrary : System.IEquatable<LockFileLibrary>
+    {
+        public System.Collections.Generic.IList<string> Files { get { throw null; } set { } }
+
+        public bool HasTools { get { throw null; } set { } }
+
+        public bool IsServiceable { get { throw null; } set { } }
+
+        public string MSBuildProject { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public string Path { get { throw null; } set { } }
+
+        public string Sha512 { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public LockFileLibrary Clone() { throw null; }
+
+        public bool Equals(LockFileLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileRuntimeTarget : LockFileItem
+    {
+        public static readonly string AssetTypeProperty;
+        public static readonly string RidProperty;
+        public LockFileRuntimeTarget(string path, string runtime, string assetType) : base(default!) { }
+
+        public LockFileRuntimeTarget(string path) : base(default!) { }
+
+        public string AssetType { get { throw null; } set { } }
+
+        public string Runtime { get { throw null; } set { } }
+    }
+
+    public partial class LockFileTarget : System.IEquatable<LockFileTarget>
+    {
+        public System.Collections.Generic.IList<LockFileTargetLibrary> Libraries { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(LockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class LockFileTargetLibrary : System.IEquatable<LockFileTargetLibrary>
+    {
+        public System.Collections.Generic.IList<LockFileItem> Build { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> BuildMultiTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> CompileTimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileContentFile> ContentFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> EmbedAssemblies { get { throw null; } set { } }
+
+        public string Framework { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FrameworkReferences { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> NativeLibraries { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ResourceAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> RuntimeAssemblies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileRuntimeTarget> RuntimeTargets { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LockFileItem> ToolsAssemblies { get { throw null; } set { } }
+
+        public string Type { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public bool Equals(LockFileTargetLibrary other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class LockFileUtilities
+    {
+        public static LockFile GetLockFile(string lockFilePath, Common.ILogger logger) { throw null; }
+    }
+
+    public partial class LockFileValidationResult
+    {
+        public LockFileValidationResult(bool isValid, System.Collections.Generic.IReadOnlyList<string> invalidReasons) { }
+
+        public System.Collections.Generic.IReadOnlyList<string> InvalidReasons { get { throw null; } }
+
+        public bool IsValid { get { throw null; } }
+    }
+
+    public enum PackageDependencyType
+    {
+        Direct = 0,
+        Transitive = 1,
+        Project = 2,
+        CentralTransitive = 3
+    }
+
+    public partial class PackagesConfigProjectRestoreMetadata : ProjectRestoreMetadata
+    {
+        public string PackagesConfigPath { get { throw null; } set { } }
+
+        public string RepositoryPath { get { throw null; } set { } }
+
+        public override ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(PackagesConfigProjectRestoreMetadata obj) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class PackagesLockFile : System.IEquatable<PackagesLockFile>
+    {
+        public PackagesLockFile() { }
+
+        public PackagesLockFile(int version) { }
+
+        public string Path { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<PackagesLockFileTarget> Targets { get { throw null; } set { } }
+
+        public int Version { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileFormat
+    {
+        public static readonly string LockFileName;
+        public static readonly int PackagesLockFileVersion;
+        public static readonly int Version;
+        public static PackagesLockFile Parse(string lockFileContent, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Parse(string lockFileContent, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.Stream stream, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(System.IO.TextReader reader, Common.ILogger log, string path) { throw null; }
+
+        public static PackagesLockFile Read(string filePath, Common.ILogger log) { throw null; }
+
+        public static PackagesLockFile Read(string filePath) { throw null; }
+
+        public static string Render(PackagesLockFile lockFile) { throw null; }
+
+        public static void Write(System.IO.Stream stream, PackagesLockFile lockFile) { }
+
+        public static void Write(System.IO.TextWriter textWriter, PackagesLockFile lockFile) { }
+
+        public static void Write(string filePath, PackagesLockFile lockFile) { }
+    }
+
+    public partial class PackagesLockFileTarget : System.IEquatable<PackagesLockFileTarget>
+    {
+        public System.Collections.Generic.IList<LockFileDependency> Dependencies { get { throw null; } set { } }
+
+        public string Name { get { throw null; } }
+
+        public string RuntimeIdentifier { get { throw null; } set { } }
+
+        public Frameworks.NuGetFramework TargetFramework { get { throw null; } set { } }
+
+        public bool Equals(PackagesLockFileTarget other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackagesLockFileUtilities
+    {
+        public static string GetNuGetLockFilePath(PackageSpec project) { throw null; }
+
+        public static string GetNuGetLockFilePath(string baseDirectory, string projectName) { throw null; }
+
+        [System.Obsolete("This method is obsolete. Call IsLockFileValid instead.")]
+        public static bool IsLockFileStillValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static LockFileValidityWithMatchedResults IsLockFileStillValid(PackagesLockFile expected, PackagesLockFile actual) { throw null; }
+
+        public static LockFileValidationResult IsLockFileValid(DependencyGraphSpec dgSpec, PackagesLockFile nuGetLockFile) { throw null; }
+
+        public static bool IsNuGetLockFileEnabled(PackageSpec project) { throw null; }
+
+        public partial class LockFileValidityWithMatchedResults
+        {
+            public static readonly LockFileValidityWithMatchedResults Invalid;
+            public LockFileValidityWithMatchedResults(bool isValid, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> matchedDependencies) { }
+
+            public bool IsValid { get { throw null; } }
+
+            public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<LockFileDependency, LockFileDependency>> MatchedDependencies { get { throw null; } }
+        }
+    }
+
+    public partial class PackageSpec
+    {
+        public static readonly Versioning.NuGetVersion DefaultVersion;
+        public static readonly string PackageSpecFileName;
+        public PackageSpec() { }
+
+        public PackageSpec(System.Collections.Generic.IList<TargetFrameworkInformation> frameworks) { }
+
+        [System.Obsolete]
+        public string[] Authors { get { throw null; } set { } }
+
+        public string BaseDirectory { get { throw null; } }
+
+        [System.Obsolete]
+        public BuildOptions BuildOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IList<string> ContentFiles { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Copyright { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Description { get { throw null; } set { } }
+
+        public string FilePath { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool HasVersionSnapshot { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string IconUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool IsDefaultVersion { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string Language { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string LicenseUrl { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Owners { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, string> PackInclude { get { throw null; } }
+
+        [System.Obsolete]
+        public PackOptions PackOptions { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ProjectUrl { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string ReleaseNotes { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public bool RequireLicenseAcceptance { get { throw null; } set { } }
+
+        public ProjectRestoreMetadata RestoreMetadata { get { throw null; } set { } }
+
+        public ProjectRestoreSettings RestoreSettings { get { throw null; } set { } }
+
+        public RuntimeModel.RuntimeGraph RuntimeGraph { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IEnumerable<string>> Scripts { get { throw null; } }
+
+        [System.Obsolete]
+        public string Summary { get { throw null; } set { } }
+
+        [System.Obsolete]
+        public string[] Tags { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<TargetFrameworkInformation> TargetFrameworks { get { throw null; } }
+
+        public string Title { get { throw null; } set { } }
+
+        public Versioning.NuGetVersion Version { get { throw null; } set { } }
+
+        public PackageSpec Clone() { throw null; }
+
+        public bool Equals(PackageSpec other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public static partial class PackageSpecExtensions
+    {
+        public static ProjectRestoreMetadataFrameworkInfo GetRestoreMetadataFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, Frameworks.NuGetFramework targetFramework) { throw null; }
+    }
+
+    public static partial class PackageSpecOperations
+    {
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageDependency dependency) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity, System.Collections.Generic.IEnumerable<Frameworks.NuGetFramework> frameworksToAdd) { }
+
+        public static void AddOrUpdateDependency(PackageSpec spec, Packaging.Core.PackageIdentity identity) { }
+
+        public static bool HasPackage(PackageSpec spec, string packageId) { throw null; }
+
+        public static void RemoveDependency(PackageSpec spec, string packageId) { }
+    }
+
+    public partial class PackageSpecReferenceDependencyProvider : DependencyResolver.IDependencyProvider
+    {
+        public PackageSpecReferenceDependencyProvider(System.Collections.Generic.IEnumerable<ExternalProjectReference> externalProjects, Common.ILogger logger) { }
+
+        public LibraryModel.Library GetLibrary(LibraryModel.LibraryRange libraryRange, Frameworks.NuGetFramework targetFramework) { throw null; }
+
+        public bool SupportsType(LibraryModel.LibraryDependencyTarget libraryType) { throw null; }
+    }
+
+    public static partial class PackageSpecUtility
+    {
+        public static bool IsSnapshotVersion(string version) { throw null; }
+
+        public static Versioning.NuGetVersion SpecifySnapshot(string version, string snapshotValue) { throw null; }
+    }
+
+    public sealed partial class PackageSpecWriter
+    {
+        public static void Write(PackageSpec packageSpec, RuntimeModel.IObjectWriter writer) { }
+
+        public static void WriteToFile(PackageSpec packageSpec, string filePath) { }
+    }
+
+    public partial class PackOptions : System.IEquatable<PackOptions>
+    {
+        public IncludeExcludeFiles IncludeExcludeFiles { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, IncludeExcludeFiles> Mappings { get { throw null; } set { } }
+
+        public System.Collections.Generic.IReadOnlyList<Packaging.Core.PackageType> PackageType { get { throw null; } set { } }
+
+        public PackOptions Clone() { throw null; }
+
+        public bool Equals(PackOptions other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectFileDependencyGroup : System.IEquatable<ProjectFileDependencyGroup>
+    {
+        public ProjectFileDependencyGroup(string frameworkName, System.Collections.Generic.IEnumerable<string> dependencies) { }
+
+        public System.Collections.Generic.IEnumerable<string> Dependencies { get { throw null; } }
+
+        public string FrameworkName { get { throw null; } }
+
+        public bool Equals(ProjectFileDependencyGroup other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadata : System.IEquatable<ProjectRestoreMetadata>
+    {
+        public string CacheFilePath { get { throw null; } set { } }
+
+        public bool CentralPackageTransitivePinningEnabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionOverrideDisabled { get { throw null; } set { } }
+
+        public bool CentralPackageVersionsEnabled { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> ConfigFilePaths { get { throw null; } set { } }
+
+        public bool CrossTargeting { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> FallbackFolders { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFile> Files { get { throw null; } set { } }
+
+        public bool LegacyPackagesDirectory { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<string> OriginalTargetFrameworks { get { throw null; } set { } }
+
+        public string OutputPath { get { throw null; } set { } }
+
+        public string PackagesPath { get { throw null; } set { } }
+
+        public string ProjectJsonPath { get { throw null; } set { } }
+
+        public string ProjectName { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public ProjectStyle ProjectStyle { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public WarningProperties ProjectWideWarningProperties { get { throw null; } set { } }
+
+        public RestoreAuditProperties RestoreAuditProperties { get { throw null; } set { } }
+
+        public RestoreLockProperties RestoreLockProperties { get { throw null; } set { } }
+
+        public bool SkipContentFileWrite { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<Configuration.PackageSource> Sources { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreMetadataFrameworkInfo> TargetFrameworks { get { throw null; } set { } }
+
+        public bool ValidateRuntimeAssets { get { throw null; } set { } }
+
+        public virtual ProjectRestoreMetadata Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadata other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        protected void FillClone(ProjectRestoreMetadata clone) { }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFile : System.IEquatable<ProjectRestoreMetadataFile>, System.IComparable<ProjectRestoreMetadataFile>
+    {
+        public ProjectRestoreMetadataFile(string packagePath, string absolutePath) { }
+
+        public string AbsolutePath { get { throw null; } }
+
+        public string PackagePath { get { throw null; } }
+
+        public ProjectRestoreMetadataFile Clone() { throw null; }
+
+        public int CompareTo(ProjectRestoreMetadataFile other) { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFile other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreMetadataFrameworkInfo : System.IEquatable<ProjectRestoreMetadataFrameworkInfo>
+    {
+        public ProjectRestoreMetadataFrameworkInfo() { }
+
+        public ProjectRestoreMetadataFrameworkInfo(Frameworks.NuGetFramework frameworkName) { }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<ProjectRestoreReference> ProjectReferences { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public ProjectRestoreMetadataFrameworkInfo Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreMetadataFrameworkInfo other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreReference : System.IEquatable<ProjectRestoreReference>
+    {
+        public LibraryModel.LibraryIncludeFlags ExcludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags IncludeAssets { get { throw null; } set { } }
+
+        public LibraryModel.LibraryIncludeFlags PrivateAssets { get { throw null; } set { } }
+
+        public string ProjectPath { get { throw null; } set { } }
+
+        public string ProjectUniqueName { get { throw null; } set { } }
+
+        public ProjectRestoreReference Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreReference other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ProjectRestoreSettings
+    {
+        public bool HideWarningsAndErrors { get { throw null; } set { } }
+
+        public ProjectRestoreSettings Clone() { throw null; }
+
+        public bool Equals(ProjectRestoreSettings other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public enum ProjectStyle : ushort
+    {
+        Unknown = 0,
+        ProjectJson = 1,
+        PackageReference = 2,
+        DotnetCliTool = 3,
+        Standalone = 4,
+        PackagesConfig = 5,
+        DotnetToolReference = 6
+    }
+
+    public partial class RestoreAuditProperties : System.IEquatable<RestoreAuditProperties>
+    {
+        public string? AuditLevel { get { throw null; } set { } }
+
+        public string? AuditMode { get { throw null; } set { } }
+
+        public string? EnableAudit { get { throw null; } set { } }
+
+        public bool Equals(RestoreAuditProperties? other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool operator ==(RestoreAuditProperties? x, RestoreAuditProperties? y) { throw null; }
+
+        public static bool operator !=(RestoreAuditProperties? x, RestoreAuditProperties? y) { throw null; }
+    }
+
+    public partial class RestoreLockProperties : System.IEquatable<RestoreLockProperties>
+    {
+        public RestoreLockProperties() { }
+
+        public RestoreLockProperties(string restorePackagesWithLockFile, string nuGetLockFilePath, bool restoreLockedMode) { }
+
+        public string NuGetLockFilePath { get { throw null; } }
+
+        public bool RestoreLockedMode { get { throw null; } }
+
+        public string RestorePackagesWithLockFile { get { throw null; } }
+
+        public RestoreLockProperties Clone() { throw null; }
+
+        public bool Equals(RestoreLockProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+    }
+
+    public partial class TargetFrameworkInformation : System.IEquatable<TargetFrameworkInformation>
+    {
+        public bool AssetTargetFallback { get { throw null; } set { } }
+
+        public System.Collections.Generic.IDictionary<string, LibraryModel.CentralPackageVersion> CentralPackageVersions { get { throw null; } }
+
+        public System.Collections.Generic.IList<LibraryModel.LibraryDependency> Dependencies { get { throw null; } set { } }
+
+        public System.Collections.Generic.IList<LibraryModel.DownloadDependency> DownloadDependencies { get { throw null; } }
+
+        public Frameworks.NuGetFramework FrameworkName { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<LibraryModel.FrameworkDependency> FrameworkReferences { get { throw null; } }
+
+        public System.Collections.Generic.IList<Frameworks.NuGetFramework> Imports { get { throw null; } set { } }
+
+        public string RuntimeIdentifierGraphPath { get { throw null; } set { } }
+
+        public string TargetAlias { get { throw null; } set { } }
+
+        public bool Warn { get { throw null; } set { } }
+
+        public TargetFrameworkInformation Clone() { throw null; }
+
+        public bool Equals(TargetFrameworkInformation other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ToolPathResolver
+    {
+        public ToolPathResolver(string packagesDirectory, bool isLowercase) { }
+
+        public ToolPathResolver(string packagesDirectory) { }
+
+        public string GetBestToolDirectoryPath(string packageId, Versioning.VersionRange versionRange, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+
+        public string GetLockFilePath(string toolDirectory) { throw null; }
+
+        public string GetToolDirectoryPath(string packageId, Versioning.NuGetVersion version, Frameworks.NuGetFramework framework) { throw null; }
+    }
+
+    public partial class WarningProperties : System.IEquatable<WarningProperties>
+    {
+        public WarningProperties() { }
+
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> warningsNotAsErrors) { }
+
+        [System.Obsolete("Use the constructor with 4 instead.")]
+        public WarningProperties(System.Collections.Generic.ISet<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.ISet<Common.NuGetLogCode> noWarn, bool allWarningsAsErrors) { }
+
+        public bool AllWarningsAsErrors { get { throw null; } set { } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> NoWarn { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsAsErrors { get { throw null; } }
+
+        public System.Collections.Generic.ISet<Common.NuGetLogCode> WarningsNotAsErrors { get { throw null; } }
+
+        public WarningProperties Clone() { throw null; }
+
+        public bool Equals(WarningProperties other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsNotAsErrors) { throw null; }
+
+        [System.Obsolete]
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> warningsAsErrors, System.Collections.Generic.IEnumerable<Common.NuGetLogCode> noWarn) { throw null; }
+
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn, string warningsNotAsErrors) { throw null; }
+
+        [System.Obsolete]
+        public static WarningProperties GetWarningProperties(string treatWarningsAsErrors, string warningsAsErrors, string noWarn) { throw null; }
+    }
+}
+
+namespace NuGet.ProjectModel.ProjectLockFile
+{
+    public partial class LockFileDependencyComparerWithoutContentHash : System.Collections.Generic.IEqualityComparer<LockFileDependency>
+    {
+        public static LockFileDependencyComparerWithoutContentHash Default { get { throw null; } }
+
+        public bool Equals(LockFileDependency x, LockFileDependency y) { throw null; }
+
+        public int GetHashCode(LockFileDependency obj) { throw null; }
+    }
+}

--- a/src/referencePackages/src/nuget.projectmodel/6.7.0/nuget.projectmodel.nuspec
+++ b/src/referencePackages/src/nuget.projectmodel/6.7.0/nuget.projectmodel.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>NuGet.ProjectModel</id>
+    <version>6.7.0</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <projectUrl>https://aka.ms/nugetprj</projectUrl>
+    <description>NuGet's core types and interfaces for PackageReference-based restore, such as lock files, assets file and internal restore models.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nuget</tags>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client" commit="b46f5f64159a81d930ac8cdfde96e76f90796c62" />
+    <dependencies>
+      <group targetFramework="net5.0">
+        <dependency id="NuGet.DependencyResolver.Core" version="6.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="NuGet.DependencyResolver.Core" version="6.7.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Arcade introduced NuGet prebuilts in https://github.com/dotnet/arcade/pull/14159 due to a version change from 6.2.4 to 6.7.0. This didn't fail the build because [all NuGet dependencies are in the prebuilt baseline](https://github.com/dotnet/arcade/blob/adbabc12338fa0695ba6ff15669f683b643ab1d6/eng/SourceBuildPrebuiltBaseline.xml#L8-L9) due to https://github.com/NuGet/Home/issues/11059.

This is resolved by adding the following packages to SBRP:

* NuGet.LibraryModel.6.7.0
* NuGet.DependencyResolver.Core.6.7.0
* NuGet.ProjectModel.6.7.0
* NuGet.Commands.6.7.0