### PR TITLE
Include sb argument when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,4 +18,8 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 
-"$scriptroot/eng/common/build.sh" --build --restore --pack "$@"
+if [[ $@ == *"ArcadeInnerBuildFromSource=true"* ]]; then
+  "$scriptroot/eng/common/build.sh" --build --restore --pack "$@"
+else
+  "$scriptroot/eng/common/build.sh" -sb "$@"
+fi


### PR DESCRIPTION
Closes https://github.com/dotnet/source-build/issues/3044

Build `source-build-reference-packages` repo in the source-build configuration regardless of if `-sb` is passed to `./build.sh`.

If the `-sb` argument is passed to the inner clone, the build will encounter a failure due to the `ArcadeBuildFromSource` being set to true. This discrepancy indicates that while the outer build is configured to utilize the `sb` argument, the inner clone should not pass `-sb` to `eng/build.sh`.