### PR TITLE
Fix path for nupkg-cache, remove newtonsoft-json prebuilt

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -18,7 +18,7 @@
              Directories="$(LocalNuGetPackageCacheDirectory)" />
 
     <Exec
-      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId)"
+      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:SourceBuildOutputDir=$(SourceBuildOutputDir) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildFromSource=true /p:ArcadeInnerBuildFromSource=true /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -7,10 +7,6 @@
     <UsagePattern IdentityGlob="runtime.linux-x64.Microsoft.NETCore.ILAsm/*" />
     <UsagePattern IdentityGlob="runtime.linux-x64.Microsoft.NETCore.ILDAsm/*" />
 
-    <!-- Necessary to work around NuGet non-determinism with online builds/feeds. Can be removed once 
-    dependencies on it are removed from the previous-source-built packages. -->
-    <UsagePattern IdentityGlob="Newtonsoft.Json/13.0.1" />
-
   </IgnorePatterns>
   <Usages/>
 </UsageData>


### PR DESCRIPTION
The path for `source-build-int-nupkg-cache` was previously being set to `/root/repos/source-build-reference-packages/artifacts/sb/src/artifacts/sb/src/artifacts/obj/source-built-upstream-cache/`, causing new SBRPs that depended on DependencyPackageProjectss to reference the online feeds.

This PR changes the path to be set to `/root/repos/source-build-reference-packages/artifacts/sb/src/artifacts/obj/source-built-upstream-cache/`. This fix should also eliminate the need for `Newtonsoft.Json.13.0.1` in the prebuilt baseline.

**Leaving as a draft because `Newtonsoft.Json.13.0.1` is still being detected as a prebuilt.**