### PR TITLE
Ensure darc publishing is enabled for SBRP

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -71,14 +71,11 @@ stages:
         testRunTitle: 'Windows_SBRP_tests'
       condition: always()
 
-# Based on - https://github.com/dotnet/arcade/blob/9b3f304c7bc9fd4d11be9ca0b466b83e98d2a191/Documentation/CorePackages/Publishing.md#moving-away-from-the-legacy-pushtoblobfeed-task
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
+  - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
-      publishingInfraVersion: 3
+      dependsOn:
+      - Linux
+      - Windows
+      publishUsingPipelines: true
       publishAssetsImmediately: true
-      enableSourceLinkValidation: false
-      #Nuget and Signing Validation are not needed as we only produce a transport package.
-      enableSigningValidation: false
-      enableNugetValidation: false
-
+      enablePublishBuildArtifacts: true

--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -71,11 +71,12 @@ stages:
         testRunTitle: 'Windows_SBRP_tests'
       condition: always()
 
-  - template: /eng/common/templates/job/publish-build-assets.yml
-    parameters:
-      dependsOn:
-      - Linux
-      - Windows
-      publishUsingPipelines: true
-      publishAssetsImmediately: true
-      enablePublishBuildArtifacts: true
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        dependsOn:
+        - Linux
+        - Windows
+        publishUsingPipelines: true
+        publishAssetsImmediately: true
+        enablePublishBuildArtifacts: true


### PR DESCRIPTION
After the changes from https://github.com/dotnet/source-build-reference-packages/pull/824, darc publishing is no longer occurring for SBRP which means there's no dependency flow coming from SBRP. Only the `Linux` and `Windows` build jobs get run in the pipeline. This is due to the [removal of the usage of the jobs.yml template](https://github.com/dotnet/source-build-reference-packages/pull/824/files#diff-33ae5736679b1efe12fde9f3fb58dbe360dd8a8bb32e5b98620bf7d644114f19L22) which handled the publishing.

I've fixed this by directly referencing the publish-build-assets.yml template which jobs.yml was handling before. I've also removed the use of the post-build.yml template since that wasn't doing anything anyway.