### PR TITLE
Publish test results from the `Release` path

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -40,7 +40,7 @@ stages:
       displayName: Publish Test Results
       inputs:
         testResultsFormat: 'xUnit'
-        testResultsFiles: '**/artifacts/TestResults/Debug/*.xml'
+        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
         testRunTitle: 'Linux_SBRP_tests'
       condition: always()
 
@@ -67,7 +67,7 @@ stages:
       displayName: Publish Test Results
       inputs:
         testResultsFormat: 'xUnit'
-        testResultsFiles: '**/artifacts/TestResults/Debug/*.xml'
+        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
         testRunTitle: 'Windows_SBRP_tests'
       condition: always()
 


### PR DESCRIPTION
In the context of pull requests [#840](https://github.com/dotnet/source-build-reference-packages/pull/840) and [#847](https://github.com/dotnet/source-build-reference-packages/pull/847), the building and testing of this repo are now configured by default to use the `Release` configuration. 

This adjustment impacts the publishing of test results, as the test results are now stored in the `Release` path due to the default configuration used by the pipeline. It's essential to update the `Publish Test Results` job in pipeline accordingly to align with these modifications.