### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -11,8 +11,6 @@
     dependencies on it are removed from the previous-source-built packages. -->
     <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
 
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
   </IgnorePatterns>
   <Usages/>
 </UsageData>


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935. 

Addresses https://github.com/dotnet/source-build/issues/3010