### PR TITLE
Add xUnit.2.6.1

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -70,6 +70,11 @@
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.CodeAnalysis.Common.4.6.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.CodeAnalysis.CSharp.4.6.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\xunit.abstractions.2.0.3.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\xunit.assert.2.6.1.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\xunit.extensibility.core.2.6.1.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\xunit.extensibility.execution.2.6.1.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/GetPackageItems.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/GetPackageItems.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             { "adb9793829ddae60", ("MicrosoftAspNetCore", "AspNetCore") },
             { "b77a5c561934e089", ("ECMA", "ECMA") },
             { "cc7b13ffcd2ddd51", ("Open", "Open") },
-            { "979442b78dfc278e", ("Humanizer", "Humanizer") }
+            { "979442b78dfc278e", ("Humanizer", "Humanizer") },
+            { "8d05b1bb7a6fdb6c", ("XUnit.Core", "XUnit.Core")}
         };
 
         /// <summary>

--- a/src/referencePackages/src/xunit.abstractions/2.0.3/lib/netstandard1.0/xunit.abstractions.cs
+++ b/src/referencePackages/src/xunit.abstractions/2.0.3/lib/netstandard1.0/xunit.abstractions.cs
@@ -1,0 +1,469 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Reflection.AssemblyProduct("xUnit.net Testing Framework")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName = ".NET Portable Subset")]
+[assembly: System.Reflection.AssemblyTitle("xUnit.net Abstractions (PCL)")]
+[assembly: System.Reflection.AssemblyCompany("Outercurve Foundation")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright (C) Outercurve Foundation")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Xunit.Abstractions
+{
+    public partial interface IAfterTestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IAfterTestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IAssemblyInfo
+    {
+        string AssemblyPath { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        ITypeInfo GetType(string typeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetTypes(bool includePrivateTypes);
+    }
+
+    public partial interface IAttributeInfo
+    {
+        System.Collections.Generic.IEnumerable<object> GetConstructorArguments();
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        TValue GetNamedArgument<TValue>(string argumentName);
+    }
+
+    public partial interface IBeforeTestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IBeforeTestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IDiagnosticMessage : IMessageSinkMessage
+    {
+        string Message { get; }
+    }
+
+    public partial interface IDiscoveryCompleteMessage : IMessageSinkMessage
+    {
+    }
+
+    public partial interface IErrorMessage : IFailureInformation, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface IExecutionMessage : IMessageSinkMessage
+    {
+        System.Collections.Generic.IEnumerable<ITestCase> TestCases { get; }
+    }
+
+    public partial interface IFailureInformation
+    {
+        int[] ExceptionParentIndices { get; }
+
+        string[] ExceptionTypes { get; }
+
+        string[] Messages { get; }
+
+        string[] StackTraces { get; }
+    }
+
+    public partial interface IFinishedMessage : IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        int TestsFailed { get; }
+
+        int TestsRun { get; }
+
+        int TestsSkipped { get; }
+    }
+
+    public partial interface IMessageSink
+    {
+        bool OnMessage(IMessageSinkMessage message);
+    }
+
+    public partial interface IMessageSinkMessage
+    {
+    }
+
+    public partial interface IMethodInfo
+    {
+        bool IsAbstract { get; }
+
+        bool IsGenericMethodDefinition { get; }
+
+        bool IsPublic { get; }
+
+        bool IsStatic { get; }
+
+        string Name { get; }
+
+        ITypeInfo ReturnType { get; }
+
+        ITypeInfo Type { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetGenericArguments();
+        System.Collections.Generic.IEnumerable<IParameterInfo> GetParameters();
+        IMethodInfo MakeGenericMethod(params ITypeInfo[] typeArguments);
+    }
+
+    public partial interface IParameterInfo
+    {
+        string Name { get; }
+
+        ITypeInfo ParameterType { get; }
+    }
+
+    public partial interface IReflectionAssemblyInfo : IAssemblyInfo
+    {
+        System.Reflection.Assembly Assembly { get; }
+    }
+
+    public partial interface IReflectionAttributeInfo : IAttributeInfo
+    {
+        System.Attribute Attribute { get; }
+    }
+
+    public partial interface IReflectionMethodInfo : IMethodInfo
+    {
+        System.Reflection.MethodInfo MethodInfo { get; }
+    }
+
+    public partial interface IReflectionParameterInfo : IParameterInfo
+    {
+        System.Reflection.ParameterInfo ParameterInfo { get; }
+    }
+
+    public partial interface IReflectionTypeInfo : ITypeInfo
+    {
+        System.Type Type { get; }
+    }
+
+    public partial interface ISourceInformation : IXunitSerializable
+    {
+        string FileName { get; set; }
+
+        int? LineNumber { get; set; }
+    }
+
+    public partial interface ISourceInformationProvider : System.IDisposable
+    {
+        ISourceInformation GetSourceInformation(ITestCase testCase);
+    }
+
+    public partial interface ITest
+    {
+        string DisplayName { get; }
+
+        ITestCase TestCase { get; }
+    }
+
+    public partial interface ITestAssembly : IXunitSerializable
+    {
+        IAssemblyInfo Assembly { get; }
+
+        string ConfigFileName { get; }
+    }
+
+    public partial interface ITestAssemblyCleanupFailure : ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestAssemblyFinished : ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestAssemblyMessage : IMessageSinkMessage
+    {
+        ITestAssembly TestAssembly { get; }
+    }
+
+    public partial interface ITestAssemblyStarting : ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        System.DateTime StartTime { get; }
+
+        string TestEnvironment { get; }
+
+        string TestFrameworkDisplayName { get; }
+    }
+
+    public partial interface ITestCase : IXunitSerializable
+    {
+        string DisplayName { get; }
+
+        string SkipReason { get; }
+
+        ISourceInformation SourceInformation { get; set; }
+
+        ITestMethod TestMethod { get; }
+
+        object[] TestMethodArguments { get; }
+
+        System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> Traits { get; }
+
+        string UniqueID { get; }
+    }
+
+    public partial interface ITestCaseCleanupFailure : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCaseDiscoveryMessage : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCaseFinished : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCaseMessage : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestCase TestCase { get; }
+    }
+
+    public partial interface ITestCaseStarting : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClass : IXunitSerializable
+    {
+        ITypeInfo Class { get; }
+
+        ITestCollection TestCollection { get; }
+    }
+
+    public partial interface ITestClassCleanupFailure : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestClassConstructionFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassConstructionStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassDisposeFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassDisposeStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassFinished : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassMessage : ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestClass TestClass { get; }
+    }
+
+    public partial interface ITestClassStarting : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCleanupFailure : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCollection : IXunitSerializable
+    {
+        ITypeInfo CollectionDefinition { get; }
+
+        string DisplayName { get; }
+
+        ITestAssembly TestAssembly { get; }
+
+        System.Guid UniqueID { get; }
+    }
+
+    public partial interface ITestCollectionCleanupFailure : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCollectionFinished : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCollectionMessage : ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestCollection TestCollection { get; }
+    }
+
+    public partial interface ITestCollectionStarting : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestFailed : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        string Output { get; }
+    }
+
+    public partial interface ITestFramework : System.IDisposable
+    {
+        ISourceInformationProvider SourceInformationProvider { set; }
+
+        ITestFrameworkDiscoverer GetDiscoverer(IAssemblyInfo assembly);
+        ITestFrameworkExecutor GetExecutor(System.Reflection.AssemblyName assemblyName);
+    }
+
+    public partial interface ITestFrameworkDiscoverer : System.IDisposable
+    {
+        string TargetFramework { get; }
+
+        string TestFrameworkDisplayName { get; }
+
+        void Find(bool includeSourceInformation, IMessageSink discoveryMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions);
+        void Find(string typeName, bool includeSourceInformation, IMessageSink discoveryMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions);
+        string Serialize(ITestCase testCase);
+    }
+
+    public partial interface ITestFrameworkDiscoveryOptions : ITestFrameworkOptions
+    {
+    }
+
+    public partial interface ITestFrameworkExecutionOptions : ITestFrameworkOptions
+    {
+    }
+
+    public partial interface ITestFrameworkExecutor : System.IDisposable
+    {
+        ITestCase Deserialize(string value);
+        void RunAll(IMessageSink executionMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions, ITestFrameworkExecutionOptions executionOptions);
+        void RunTests(System.Collections.Generic.IEnumerable<ITestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions);
+    }
+
+    public partial interface ITestFrameworkOptions
+    {
+        TValue GetValue<TValue>(string name);
+        void SetValue<TValue>(string name, TValue value);
+    }
+
+    public partial interface ITestMessage : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITest Test { get; }
+    }
+
+    public partial interface ITestMethod : IXunitSerializable
+    {
+        IMethodInfo Method { get; }
+
+        ITestClass TestClass { get; }
+    }
+
+    public partial interface ITestMethodCleanupFailure : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestMethodFinished : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestMethodMessage : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestMethod TestMethod { get; }
+    }
+
+    public partial interface ITestMethodStarting : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestOutput : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string Output { get; }
+    }
+
+    public partial interface ITestOutputHelper
+    {
+        void WriteLine(string format, params object[] args);
+        void WriteLine(string message);
+    }
+
+    public partial interface ITestPassed : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestResultMessage : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        string Output { get; }
+    }
+
+    public partial interface ITestSkipped : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string Reason { get; }
+    }
+
+    public partial interface ITestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITypeInfo
+    {
+        IAssemblyInfo Assembly { get; }
+
+        ITypeInfo BaseType { get; }
+
+        System.Collections.Generic.IEnumerable<ITypeInfo> Interfaces { get; }
+
+        bool IsAbstract { get; }
+
+        bool IsGenericParameter { get; }
+
+        bool IsGenericType { get; }
+
+        bool IsSealed { get; }
+
+        bool IsValueType { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetGenericArguments();
+        IMethodInfo GetMethod(string methodName, bool includePrivateMethod);
+        System.Collections.Generic.IEnumerable<IMethodInfo> GetMethods(bool includePrivateMethods);
+    }
+
+    public partial interface IXunitSerializable
+    {
+        void Deserialize(IXunitSerializationInfo info);
+        void Serialize(IXunitSerializationInfo info);
+    }
+
+    public partial interface IXunitSerializationInfo
+    {
+        void AddValue(string key, object value, System.Type type = null);
+        object GetValue(string key, System.Type type);
+        T GetValue<T>(string key);
+    }
+}

--- a/src/referencePackages/src/xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.cs
+++ b/src/referencePackages/src/xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.cs
@@ -1,0 +1,469 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Reflection.AssemblyProduct("xUnit.net Testing Framework")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETPortable,Version=v4.5,Profile=Profile259", FrameworkDisplayName = ".NET Portable Subset")]
+[assembly: System.Reflection.AssemblyTitle("xUnit.net Abstractions (PCL)")]
+[assembly: System.Reflection.AssemblyCompany("Outercurve Foundation")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright (C) Outercurve Foundation")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Xunit.Abstractions
+{
+    public partial interface IAfterTestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IAfterTestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IAssemblyInfo
+    {
+        string AssemblyPath { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        ITypeInfo GetType(string typeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetTypes(bool includePrivateTypes);
+    }
+
+    public partial interface IAttributeInfo
+    {
+        System.Collections.Generic.IEnumerable<object> GetConstructorArguments();
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        TValue GetNamedArgument<TValue>(string argumentName);
+    }
+
+    public partial interface IBeforeTestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IBeforeTestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string AttributeName { get; }
+    }
+
+    public partial interface IDiagnosticMessage : IMessageSinkMessage
+    {
+        string Message { get; }
+    }
+
+    public partial interface IDiscoveryCompleteMessage : IMessageSinkMessage
+    {
+    }
+
+    public partial interface IErrorMessage : IFailureInformation, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface IExecutionMessage : IMessageSinkMessage
+    {
+        System.Collections.Generic.IEnumerable<ITestCase> TestCases { get; }
+    }
+
+    public partial interface IFailureInformation
+    {
+        int[] ExceptionParentIndices { get; }
+
+        string[] ExceptionTypes { get; }
+
+        string[] Messages { get; }
+
+        string[] StackTraces { get; }
+    }
+
+    public partial interface IFinishedMessage : IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        int TestsFailed { get; }
+
+        int TestsRun { get; }
+
+        int TestsSkipped { get; }
+    }
+
+    public partial interface IMessageSink
+    {
+        bool OnMessage(IMessageSinkMessage message);
+    }
+
+    public partial interface IMessageSinkMessage
+    {
+    }
+
+    public partial interface IMethodInfo
+    {
+        bool IsAbstract { get; }
+
+        bool IsGenericMethodDefinition { get; }
+
+        bool IsPublic { get; }
+
+        bool IsStatic { get; }
+
+        string Name { get; }
+
+        ITypeInfo ReturnType { get; }
+
+        ITypeInfo Type { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetGenericArguments();
+        System.Collections.Generic.IEnumerable<IParameterInfo> GetParameters();
+        IMethodInfo MakeGenericMethod(params ITypeInfo[] typeArguments);
+    }
+
+    public partial interface IParameterInfo
+    {
+        string Name { get; }
+
+        ITypeInfo ParameterType { get; }
+    }
+
+    public partial interface IReflectionAssemblyInfo : IAssemblyInfo
+    {
+        System.Reflection.Assembly Assembly { get; }
+    }
+
+    public partial interface IReflectionAttributeInfo : IAttributeInfo
+    {
+        System.Attribute Attribute { get; }
+    }
+
+    public partial interface IReflectionMethodInfo : IMethodInfo
+    {
+        System.Reflection.MethodInfo MethodInfo { get; }
+    }
+
+    public partial interface IReflectionParameterInfo : IParameterInfo
+    {
+        System.Reflection.ParameterInfo ParameterInfo { get; }
+    }
+
+    public partial interface IReflectionTypeInfo : ITypeInfo
+    {
+        System.Type Type { get; }
+    }
+
+    public partial interface ISourceInformation : IXunitSerializable
+    {
+        string FileName { get; set; }
+
+        int? LineNumber { get; set; }
+    }
+
+    public partial interface ISourceInformationProvider : System.IDisposable
+    {
+        ISourceInformation GetSourceInformation(ITestCase testCase);
+    }
+
+    public partial interface ITest
+    {
+        string DisplayName { get; }
+
+        ITestCase TestCase { get; }
+    }
+
+    public partial interface ITestAssembly : IXunitSerializable
+    {
+        IAssemblyInfo Assembly { get; }
+
+        string ConfigFileName { get; }
+    }
+
+    public partial interface ITestAssemblyCleanupFailure : ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestAssemblyFinished : ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestAssemblyMessage : IMessageSinkMessage
+    {
+        ITestAssembly TestAssembly { get; }
+    }
+
+    public partial interface ITestAssemblyStarting : ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        System.DateTime StartTime { get; }
+
+        string TestEnvironment { get; }
+
+        string TestFrameworkDisplayName { get; }
+    }
+
+    public partial interface ITestCase : IXunitSerializable
+    {
+        string DisplayName { get; }
+
+        string SkipReason { get; }
+
+        ISourceInformation SourceInformation { get; set; }
+
+        ITestMethod TestMethod { get; }
+
+        object[] TestMethodArguments { get; }
+
+        System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> Traits { get; }
+
+        string UniqueID { get; }
+    }
+
+    public partial interface ITestCaseCleanupFailure : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCaseDiscoveryMessage : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCaseFinished : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCaseMessage : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestCase TestCase { get; }
+    }
+
+    public partial interface ITestCaseStarting : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClass : IXunitSerializable
+    {
+        ITypeInfo Class { get; }
+
+        ITestCollection TestCollection { get; }
+    }
+
+    public partial interface ITestClassCleanupFailure : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestClassConstructionFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassConstructionStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassDisposeFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassDisposeStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassFinished : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestClassMessage : ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestClass TestClass { get; }
+    }
+
+    public partial interface ITestClassStarting : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCleanupFailure : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCollection : IXunitSerializable
+    {
+        ITypeInfo CollectionDefinition { get; }
+
+        string DisplayName { get; }
+
+        ITestAssembly TestAssembly { get; }
+
+        System.Guid UniqueID { get; }
+    }
+
+    public partial interface ITestCollectionCleanupFailure : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestCollectionFinished : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestCollectionMessage : ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestCollection TestCollection { get; }
+    }
+
+    public partial interface ITestCollectionStarting : ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestFailed : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestFinished : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        string Output { get; }
+    }
+
+    public partial interface ITestFramework : System.IDisposable
+    {
+        ISourceInformationProvider SourceInformationProvider { set; }
+
+        ITestFrameworkDiscoverer GetDiscoverer(IAssemblyInfo assembly);
+        ITestFrameworkExecutor GetExecutor(System.Reflection.AssemblyName assemblyName);
+    }
+
+    public partial interface ITestFrameworkDiscoverer : System.IDisposable
+    {
+        string TargetFramework { get; }
+
+        string TestFrameworkDisplayName { get; }
+
+        void Find(bool includeSourceInformation, IMessageSink discoveryMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions);
+        void Find(string typeName, bool includeSourceInformation, IMessageSink discoveryMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions);
+        string Serialize(ITestCase testCase);
+    }
+
+    public partial interface ITestFrameworkDiscoveryOptions : ITestFrameworkOptions
+    {
+    }
+
+    public partial interface ITestFrameworkExecutionOptions : ITestFrameworkOptions
+    {
+    }
+
+    public partial interface ITestFrameworkExecutor : System.IDisposable
+    {
+        ITestCase Deserialize(string value);
+        void RunAll(IMessageSink executionMessageSink, ITestFrameworkDiscoveryOptions discoveryOptions, ITestFrameworkExecutionOptions executionOptions);
+        void RunTests(System.Collections.Generic.IEnumerable<ITestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions);
+    }
+
+    public partial interface ITestFrameworkOptions
+    {
+        TValue GetValue<TValue>(string name);
+        void SetValue<TValue>(string name, TValue value);
+    }
+
+    public partial interface ITestMessage : ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITest Test { get; }
+    }
+
+    public partial interface ITestMethod : IXunitSerializable
+    {
+        IMethodInfo Method { get; }
+
+        ITestClass TestClass { get; }
+    }
+
+    public partial interface ITestMethodCleanupFailure : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage, IFailureInformation
+    {
+    }
+
+    public partial interface ITestMethodFinished : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IFinishedMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestMethodMessage : ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        ITestMethod TestMethod { get; }
+    }
+
+    public partial interface ITestMethodStarting : ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestOutput : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string Output { get; }
+    }
+
+    public partial interface ITestOutputHelper
+    {
+        void WriteLine(string format, params object[] args);
+        void WriteLine(string message);
+    }
+
+    public partial interface ITestPassed : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITestResultMessage : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IMessageSinkMessage
+    {
+        decimal ExecutionTime { get; }
+
+        string Output { get; }
+    }
+
+    public partial interface ITestSkipped : ITestResultMessage, ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+        string Reason { get; }
+    }
+
+    public partial interface ITestStarting : ITestMessage, ITestCaseMessage, ITestMethodMessage, ITestClassMessage, ITestCollectionMessage, ITestAssemblyMessage, IExecutionMessage, IMessageSinkMessage
+    {
+    }
+
+    public partial interface ITypeInfo
+    {
+        IAssemblyInfo Assembly { get; }
+
+        ITypeInfo BaseType { get; }
+
+        System.Collections.Generic.IEnumerable<ITypeInfo> Interfaces { get; }
+
+        bool IsAbstract { get; }
+
+        bool IsGenericParameter { get; }
+
+        bool IsGenericType { get; }
+
+        bool IsSealed { get; }
+
+        bool IsValueType { get; }
+
+        string Name { get; }
+
+        System.Collections.Generic.IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName);
+        System.Collections.Generic.IEnumerable<ITypeInfo> GetGenericArguments();
+        IMethodInfo GetMethod(string methodName, bool includePrivateMethod);
+        System.Collections.Generic.IEnumerable<IMethodInfo> GetMethods(bool includePrivateMethods);
+    }
+
+    public partial interface IXunitSerializable
+    {
+        void Deserialize(IXunitSerializationInfo info);
+        void Serialize(IXunitSerializationInfo info);
+    }
+
+    public partial interface IXunitSerializationInfo
+    {
+        void AddValue(string key, object value, System.Type type = null);
+        object GetValue(string key, System.Type type);
+        T GetValue<T>(string key);
+    }
+}

--- a/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.csproj
+++ b/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>xunit.abstractions</AssemblyName>
+    <StrongNameKeyId>XUnit.Core</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.nuspec
+++ b/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>xunit.abstractions</id>
+    <version>2.0.3</version>
+    <title>xUnit.net [Abstractions]</title>
+    <authors>James Newkirk,Brad Wilson</authors>
+    <owners>James Newkirk,Brad Wilson</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://raw.githubusercontent.com/xunit/xunit/master/license.txt</licenseUrl>
+    <projectUrl>https://github.com/xunit/xunit</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/xunit/media/master/logo-512-transparent.png</iconUrl>
+    <description>Common abstractions used to exchange information between xUnit.net and version-independent runners (xunit.abstractions.dll).</description>
+    <summary>Common abstractions used to exchange information between xUnit.net and version-independent runners (xunit.abstractions.dll).</summary>
+    <language>en-US</language>
+    <dependencies>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+      </group>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/xunit.assert/2.6.1/lib/netstandard1.1/xunit.assert.cs
+++ b/src/referencePackages/src/xunit.assert/2.6.1/lib/netstandard1.1/xunit.assert.cs
@@ -1,0 +1,798 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Reflection.AssemblyFileVersion("2.6.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("2.6.1+9f1684f5f7")]
+[assembly: System.Reflection.AssemblyCompany(".NET Foundation")]
+[assembly: System.Reflection.AssemblyProduct("xUnit.net Testing Framework")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright (C) .NET Foundation")]
+[assembly: System.Reflection.AssemblyTitle("xUnit.net Assertion Library")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.1", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.6.1.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Xunit
+{
+    public partial class Assert
+    {
+        protected Assert() { }
+
+        public static void All<T>(System.Collections.Generic.IEnumerable<T> collection, System.Action<T, int> action) { }
+
+        public static void All<T>(System.Collections.Generic.IEnumerable<T> collection, System.Action<T> action) { }
+
+        public static System.Threading.Tasks.Task AllAsync<T>(System.Collections.Generic.IEnumerable<T> collection, System.Func<T, int, System.Threading.Tasks.Task> action) { throw null; }
+
+        public static System.Threading.Tasks.Task AllAsync<T>(System.Collections.Generic.IEnumerable<T> collection, System.Func<T, System.Threading.Tasks.Task> action) { throw null; }
+
+        public static void Collection<T>(System.Collections.Generic.IEnumerable<T> collection, params System.Action<T>[] elementInspectors) { }
+
+        public static System.Threading.Tasks.Task CollectionAsync<T>(System.Collections.Generic.IEnumerable<T> collection, params System.Func<T, System.Threading.Tasks.Task>[] elementInspectors) { throw null; }
+
+        public static void Contains(string expectedSubstring, string? actualString, System.StringComparison comparisonType) { }
+
+        public static void Contains(string expectedSubstring, string? actualString) { }
+
+        public static void Contains<T>(T expected, System.Collections.Generic.HashSet<T> set) { }
+
+        public static void Contains<T>(T expected, System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void Contains<T>(T expected, System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public static void Contains<T>(T expected, System.Collections.Generic.ISet<T> set) { }
+
+        public static void Contains<T>(System.Collections.Generic.IEnumerable<T> collection, System.Predicate<T> filter) { }
+
+        public static TValue Contains<TKey, TValue>(TKey expected, System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue> collection) { throw null; }
+
+        public static TValue Contains<TKey, TValue>(TKey expected, System.Collections.Generic.Dictionary<TKey, TValue> collection) { throw null; }
+
+        public static TValue Contains<TKey, TValue>(TKey expected, System.Collections.Generic.IDictionary<TKey, TValue> collection) { throw null; }
+
+        public static TValue Contains<TKey, TValue>(TKey expected, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> collection) { throw null; }
+
+        public static TValue Contains<TKey, TValue>(TKey expected, System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue> collection) { throw null; }
+
+        public static void Distinct<T>(System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void Distinct<T>(System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public static void DoesNotContain(string expectedSubstring, string? actualString, System.StringComparison comparisonType) { }
+
+        public static void DoesNotContain(string expectedSubstring, string? actualString) { }
+
+        public static void DoesNotContain<T>(T expected, System.Collections.Generic.HashSet<T> set) { }
+
+        public static void DoesNotContain<T>(T expected, System.Collections.Generic.IEnumerable<T> collection, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void DoesNotContain<T>(T expected, System.Collections.Generic.IEnumerable<T> collection) { }
+
+        public static void DoesNotContain<T>(T expected, System.Collections.Generic.ISet<T> set) { }
+
+        public static void DoesNotContain<T>(System.Collections.Generic.IEnumerable<T> collection, System.Predicate<T> filter) { }
+
+        public static void DoesNotContain<TKey, TValue>(TKey expected, System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue> collection) { }
+
+        public static void DoesNotContain<TKey, TValue>(TKey expected, System.Collections.Generic.Dictionary<TKey, TValue> collection) { }
+
+        public static void DoesNotContain<TKey, TValue>(TKey expected, System.Collections.Generic.IDictionary<TKey, TValue> collection) { }
+
+        public static void DoesNotContain<TKey, TValue>(TKey expected, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> collection) { }
+
+        public static void DoesNotContain<TKey, TValue>(TKey expected, System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue> collection) { }
+
+        public static void DoesNotMatch(string expectedRegexPattern, string? actualString) { }
+
+        public static void DoesNotMatch(System.Text.RegularExpressions.Regex expectedRegex, string? actualString) { }
+
+        public static void Empty(System.Collections.IEnumerable collection) { }
+
+        public static void Empty(string value) { }
+
+        public static void EndsWith(string? expectedEndString, string? actualString, System.StringComparison comparisonType) { }
+
+        public static void EndsWith(string? expectedEndString, string? actualString) { }
+
+        public static void Equal(System.DateTime expected, System.DateTime actual, System.TimeSpan precision) { }
+
+        public static void Equal(System.DateTime expected, System.DateTime actual) { }
+
+        public static void Equal(System.DateTimeOffset expected, System.DateTimeOffset actual, System.TimeSpan precision) { }
+
+        public static void Equal(System.DateTimeOffset expected, System.DateTimeOffset actual) { }
+
+        public static void Equal(decimal expected, decimal actual, int precision) { }
+
+        public static void Equal(double expected, double actual, double tolerance) { }
+
+        public static void Equal(double expected, double actual, int precision, System.MidpointRounding rounding) { }
+
+        public static void Equal(double expected, double actual, int precision) { }
+
+        public static void Equal(float expected, float actual, int precision, System.MidpointRounding rounding) { }
+
+        public static void Equal(float expected, float actual, int precision) { }
+
+        public static void Equal(float expected, float actual, float tolerance) { }
+
+        public static void Equal(string? expected, string? actual, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false, bool ignoreAllWhiteSpace = false) { }
+
+        public static void Equal(string? expected, string? actual) { }
+
+        public static void Equal<T>(T expected, T actual, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void Equal<T>(T expected, T actual, System.Func<T, T, bool> comparer) { }
+
+        public static void Equal<T>(T expected, T actual) { }
+
+        public static void Equal<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void Equal<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual, System.Func<T, T, bool> comparer) { }
+
+        public static void Equal<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual) { }
+
+        [System.Obsolete("This is an override of Object.Equals(). Call Assert.Equal() instead.", true)]
+        public new static bool Equals(object a, object b) { throw null; }
+
+        public static void Equivalent(object? expected, object? actual, bool strict = false) { }
+
+        public static void Fail(string? message = null) { }
+
+        public static void False(bool condition, string? userMessage) { }
+
+        public static void False(bool condition) { }
+
+        public static void False(bool? condition, string? userMessage) { }
+
+        public static void False(bool? condition) { }
+
+        public static void InRange<T>(T actual, T low, T high, System.Collections.Generic.IComparer<T> comparer) { }
+
+        public static void InRange<T>(T actual, T low, T high)
+            where T : System.IComparable { }
+
+        public static void IsAssignableFrom(System.Type expectedType, object? @object) { }
+
+        public static T IsAssignableFrom<T>(object? @object) { throw null; }
+
+        public static void IsNotAssignableFrom(System.Type expectedType, object? @object) { }
+
+        public static void IsNotAssignableFrom<T>(object? @object) { }
+
+        public static void IsNotType(System.Type expectedType, object? @object) { }
+
+        public static void IsNotType<T>(object? @object) { }
+
+        public static void IsType(System.Type expectedType, object? @object) { }
+
+        public static T IsType<T>(object? @object) { throw null; }
+
+        public static void Matches(string expectedRegexPattern, string? actualString) { }
+
+        public static void Matches(System.Text.RegularExpressions.Regex expectedRegex, string? actualString) { }
+
+        public static void Multiple(params System.Action[] checks) { }
+
+        public static void NotEmpty(System.Collections.IEnumerable collection) { }
+
+        public static void NotEqual(decimal expected, decimal actual, int precision) { }
+
+        public static void NotEqual(double expected, double actual, double tolerance) { }
+
+        public static void NotEqual(double expected, double actual, int precision, System.MidpointRounding rounding) { }
+
+        public static void NotEqual(double expected, double actual, int precision) { }
+
+        public static void NotEqual(float expected, float actual, int precision, System.MidpointRounding rounding) { }
+
+        public static void NotEqual(float expected, float actual, int precision) { }
+
+        public static void NotEqual(float expected, float actual, float tolerance) { }
+
+        public static void NotEqual<T>(T expected, T actual, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void NotEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer) { }
+
+        public static void NotEqual<T>(T expected, T actual) { }
+
+        public static void NotEqual<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+
+        public static void NotEqual<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual, System.Func<T, T, bool> comparer) { }
+
+        public static void NotEqual<T>(System.Collections.Generic.IEnumerable<T>? expected, System.Collections.Generic.IEnumerable<T>? actual) { }
+
+        public static void NotInRange<T>(T actual, T low, T high, System.Collections.Generic.IComparer<T> comparer) { }
+
+        public static void NotInRange<T>(T actual, T low, T high)
+            where T : System.IComparable { }
+
+        public static void NotNull(object? @object) { }
+
+        public static T NotNull<T>(T? value)
+            where T : struct { throw null; }
+
+        public static void NotSame(object? expected, object? actual) { }
+
+        public static void NotStrictEqual<T>(T expected, T actual) { }
+
+        public static void Null(object? @object) { }
+
+        public static void Null<T>(T? value)
+            where T : struct { }
+
+        public static void ProperSubset<T>(System.Collections.Generic.ISet<T> expectedSubset, System.Collections.Generic.ISet<T>? actual) { }
+
+        public static void ProperSuperset<T>(System.Collections.Generic.ISet<T> expectedSuperset, System.Collections.Generic.ISet<T>? actual) { }
+
+        public static void PropertyChanged(System.ComponentModel.INotifyPropertyChanged @object, string propertyName, System.Action testCode) { }
+
+        [System.Obsolete("You must call Assert.PropertyChangedAsync (and await the result) when testing async code.", true)]
+        public static void PropertyChanged(System.ComponentModel.INotifyPropertyChanged @object, string propertyName, System.Func<System.Threading.Tasks.Task> testCode) { }
+
+        public static System.Threading.Tasks.Task PropertyChangedAsync(System.ComponentModel.INotifyPropertyChanged @object, string propertyName, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static RaisedEvent<T> Raises<T>(System.Action<System.EventHandler<T>> attach, System.Action<System.EventHandler<T>> detach, System.Action testCode) { throw null; }
+
+        public static RaisedEvent<System.EventArgs> RaisesAny(System.Action<System.EventHandler> attach, System.Action<System.EventHandler> detach, System.Action testCode) { throw null; }
+
+        public static RaisedEvent<T> RaisesAny<T>(System.Action<System.EventHandler<T>> attach, System.Action<System.EventHandler<T>> detach, System.Action testCode) { throw null; }
+
+        public static System.Threading.Tasks.Task<RaisedEvent<System.EventArgs>> RaisesAnyAsync(System.Action<System.EventHandler> attach, System.Action<System.EventHandler> detach, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static System.Threading.Tasks.Task<RaisedEvent<T>> RaisesAnyAsync<T>(System.Action<System.EventHandler<T>> attach, System.Action<System.EventHandler<T>> detach, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static System.Threading.Tasks.Task<RaisedEvent<T>> RaisesAsync<T>(System.Action<System.EventHandler<T>> attach, System.Action<System.EventHandler<T>> detach, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        protected static System.Exception? RecordException(System.Action testCode) { throw null; }
+
+        protected static System.Exception? RecordException(System.Func<object?> testCode, string asyncMethodName) { throw null; }
+
+        [System.Obsolete("You must call Assert.RecordExceptionAsync (and await the result) when testing async code.", true)]
+        protected static System.Exception RecordException(System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        protected static System.Threading.Tasks.Task<System.Exception?> RecordExceptionAsync(System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        [System.Obsolete("This is an override of Object.ReferenceEquals(). Call Assert.Same() instead.", true)]
+        public new static bool ReferenceEquals(object a, object b) { throw null; }
+
+        public static void Same(object? expected, object? actual) { }
+
+        public static void Single(System.Collections.IEnumerable collection, object? expected) { }
+
+        public static object? Single(System.Collections.IEnumerable collection) { throw null; }
+
+        public static T Single<T>(System.Collections.Generic.IEnumerable<T> collection, System.Predicate<T> predicate) { throw null; }
+
+        public static T Single<T>(System.Collections.Generic.IEnumerable<T> collection) { throw null; }
+
+        public static void StartsWith(string? expectedStartString, string? actualString, System.StringComparison comparisonType) { }
+
+        public static void StartsWith(string? expectedStartString, string? actualString) { }
+
+        public static void StrictEqual<T>(T expected, T actual) { }
+
+        public static void Subset<T>(System.Collections.Generic.ISet<T> expectedSubset, System.Collections.Generic.ISet<T>? actual) { }
+
+        public static void Superset<T>(System.Collections.Generic.ISet<T> expectedSuperset, System.Collections.Generic.ISet<T>? actual) { }
+
+        public static System.Exception Throws(System.Type exceptionType, System.Action testCode) { throw null; }
+
+        public static System.Exception Throws(System.Type exceptionType, System.Func<object?> testCode) { throw null; }
+
+        [System.Obsolete("You must call Assert.ThrowsAsync (and await the result) when testing async code.", true)]
+        public static System.Exception Throws(System.Type exceptionType, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static T Throws<T>(System.Action testCode)
+            where T : System.Exception { throw null; }
+
+        public static T Throws<T>(System.Func<object?> testCode)
+            where T : System.Exception { throw null; }
+
+        [System.Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+        public static T Throws<T>(System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.Exception { throw null; }
+
+        public static T Throws<T>(string? paramName, System.Action testCode)
+            where T : System.ArgumentException { throw null; }
+
+        public static T Throws<T>(string? paramName, System.Func<object?> testCode)
+            where T : System.ArgumentException { throw null; }
+
+        [System.Obsolete("You must call Assert.ThrowsAsync<T> (and await the result) when testing async code.", true)]
+        public static T Throws<T>(string? paramName, System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.ArgumentException { throw null; }
+
+        public static T ThrowsAny<T>(System.Action testCode)
+            where T : System.Exception { throw null; }
+
+        public static T ThrowsAny<T>(System.Func<object?> testCode)
+            where T : System.Exception { throw null; }
+
+        [System.Obsolete("You must call Assert.ThrowsAnyAsync<T> (and await the result) when testing async code.", true)]
+        public static T ThrowsAny<T>(System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.Exception { throw null; }
+
+        public static System.Threading.Tasks.Task<T> ThrowsAnyAsync<T>(System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.Exception { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Exception> ThrowsAsync(System.Type exceptionType, System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static System.Threading.Tasks.Task<T> ThrowsAsync<T>(System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.Exception { throw null; }
+
+        public static System.Threading.Tasks.Task<T> ThrowsAsync<T>(string? paramName, System.Func<System.Threading.Tasks.Task> testCode)
+            where T : System.ArgumentException { throw null; }
+
+        public static void True(bool condition, string? userMessage) { }
+
+        public static void True(bool condition) { }
+
+        public static void True(bool? condition, string? userMessage) { }
+
+        public static void True(bool? condition) { }
+
+        public partial class RaisedEvent<T>
+        {
+            public RaisedEvent(object? sender, T args) { }
+
+            public T Arguments { get { throw null; } }
+
+            public object? Sender { get { throw null; } }
+        }
+    }
+}
+
+namespace Xunit.Sdk
+{
+    public partial class AllException : XunitException
+    {
+        internal AllException() : base(default) { }
+
+        public static AllException ForFailures(int totalItems, System.Collections.Generic.IReadOnlyList<System.Tuple<int, string, System.Exception>> errors) { throw null; }
+    }
+
+    public static partial class ArgumentFormatter
+    {
+        public const int MAX_DEPTH = 3;
+        public const int MAX_ENUMERABLE_LENGTH = 5;
+        public const int MAX_OBJECT_ITEM_COUNT = 5;
+        public const int MAX_STRING_LENGTH = 50;
+        public static string Ellipsis { get { throw null; } }
+
+        public static string EscapeString(string s) { throw null; }
+
+        public static string Format(object? value, int depth = 1) { throw null; }
+
+        public static string FormatTypeName(System.Type type, bool fullTypeName = false) { throw null; }
+    }
+
+    public partial class CollectionException : XunitException
+    {
+        internal CollectionException() : base(default) { }
+
+        public static CollectionException ForMismatchedItem(System.Exception exception, int indexFailurePoint, int? failurePointerIndent, string formattedCollection) { throw null; }
+
+        public static CollectionException ForMismatchedItemCount(int expectedCount, int actualCount, string formattedCollection) { throw null; }
+    }
+
+    public abstract partial class CollectionTracker : System.IDisposable
+    {
+        protected CollectionTracker(System.Collections.IEnumerable innerEnumerable) { }
+
+        protected internal System.Collections.IEnumerable InnerEnumerable { get { throw null; } protected set { } }
+
+        public static bool AreCollectionsEqual(CollectionTracker? x, CollectionTracker? y, System.Collections.IEqualityComparer itemComparer, bool isDefaultItemComparer, out int? mismatchedIndex) { throw null; }
+
+        public abstract void Dispose();
+        public abstract string FormatIndexedMismatch(int startIndex, int endIndex, int? mismatchedIndex, out int? pointerIndent, int depth = 1);
+        public abstract string FormatIndexedMismatch(int? mismatchedIndex, out int? pointerIndent, int depth = 1);
+        public abstract string FormatStart(int depth = 1);
+        public abstract void GetMismatchExtents(int? mismatchedIndex, out int startIndex, out int endIndex);
+        protected internal abstract System.Collections.IEnumerator GetSafeEnumerator();
+        public abstract string? TypeAt(int? index);
+        public static CollectionTracker<object> Wrap(System.Collections.IEnumerable enumerable) { throw null; }
+    }
+
+    public static partial class CollectionTrackerExtensions
+    {
+        public static CollectionTracker? AsTracker(this System.Collections.IEnumerable? enumerable) { throw null; }
+
+        public static CollectionTracker<T>? AsTracker<T>(this System.Collections.Generic.IEnumerable<T>? enumerable) { throw null; }
+
+        public static System.Collections.IEnumerator GetEnumerator(this CollectionTracker tracker) { throw null; }
+    }
+
+    public sealed partial class CollectionTracker<T> : CollectionTracker, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+    {
+        internal CollectionTracker() : base(default!) { }
+
+        public int IterationCount { get { throw null; } }
+
+        public override void Dispose() { }
+
+        public override string FormatIndexedMismatch(int startIndex, int endIndex, int? mismatchedIndex, out int? pointerIndent, int depth = 1) { throw null; }
+
+        public override string FormatIndexedMismatch(int? mismatchedIndex, out int? pointerIndent, int depth = 1) { throw null; }
+
+        public static string FormatStart(System.Collections.Generic.IEnumerable<T> collection, int depth = 1) { throw null; }
+
+        public override string FormatStart(int depth = 1) { throw null; }
+
+        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+
+        public override void GetMismatchExtents(int? mismatchedIndex, out int startIndex, out int endIndex) { throw null; }
+
+        protected internal override System.Collections.IEnumerator GetSafeEnumerator() { throw null; }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override string? TypeAt(int? index) { throw null; }
+
+        public static CollectionTracker<T> Wrap(System.Collections.Generic.IEnumerable<T> collection) { throw null; }
+    }
+
+    public partial class ContainsException : XunitException
+    {
+        internal ContainsException() : base(default) { }
+
+        public static ContainsException ForCollectionFilterNotMatched(string collection) { throw null; }
+
+        public static ContainsException ForCollectionItemNotFound(string item, string collection) { throw null; }
+
+        public static ContainsException ForKeyNotFound(string expectedKey, string keys) { throw null; }
+
+        public static ContainsException ForSetItemNotFound(string item, string set) { throw null; }
+
+        public static ContainsException ForSubMemoryNotFound(string expectedSubMemory, string memory) { throw null; }
+
+        public static ContainsException ForSubSpanNotFound(string expectedSubSpan, string span) { throw null; }
+
+        public static ContainsException ForSubStringNotFound(string expectedSubString, string? @string) { throw null; }
+    }
+
+    public partial class DistinctException : XunitException
+    {
+        internal DistinctException() : base(default) { }
+
+        public static DistinctException ForDuplicateItem(string item, string collection) { throw null; }
+    }
+
+    public partial class DoesNotContainException : XunitException
+    {
+        internal DoesNotContainException() : base(default) { }
+
+        public static DoesNotContainException ForCollectionFilterMatched(int indexFailurePoint, int? failurePointerIndent, string collection) { throw null; }
+
+        public static DoesNotContainException ForCollectionItemFound(string item, int indexFailurePoint, int? failurePointerIndent, string collection) { throw null; }
+
+        public static DoesNotContainException ForKeyFound(string expectedKey, string keys) { throw null; }
+
+        public static DoesNotContainException ForSetItemFound(string item, string set) { throw null; }
+
+        public static DoesNotContainException ForSubMemoryFound(string expectedSubMemory, int indexFailurePoint, int? failurePointerIndent, string memory) { throw null; }
+
+        public static DoesNotContainException ForSubSpanFound(string expectedSubSpan, int indexFailurePoint, int? failurePointerIndent, string span) { throw null; }
+
+        public static DoesNotContainException ForSubStringFound(string expectedSubString, int indexFailurePoint, string @string) { throw null; }
+    }
+
+    public partial class DoesNotMatchException : XunitException
+    {
+        internal DoesNotMatchException() : base(default) { }
+
+        public static DoesNotMatchException ForMatch(string expectedRegexPattern, int indexFailurePoint, int failurePointerIndent, string @string) { throw null; }
+    }
+
+    public partial class EmptyException : XunitException
+    {
+        internal EmptyException() : base(default) { }
+
+        public static EmptyException ForNonEmptyCollection(string collection) { throw null; }
+
+        public static EmptyException ForNonEmptyString(string value) { throw null; }
+    }
+
+    public partial class EndsWithException : XunitException
+    {
+        internal EndsWithException() : base(default) { }
+
+        public static EndsWithException ForStringNotFound(string? expected, string? actual) { throw null; }
+    }
+
+    public partial class EqualException : XunitException
+    {
+        internal EqualException() : base(default) { }
+
+        public static EqualException ForMismatchedCollections(int? mismatchedIndex, string expected, int? expectedPointer, string? expectedType, string actual, int? actualPointer, string? actualType, string? collectionDisplay = null) { throw null; }
+
+        public static EqualException ForMismatchedCollectionsWithError(int? mismatchedIndex, string expected, int? expectedPointer, string? expectedType, string actual, int? actualPointer, string? actualType, System.Exception? error, string? collectionDisplay = null) { throw null; }
+
+        public static EqualException ForMismatchedStrings(string? expected, string? actual, int expectedIndex, int actualIndex) { throw null; }
+
+        public static EqualException ForMismatchedValues(object? expected, object? actual, string? banner = null) { throw null; }
+
+        public static EqualException ForMismatchedValuesWithError(object? expected, object? actual, System.Exception? error = null, string? banner = null) { throw null; }
+    }
+
+    public partial class EquivalentException : XunitException
+    {
+        internal EquivalentException() : base(default) { }
+
+        public static EquivalentException ForCircularReference(string memberName) { throw null; }
+
+        public static EquivalentException ForExceededDepth(int depth, string memberName) { throw null; }
+
+        public static EquivalentException ForExtraCollectionValue(System.Collections.Generic.IEnumerable<object?> expected, System.Collections.Generic.IEnumerable<object?> actual, System.Collections.Generic.IEnumerable<object?> actualLeftovers, string memberName) { throw null; }
+
+        public static EquivalentException ForMemberListMismatch(System.Collections.Generic.IEnumerable<string> expectedMemberNames, System.Collections.Generic.IEnumerable<string> actualMemberNames, string prefix) { throw null; }
+
+        public static EquivalentException ForMemberValueMismatch(object? expected, object? actual, string memberName, System.Exception? innerException = null) { throw null; }
+
+        public static EquivalentException ForMismatchedTypes(System.Type expectedType, System.Type actualType, string memberName) { throw null; }
+
+        public static EquivalentException ForMissingCollectionValue(object? expected, System.Collections.Generic.IEnumerable<object?> actual, string memberName) { throw null; }
+    }
+
+    public partial class FailException : XunitException
+    {
+        internal FailException() : base(default) { }
+
+        public static FailException ForFailure(string? message) { throw null; }
+    }
+
+    public partial class FalseException : XunitException
+    {
+        internal FalseException() : base(default) { }
+
+        public static FalseException ForNonFalseValue(string? message, bool? value) { throw null; }
+    }
+
+    public partial interface IAssertionException
+    {
+    }
+
+    public partial class InRangeException : XunitException
+    {
+        internal InRangeException() : base(default) { }
+
+        public static InRangeException ForValueNotInRange(object actual, object low, object high) { throw null; }
+    }
+
+    public partial class IsAssignableFromException : XunitException
+    {
+        internal IsAssignableFromException() : base(default) { }
+
+        public static IsAssignableFromException ForIncompatibleType(System.Type expected, object? actual) { throw null; }
+    }
+
+    public partial class IsNotAssignableFromException : XunitException
+    {
+        internal IsNotAssignableFromException() : base(default) { }
+
+        public static IsNotAssignableFromException ForCompatibleType(System.Type expected, object actual) { throw null; }
+    }
+
+    public partial class IsNotTypeException : XunitException
+    {
+        internal IsNotTypeException() : base(default) { }
+
+        public static IsNotTypeException ForExactType(System.Type type) { throw null; }
+    }
+
+    public partial class IsTypeException : XunitException
+    {
+        internal IsTypeException() : base(default) { }
+
+        public static IsTypeException ForMismatchedType(string expectedTypeName, string? actualTypeName) { throw null; }
+    }
+
+    public partial class MatchesException : XunitException
+    {
+        internal MatchesException() : base(default) { }
+
+        public static MatchesException ForMatchNotFound(string expectedRegexPattern, string? actual) { throw null; }
+    }
+
+    public partial class MultipleException : XunitException
+    {
+        internal MultipleException() : base(default) { }
+
+        public System.Collections.Generic.IReadOnlyCollection<System.Exception> InnerExceptions { get { throw null; } }
+
+        public override string? StackTrace { get { throw null; } }
+
+        public static MultipleException ForFailures(System.Collections.Generic.IReadOnlyCollection<System.Exception> innerExceptions) { throw null; }
+    }
+
+    public partial class NotEmptyException : XunitException
+    {
+        internal NotEmptyException() : base(default) { }
+
+        public static NotEmptyException ForNonEmptyCollection() { throw null; }
+    }
+
+    public partial class NotEqualException : XunitException
+    {
+        internal NotEqualException() : base(default) { }
+
+        public static NotEqualException ForEqualCollections(string expected, string actual, string? collectionDisplay = null) { throw null; }
+
+        public static NotEqualException ForEqualCollectionsWithError(int? mismatchedIndex, string expected, int? expectedPointer, string actual, int? actualPointer, System.Exception? error = null, string? collectionDisplay = null) { throw null; }
+
+        public static NotEqualException ForEqualValues(string expected, string actual, string? banner = null) { throw null; }
+
+        public static NotEqualException ForEqualValuesWithError(string expected, string actual, System.Exception? error = null, string? banner = null) { throw null; }
+    }
+
+    public partial class NotInRangeException : XunitException
+    {
+        internal NotInRangeException() : base(default) { }
+
+        public static NotInRangeException ForValueInRange(object actual, object low, object high) { throw null; }
+    }
+
+    public partial class NotNullException : XunitException
+    {
+        internal NotNullException() : base(default) { }
+
+        public static System.Exception ForNullStruct(System.Type type) { throw null; }
+
+        public static NotNullException ForNullValue() { throw null; }
+    }
+
+    public partial class NotSameException : XunitException
+    {
+        internal NotSameException() : base(default) { }
+
+        public static NotSameException ForSameValues() { throw null; }
+    }
+
+    public partial class NotStrictEqualException : XunitException
+    {
+        internal NotStrictEqualException() : base(default) { }
+
+        public static NotStrictEqualException ForEqualValues(string expected, string actual) { throw null; }
+    }
+
+    public partial class NullException : XunitException
+    {
+        internal NullException() : base(default) { }
+
+        public static System.Exception ForNonNullStruct<T>(System.Type type, T? actual)
+            where T : struct { throw null; }
+
+        public static NullException ForNonNullValue(object actual) { throw null; }
+    }
+
+    public partial class ProperSubsetException : XunitException
+    {
+        internal ProperSubsetException() : base(default) { }
+
+        public static ProperSubsetException ForFailure(string expected, string actual) { throw null; }
+    }
+
+    public partial class ProperSupersetException : XunitException
+    {
+        internal ProperSupersetException() : base(default) { }
+
+        public static ProperSupersetException ForFailure(string expected, string actual) { throw null; }
+    }
+
+    public partial class PropertyChangedException : XunitException
+    {
+        internal PropertyChangedException() : base(default) { }
+
+        public static PropertyChangedException ForUnsetProperty(string propertyName) { throw null; }
+    }
+
+    public partial class RaisesAnyException : XunitException
+    {
+        internal RaisesAnyException() : base(default) { }
+
+        public static RaisesAnyException ForNoEvent(System.Type expected) { throw null; }
+    }
+
+    public partial class RaisesException : XunitException
+    {
+        internal RaisesException() : base(default) { }
+
+        public static RaisesException ForIncorrectType(System.Type expected, System.Type actual) { throw null; }
+
+        public static RaisesException ForNoEvent(System.Type expected) { throw null; }
+    }
+
+    public partial class SameException : XunitException
+    {
+        internal SameException() : base(default) { }
+
+        public static SameException ForFailure(string expected, string actual) { throw null; }
+    }
+
+    public partial class SingleException : XunitException
+    {
+        internal SingleException() : base(default) { }
+
+        public static SingleException Empty(string? expected, string collection) { throw null; }
+
+        public static SingleException MoreThanOne(int count, string? expected, string collection, System.Collections.Generic.ICollection<int> matchIndices) { throw null; }
+    }
+
+    public partial class SkipException : XunitException
+    {
+        internal SkipException() : base(default) { }
+
+        public static SkipException ForSkip(string message) { throw null; }
+    }
+
+    public partial class StartsWithException : XunitException
+    {
+        internal StartsWithException() : base(default) { }
+
+        public static StartsWithException ForStringNotFound(string? expected, string? actual) { throw null; }
+    }
+
+    public partial class StrictEqualException : XunitException
+    {
+        internal StrictEqualException() : base(default) { }
+
+        public static StrictEqualException ForEqualValues(string expected, string actual) { throw null; }
+    }
+
+    public partial class SubsetException : XunitException
+    {
+        internal SubsetException() : base(default) { }
+
+        public static SubsetException ForFailure(string expected, string actual) { throw null; }
+    }
+
+    public partial class SupersetException : XunitException
+    {
+        internal SupersetException() : base(default) { }
+
+        public static SupersetException ForFailure(string expected, string actual) { throw null; }
+    }
+
+    public partial class ThrowsAnyException : XunitException
+    {
+        internal ThrowsAnyException() : base(default) { }
+
+        public static ThrowsAnyException ForIncorrectExceptionType(System.Type expected, System.Exception actual) { throw null; }
+
+        public static ThrowsAnyException ForNoException(System.Type expected) { throw null; }
+    }
+
+    public partial class ThrowsException : XunitException
+    {
+        internal ThrowsException() : base(default) { }
+
+        public static ThrowsException ForIncorrectExceptionType(System.Type expected, System.Exception actual) { throw null; }
+
+        public static ThrowsException ForIncorrectParameterName(System.Type expected, string? expectedParamName, string? actualParamName) { throw null; }
+
+        public static ThrowsException ForNoException(System.Type expected) { throw null; }
+    }
+
+    public partial class TrueException : XunitException
+    {
+        internal TrueException() : base(default) { }
+
+        public static TrueException ForNonTrueValue(string? message, bool? value) { throw null; }
+    }
+
+    public partial class XunitException : System.Exception, IAssertionException
+    {
+        public XunitException(string? userMessage, System.Exception? innerException) { }
+
+        public XunitException(string? userMessage) { }
+
+        public override string ToString() { throw null; }
+    }
+}

--- a/src/referencePackages/src/xunit.assert/2.6.1/xunit.assert.2.6.1.csproj
+++ b/src/referencePackages/src/xunit.assert/2.6.1/xunit.assert.2.6.1.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <AssemblyName>xunit.assert</AssemblyName>
+    <StrongNameKeyId>XUnit.Core</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/xunit.assert/2.6.1/xunit.assert.nuspec
+++ b/src/referencePackages/src/xunit.assert/2.6.1/xunit.assert.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>xunit.assert</id>
+    <version>2.6.1</version>
+    <title>xUnit.net [Assertion Library]</title>
+    <authors>jnewkirk,bradwilson</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <description>Includes the assertion library from xUnit.net (xunit.assert.dll). Supports .NET Standard 1.1+ and .NET 6.0+.</description>
+    <releaseNotes>https://xunit.net/releases/v2/2.6.1</releaseNotes>
+    <copyright>Copyright (C) .NET Foundation</copyright>
+    <repository type="git" url="https://github.com/xunit/xunit" commit="9f1684f5f74196d952f0085d7bde21aa20df6229" />
+    <dependencies>
+      <group targetFramework=".NETStandard1.1">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/xunit.extensibility.core/2.6.1/lib/netstandard1.1/xunit.core.cs
+++ b/src/referencePackages/src/xunit.extensibility.core/2.6.1/lib/netstandard1.1/xunit.core.cs
@@ -1,0 +1,443 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Reflection.AssemblyFileVersion("2.6.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("2.6.1+9f1684f5f7")]
+[assembly: System.Reflection.AssemblyCompany(".NET Foundation")]
+[assembly: System.Reflection.AssemblyProduct("xUnit.net Testing Framework")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright (C) .NET Foundation")]
+[assembly: System.Reflection.AssemblyTitle("xUnit.net Core")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.1", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.6.1.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace Xunit
+{
+    [Sdk.TraitDiscoverer("Xunit.Sdk.AssemblyTraitDiscoverer", "xunit.core")]
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
+    public sealed partial class AssemblyTraitAttribute : System.Attribute, Sdk.ITraitAttribute
+    {
+        public AssemblyTraitAttribute(string name, string value) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public partial class ClassDataAttribute : Sdk.DataAttribute
+    {
+        public ClassDataAttribute(System.Type @class) { }
+
+        public System.Type Class { get { throw null; } }
+
+        public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class CollectionAttribute : System.Attribute
+    {
+        public CollectionAttribute(string name) { }
+    }
+
+    public enum CollectionBehavior
+    {
+        CollectionPerAssembly = 0,
+        CollectionPerClass = 1
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = false)]
+    public sealed partial class CollectionBehaviorAttribute : System.Attribute
+    {
+        public CollectionBehaviorAttribute() { }
+
+        public CollectionBehaviorAttribute(string factoryTypeName, string factoryAssemblyName) { }
+
+        public CollectionBehaviorAttribute(CollectionBehavior collectionBehavior) { }
+
+        public bool DisableTestParallelization { get { throw null; } set { } }
+
+        public int MaxParallelThreads { get { throw null; } set { } }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class CollectionDefinitionAttribute : System.Attribute
+    {
+        public CollectionDefinitionAttribute(string name) { }
+
+        public bool DisableParallelization { get { throw null; } set { } }
+    }
+
+    [Sdk.XunitTestCaseDiscoverer("Xunit.Sdk.FactDiscoverer", "xunit.execution.{Platform}")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = false)]
+    public partial class FactAttribute : System.Attribute
+    {
+        public virtual string DisplayName { get { throw null; } set { } }
+
+        public virtual string Skip { get { throw null; } set { } }
+
+        public virtual int Timeout { get { throw null; } set { } }
+    }
+
+    public partial interface IAsyncLifetime
+    {
+        System.Threading.Tasks.Task DisposeAsync();
+        System.Threading.Tasks.Task InitializeAsync();
+    }
+
+    public partial interface IClassFixture<TFixture>
+        where TFixture : class
+    {
+    }
+
+    public partial interface ICollectionFixture<TFixture>
+        where TFixture : class
+    {
+    }
+
+    [System.CLSCompliant(false)]
+    [Sdk.DataDiscoverer("Xunit.Sdk.InlineDataDiscoverer", "xunit.core")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true)]
+    public sealed partial class InlineDataAttribute : Sdk.DataAttribute
+    {
+        public InlineDataAttribute(params object[] data) { }
+
+        public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod) { throw null; }
+    }
+
+    public partial interface ITestCollectionOrderer
+    {
+        System.Collections.Generic.IEnumerable<Abstractions.ITestCollection> OrderTestCollections(System.Collections.Generic.IEnumerable<Abstractions.ITestCollection> testCollections);
+    }
+
+    [System.CLSCompliant(false)]
+    [Sdk.DataDiscoverer("Xunit.Sdk.MemberDataDiscoverer", "xunit.core")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public sealed partial class MemberDataAttribute : MemberDataAttributeBase
+    {
+        public MemberDataAttribute(string memberName, params object[] parameters) : base(default!, default!) { }
+
+        protected override object[] ConvertDataItem(System.Reflection.MethodInfo testMethod, object item) { throw null; }
+    }
+
+    [System.CLSCompliant(false)]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public abstract partial class MemberDataAttributeBase : Sdk.DataAttribute
+    {
+        protected MemberDataAttributeBase(string memberName, object[] parameters) { }
+
+        public bool DisableDiscoveryEnumeration { get { throw null; } set { } }
+
+        public string MemberName { get { throw null; } }
+
+        public System.Type MemberType { get { throw null; } set { } }
+
+        public object[] Parameters { get { throw null; } }
+
+        protected abstract object[] ConvertDataItem(System.Reflection.MethodInfo testMethod, object item);
+        public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod) { throw null; }
+    }
+
+    public partial class Record
+    {
+        public static System.Exception Exception(System.Action testCode) { throw null; }
+
+        public static System.Exception Exception(System.Func<object> testCode) { throw null; }
+
+        [System.Obsolete("You must call Record.ExceptionAsync (and await the result) when testing async code.", true)]
+        public static System.Exception Exception(System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+
+        public static System.Threading.Tasks.Task<System.Exception> ExceptionAsync(System.Func<System.Threading.Tasks.Task> testCode) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public sealed partial class TestCaseOrdererAttribute : System.Attribute
+    {
+        public TestCaseOrdererAttribute(string ordererTypeName, string ordererAssemblyName) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Assembly, Inherited = true, AllowMultiple = false)]
+    public sealed partial class TestCollectionOrdererAttribute : System.Attribute
+    {
+        public TestCollectionOrdererAttribute(string ordererTypeName, string ordererAssemblyName) { }
+    }
+
+    [Sdk.TestFrameworkDiscoverer("Xunit.Sdk.TestFrameworkTypeDiscoverer", "xunit.execution.{Platform}")]
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = false)]
+    public sealed partial class TestFrameworkAttribute : System.Attribute, Sdk.ITestFrameworkAttribute
+    {
+        public TestFrameworkAttribute(string typeName, string assemblyName) { }
+    }
+
+    [Sdk.XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = false)]
+    public partial class TheoryAttribute : FactAttribute
+    {
+    }
+
+    public abstract partial class TheoryData : System.Collections.Generic.IEnumerable<object[]>, System.Collections.IEnumerable
+    {
+        protected void AddRow(params object[] values) { }
+
+        public System.Collections.Generic.IEnumerator<object[]> GetEnumerator() { throw null; }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public partial class TheoryData<T> : TheoryData
+    {
+        public void Add(T p) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9, T10 p10) { }
+    }
+
+    public partial class TheoryData<T1, T2> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5, T6> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5, T6, T7> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5, T6, T7, T8> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8) { }
+    }
+
+    public partial class TheoryData<T1, T2, T3, T4, T5, T6, T7, T8, T9> : TheoryData
+    {
+        public void Add(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9) { }
+    }
+
+    [Sdk.TraitDiscoverer("Xunit.Sdk.TraitDiscoverer", "xunit.core")]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = true)]
+    public sealed partial class TraitAttribute : System.Attribute, Sdk.ITraitAttribute
+    {
+        public TraitAttribute(string name, string value) { }
+    }
+}
+
+namespace Xunit.Extensions
+{
+    [System.Obsolete("Please replace [PropertyData] with [MemberData]", true)]
+    public sealed partial class PropertyDataAttribute : System.Attribute
+    {
+        public PropertyDataAttribute(string propertyName) { }
+
+        public System.Type PropertyType { get { throw null; } set { } }
+    }
+}
+
+namespace Xunit.Sdk
+{
+    public partial class AssemblyTraitDiscoverer : ITraitDiscoverer
+    {
+        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetTraits(Abstractions.IAttributeInfo traitAttribute) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public abstract partial class BeforeAfterTestAttribute : System.Attribute
+    {
+        public virtual void After(System.Reflection.MethodInfo methodUnderTest) { }
+
+        public virtual void Before(System.Reflection.MethodInfo methodUnderTest) { }
+    }
+
+    [DataDiscoverer("Xunit.Sdk.DataDiscoverer", "xunit.core")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public abstract partial class DataAttribute : System.Attribute
+    {
+        public virtual string Skip { get { throw null; } set { } }
+
+        public abstract System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod);
+    }
+
+    public partial class DataDiscoverer : IDataDiscoverer
+    {
+        public virtual System.Collections.Generic.IEnumerable<object[]> GetData(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod) { throw null; }
+
+        public virtual bool SupportsDiscoveryEnumeration(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class DataDiscovererAttribute : System.Attribute
+    {
+        public DataDiscovererAttribute(string typeName, string assemblyName) { }
+    }
+
+    public partial class ExceptionAggregator
+    {
+        public ExceptionAggregator() { }
+
+        public ExceptionAggregator(ExceptionAggregator parent) { }
+
+        public bool HasExceptions { get { throw null; } }
+
+        public void Add(System.Exception ex) { }
+
+        public void Aggregate(ExceptionAggregator aggregator) { }
+
+        public void Clear() { }
+
+        public void Run(System.Action code) { }
+
+        public System.Threading.Tasks.Task RunAsync(System.Func<System.Threading.Tasks.Task> code) { throw null; }
+
+        public System.Threading.Tasks.Task<T> RunAsync<T>(System.Func<System.Threading.Tasks.Task<T>> code) { throw null; }
+
+        public System.Exception ToException() { throw null; }
+    }
+
+    public partial interface IDataDiscoverer
+    {
+        System.Collections.Generic.IEnumerable<object[]> GetData(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod);
+        bool SupportsDiscoveryEnumeration(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod);
+    }
+
+    public partial interface IMessageBus : System.IDisposable
+    {
+        bool QueueMessage(Abstractions.IMessageSinkMessage message);
+    }
+
+    public partial class InlineDataDiscoverer : IDataDiscoverer
+    {
+        public virtual System.Collections.Generic.IEnumerable<object[]> GetData(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod) { throw null; }
+
+        public virtual bool SupportsDiscoveryEnumeration(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod) { throw null; }
+    }
+
+    public partial interface ITestCaseOrderer
+    {
+        System.Collections.Generic.IEnumerable<TTestCase> OrderTestCases<TTestCase>(System.Collections.Generic.IEnumerable<TTestCase> testCases)
+            where TTestCase : Abstractions.ITestCase;
+    }
+
+    public partial interface ITestFrameworkAttribute
+    {
+    }
+
+    public partial interface ITestFrameworkTypeDiscoverer
+    {
+        System.Type GetTestFrameworkType(Abstractions.IAttributeInfo attribute);
+    }
+
+    public partial interface ITraitAttribute
+    {
+    }
+
+    public partial interface ITraitDiscoverer
+    {
+        System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetTraits(Abstractions.IAttributeInfo traitAttribute);
+    }
+
+    public partial interface IXunitTestCase : Abstractions.ITestCase, Abstractions.IXunitSerializable
+    {
+        System.Exception InitializationException { get; }
+
+        Abstractions.IMethodInfo Method { get; }
+
+        int Timeout { get; }
+
+        System.Threading.Tasks.Task<RunSummary> RunAsync(Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource);
+    }
+
+    public partial interface IXunitTestCaseDiscoverer
+    {
+        System.Collections.Generic.IEnumerable<IXunitTestCase> Discover(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo factAttribute);
+    }
+
+    public partial interface IXunitTestCollectionFactory
+    {
+        string DisplayName { get; }
+
+        Abstractions.ITestCollection Get(Abstractions.ITypeInfo testClass);
+    }
+
+    public partial class MemberDataDiscoverer : DataDiscoverer
+    {
+        public override bool SupportsDiscoveryEnumeration(Abstractions.IAttributeInfo dataAttribute, Abstractions.IMethodInfo testMethod) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    public sealed partial class PlatformSpecificAssemblyAttribute : System.Attribute
+    {
+    }
+
+    public partial class RunSummary
+    {
+        public int Failed;
+        public int Skipped;
+        public decimal Time;
+        public int Total;
+        public void Aggregate(RunSummary other) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class TestFrameworkDiscovererAttribute : System.Attribute
+    {
+        public TestFrameworkDiscovererAttribute(string typeName, string assemblyName) { }
+    }
+
+    public enum TestMethodDisplay
+    {
+        ClassAndMethod = 1,
+        Method = 2
+    }
+
+    [System.Flags]
+    public enum TestMethodDisplayOptions
+    {
+        None = 0,
+        ReplaceUnderscoreWithSpace = 1,
+        UseOperatorMonikers = 2,
+        UseEscapeSequences = 4,
+        ReplacePeriodWithComma = 8,
+        All = 15
+    }
+
+    public partial class TraitDiscoverer : ITraitDiscoverer
+    {
+        public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> GetTraits(Abstractions.IAttributeInfo traitAttribute) { throw null; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class TraitDiscovererAttribute : System.Attribute
+    {
+        public TraitDiscovererAttribute(string typeName, string assemblyName) { }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class XunitTestCaseDiscovererAttribute : System.Attribute
+    {
+        public XunitTestCaseDiscovererAttribute(string typeName, string assemblyName) { }
+    }
+}

--- a/src/referencePackages/src/xunit.extensibility.core/2.6.1/xunit.extensibility.core.2.6.1.csproj
+++ b/src/referencePackages/src/xunit.extensibility.core/2.6.1/xunit.extensibility.core.2.6.1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <AssemblyName>xunit.core</AssemblyName>
+    <StrongNameKeyId>XUnit.Core</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/xunit.extensibility.core/2.6.1/xunit.extensibility.core.nuspec
+++ b/src/referencePackages/src/xunit.extensibility.core/2.6.1/xunit.extensibility.core.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>xunit.extensibility.core</id>
+    <version>2.6.1</version>
+    <authors>jnewkirk,bradwilson</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <description>Includes xunit.core.dll for extensibility purposes. Supports .NET 4.5.2 or later, and .NET Standard 1.1.</description>
+    <releaseNotes>https://xunit.net/releases/v2/2.6.1</releaseNotes>
+    <copyright>Copyright (C) .NET Foundation</copyright>
+    <repository type="git" url="https://github.com/xunit/xunit" commit="9f1684f5f74196d952f0085d7bde21aa20df6229" />
+    <dependencies>
+      <group targetFramework=".NETStandard1.1">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="xunit.abstractions" version="2.0.3" />
+      </group>
+    </dependencies>
+    <references>
+      <reference file="xunit.core.dll" />
+      <reference file="xunit.core.xml" />
+    </references>
+  </metadata>
+</package>

--- a/src/referencePackages/src/xunit.extensibility.execution/2.6.1/lib/netstandard1.1/xunit.execution.dotnet.cs
+++ b/src/referencePackages/src/xunit.extensibility.execution/2.6.1/lib/netstandard1.1/xunit.execution.dotnet.cs
@@ -1,0 +1,1712 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Reflection.AssemblyFileVersion("2.6.1")]
+[assembly: System.Reflection.AssemblyInformationalVersion("2.6.1+9f1684f5f7")]
+[assembly: System.Reflection.AssemblyCompany(".NET Foundation")]
+[assembly: System.Reflection.AssemblyProduct("xUnit.net Testing Framework")]
+[assembly: System.Reflection.AssemblyCopyright("Copyright (C) .NET Foundation")]
+[assembly: System.Reflection.AssemblyTitle("xUnit.net Execution (dotnet)")]
+[assembly: System.CLSCompliant(true)]
+[assembly: Xunit.Sdk.PlatformSpecificAssembly]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.1", FrameworkDisplayName = "")]
+[assembly: System.Reflection.AssemblyConfiguration("Release")]
+[assembly: System.Reflection.AssemblyVersionAttribute("2.6.1.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace <global namespace>
+{
+    public static partial class ReflectionAbstractionExtensions
+    {
+        public static object CreateTestClass(this Xunit.Abstractions.ITest test, System.Type testClassType, object[] constructorArguments, Xunit.Sdk.IMessageBus messageBus, Xunit.Sdk.ExecutionTimer timer, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        public static void DisposeTestClass(this Xunit.Abstractions.ITest test, object testClass, Xunit.Sdk.IMessageBus messageBus, Xunit.Sdk.ExecutionTimer timer, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        public static System.Collections.Generic.IEnumerable<Xunit.Abstractions.IAttributeInfo> GetCustomAttributes(this Xunit.Abstractions.IAssemblyInfo assemblyInfo, System.Type attributeType) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Xunit.Abstractions.IAttributeInfo> GetCustomAttributes(this Xunit.Abstractions.IAttributeInfo attributeInfo, System.Type attributeType) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Xunit.Abstractions.IAttributeInfo> GetCustomAttributes(this Xunit.Abstractions.IMethodInfo methodInfo, System.Type attributeType) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<Xunit.Abstractions.IAttributeInfo> GetCustomAttributes(this Xunit.Abstractions.ITypeInfo typeInfo, System.Type attributeType) { throw null; }
+
+        public static System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> GetMatchingMethods(this System.Type type, System.Reflection.MethodInfo methodInfo) { throw null; }
+
+        public static System.Reflection.MethodInfo ToRuntimeMethod(this Xunit.Abstractions.IMethodInfo methodInfo) { throw null; }
+
+        public static System.Type ToRuntimeType(this Xunit.Abstractions.ITypeInfo typeInfo) { throw null; }
+    }
+
+    public static partial class TestFrameworkOptionsReadExtensions
+    {
+        public static bool? DiagnosticMessages(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool? DiagnosticMessages(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool DiagnosticMessagesOrDefault(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool DiagnosticMessagesOrDefault(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool? DisableParallelization(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool DisableParallelizationOrDefault(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static int? MaxParallelThreads(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static int MaxParallelThreadsOrDefault(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static Xunit.Sdk.TestMethodDisplay? MethodDisplay(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static Xunit.Sdk.TestMethodDisplayOptions? MethodDisplayOptions(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static Xunit.Sdk.TestMethodDisplayOptions MethodDisplayOptionsOrDefault(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static Xunit.Sdk.TestMethodDisplay MethodDisplayOrDefault(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool? PreEnumerateTheories(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool PreEnumerateTheoriesOrDefault(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool? StopOnTestFail(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool StopOnTestFailOrDefault(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool? SynchronousMessageReporting(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool? SynchronousMessageReporting(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+
+        public static bool SynchronousMessageReportingOrDefault(this Xunit.Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        public static bool SynchronousMessageReportingOrDefault(this Xunit.Abstractions.ITestFrameworkExecutionOptions executionOptions) { throw null; }
+    }
+}
+
+namespace Xunit
+{
+    public abstract partial class LongLivedMarshalByRefObject
+    {
+        public static void DisconnectAll() { }
+    }
+}
+
+namespace Xunit.Sdk
+{
+    public partial class AfterTestFinished : TestMessage, Abstractions.IAfterTestFinished, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public AfterTestFinished(Abstractions.ITest test, string attributeName) : base(default!) { }
+
+        public string AttributeName { get { throw null; } }
+    }
+
+    public partial class AfterTestStarting : TestMessage, Abstractions.IAfterTestStarting, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public AfterTestStarting(Abstractions.ITest test, string attributeName) : base(default!) { }
+
+        public string AttributeName { get { throw null; } }
+    }
+
+    public partial class AsyncTestSyncContext : System.Threading.SynchronizationContext
+    {
+        public AsyncTestSyncContext(System.Threading.SynchronizationContext innerContext) { }
+
+        public override void OperationCompleted() { }
+
+        public override void OperationStarted() { }
+
+        public override void Post(System.Threading.SendOrPostCallback d, object state) { }
+
+        public override void Send(System.Threading.SendOrPostCallback d, object state) { }
+
+        public System.Threading.Tasks.Task<System.Exception> WaitForCompletionAsync() { throw null; }
+    }
+
+    public partial class BeforeTestFinished : TestMessage, Abstractions.IBeforeTestFinished, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public BeforeTestFinished(Abstractions.ITest test, string attributeName) : base(default!) { }
+
+        public string AttributeName { get { throw null; } }
+    }
+
+    public partial class BeforeTestStarting : TestMessage, Abstractions.IBeforeTestStarting, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public BeforeTestStarting(Abstractions.ITest test, string attributeName) : base(default!) { }
+
+        public string AttributeName { get { throw null; } }
+    }
+
+    public partial class CollectionPerAssemblyTestCollectionFactory : IXunitTestCollectionFactory
+    {
+        public CollectionPerAssemblyTestCollectionFactory(Abstractions.ITestAssembly testAssembly, Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        public string DisplayName { get { throw null; } }
+
+        public Abstractions.ITestCollection Get(Abstractions.ITypeInfo testClass) { throw null; }
+    }
+
+    public partial class CollectionPerClassTestCollectionFactory : IXunitTestCollectionFactory
+    {
+        public CollectionPerClassTestCollectionFactory(Abstractions.ITestAssembly testAssembly, Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        public string DisplayName { get { throw null; } }
+
+        public Abstractions.ITestCollection Get(Abstractions.ITypeInfo testClass) { throw null; }
+    }
+
+    public partial class DefaultTestCaseOrderer : ITestCaseOrderer
+    {
+        public DefaultTestCaseOrderer(Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        public System.Collections.Generic.IEnumerable<TTestCase> OrderTestCases<TTestCase>(System.Collections.Generic.IEnumerable<TTestCase> testCases)
+            where TTestCase : Abstractions.ITestCase { throw null; }
+    }
+
+    public partial class DefaultTestCollectionOrderer : ITestCollectionOrderer
+    {
+        public System.Collections.Generic.IEnumerable<Abstractions.ITestCollection> OrderTestCollections(System.Collections.Generic.IEnumerable<Abstractions.ITestCollection> TestCollections) { throw null; }
+    }
+
+    public partial class DelegatingMessageBus : IMessageBus, System.IDisposable
+    {
+        public DelegatingMessageBus(IMessageBus innerMessageBus, System.Action<Abstractions.IMessageSinkMessage> callback = null) { }
+
+        public void Dispose() { }
+
+        public virtual bool QueueMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class DelegatingMessageBus<TFinalMessage> : DelegatingMessageBus where TFinalMessage : class, Abstractions.IMessageSinkMessage
+    {
+        public DelegatingMessageBus(IMessageBus innerMessageBus, System.Action<Abstractions.IMessageSinkMessage> callback = null) : base(default!, default!) { }
+
+        public TFinalMessage FinalMessage { get { throw null; } }
+
+        public System.Threading.ManualResetEvent Finished { get { throw null; } }
+
+        public override bool QueueMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class DelegatingMessageSink : LongLivedMarshalByRefObject, Abstractions.IMessageSink
+    {
+        public DelegatingMessageSink(Abstractions.IMessageSink innerSink, System.Action<Abstractions.IMessageSinkMessage> callback = null) { }
+
+        public void Dispose() { }
+
+        public virtual bool OnMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class DelegatingMessageSink<TFinalMessage> : DelegatingMessageSink where TFinalMessage : class, Abstractions.IMessageSinkMessage
+    {
+        public DelegatingMessageSink(Abstractions.IMessageSink innerSink, System.Action<Abstractions.IMessageSinkMessage> callback = null) : base(default!, default!) { }
+
+        public TFinalMessage FinalMessage { get { throw null; } }
+
+        public System.Threading.ManualResetEvent Finished { get { throw null; } }
+
+        public override bool OnMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class DiagnosticMessage : LongLivedMarshalByRefObject, Abstractions.IDiagnosticMessage, Abstractions.IMessageSinkMessage
+    {
+        public DiagnosticMessage() { }
+
+        public DiagnosticMessage(string format, params object[] args) { }
+
+        public DiagnosticMessage(string message) { }
+
+        public System.Collections.Generic.HashSet<string> InterfaceTypes { get { throw null; } }
+
+        public string Message { get { throw null; } set { } }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class DiscoveryCompleteMessage : LongLivedMarshalByRefObject, Abstractions.IDiscoveryCompleteMessage, Abstractions.IMessageSinkMessage
+    {
+    }
+
+    public partial class DisplayNameFormatter
+    {
+        public DisplayNameFormatter() { }
+
+        public DisplayNameFormatter(TestMethodDisplay display, TestMethodDisplayOptions displayOptions) { }
+
+        public string Format(string displayName) { throw null; }
+    }
+
+    public partial class DisposalTracker : System.IDisposable
+    {
+        public void Add(System.IDisposable disposable) { }
+
+        public void Dispose() { }
+    }
+
+    public partial class ErrorMessage : LongLivedMarshalByRefObject, Abstractions.IErrorMessage, Abstractions.IFailureInformation, Abstractions.IExecutionMessage, Abstractions.IMessageSinkMessage
+    {
+        public ErrorMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, System.Exception ex) { }
+
+        public ErrorMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITestCase> TestCases { get { throw null; } }
+    }
+
+    public static partial class ExceptionUtility
+    {
+        public static string CombineMessages(Abstractions.IFailureInformation failureInfo) { throw null; }
+
+        public static string CombineStackTraces(Abstractions.IFailureInformation failureInfo) { throw null; }
+
+        public static Abstractions.IFailureInformation ConvertExceptionToFailureInformation(System.Exception ex) { throw null; }
+    }
+
+    public partial class ExecutionErrorTestCase : XunitTestCase
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public ExecutionErrorTestCase() { }
+
+        [System.Obsolete("Please call the constructor which takes TestMethodDisplayOptions")]
+        public ExecutionErrorTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, Abstractions.ITestMethod testMethod, string errorMessage) { }
+
+        public ExecutionErrorTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, Abstractions.ITestMethod testMethod, string errorMessage) { }
+
+        public string ErrorMessage { get { throw null; } }
+
+        public override void Deserialize(Abstractions.IXunitSerializationInfo data) { }
+
+        public override System.Threading.Tasks.Task<RunSummary> RunAsync(Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        public override void Serialize(Abstractions.IXunitSerializationInfo data) { }
+    }
+
+    public partial class ExecutionErrorTestCaseRunner : TestCaseRunner<ExecutionErrorTestCase>
+    {
+        public ExecutionErrorTestCaseRunner(ExecutionErrorTestCase testCase, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!) { }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestAsync() { throw null; }
+    }
+
+    public partial class ExecutionTimer
+    {
+        public decimal Total { get { throw null; } }
+
+        public void Aggregate(System.Action action) { }
+
+        public void Aggregate(System.TimeSpan time) { }
+
+        public System.Threading.Tasks.Task AggregateAsync(System.Func<System.Threading.Tasks.Task> asyncAction) { throw null; }
+    }
+
+    public static partial class ExtensibilityPointFactory
+    {
+        public static void Dispose() { }
+
+        public static TInterface Get<TInterface>(Abstractions.IMessageSink diagnosticMessageSink, System.Type type, object[] ctorArgs = null) { throw null; }
+
+        public static IDataDiscoverer GetDataDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, System.Type discovererType) { throw null; }
+
+        public static IDataDiscoverer GetDataDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo dataDiscovererAttribute) { throw null; }
+
+        public static ITestCaseOrderer GetTestCaseOrderer(Abstractions.IMessageSink diagnosticMessageSink, System.Type ordererType) { throw null; }
+
+        public static ITestCaseOrderer GetTestCaseOrderer(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo testCaseOrdererAttribute) { throw null; }
+
+        public static ITestCollectionOrderer GetTestCollectionOrderer(Abstractions.IMessageSink diagnosticMessageSink, System.Type ordererType) { throw null; }
+
+        public static ITestCollectionOrderer GetTestCollectionOrderer(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo testCollectionOrdererAttribute) { throw null; }
+
+        public static ITestFrameworkTypeDiscoverer GetTestFrameworkTypeDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, System.Type frameworkType) { throw null; }
+
+        public static ITestFrameworkTypeDiscoverer GetTestFrameworkTypeDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo testFrameworkDiscovererAttribute) { throw null; }
+
+        public static ITraitDiscoverer GetTraitDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, System.Type traitDiscovererType) { throw null; }
+
+        public static ITraitDiscoverer GetTraitDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo traitDiscovererAttribute) { throw null; }
+
+        public static IXunitTestCaseDiscoverer GetXunitTestCaseDiscoverer(Abstractions.IMessageSink diagnosticMessageSink, System.Type testCaseDiscovererType) { throw null; }
+
+        public static IXunitTestCollectionFactory GetXunitTestCollectionFactory(Abstractions.IMessageSink diagnosticMessageSink, System.Type testCollectionFactoryType, Abstractions.ITestAssembly testAssembly) { throw null; }
+
+        public static IXunitTestCollectionFactory GetXunitTestCollectionFactory(Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IAttributeInfo collectionBehaviorAttribute, Abstractions.ITestAssembly testAssembly) { throw null; }
+    }
+
+    public partial class FactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        public FactDiscoverer(Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        protected virtual IXunitTestCase CreateTestCase(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo factAttribute) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<IXunitTestCase> Discover(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo factAttribute) { throw null; }
+    }
+
+    public abstract partial class GeneralDigest
+    {
+        internal GeneralDigest() { }
+
+        public abstract string AlgorithmName { get; }
+
+        public void BlockUpdate(byte[] input, int inOff, int length) { }
+
+        protected void CopyIn(GeneralDigest t) { }
+
+        public abstract int DoFinal(byte[] output, int outOff);
+        public void Finish() { }
+
+        public int GetByteLength() { throw null; }
+
+        public abstract int GetDigestSize();
+        public virtual void Reset() { }
+
+        public void Update(byte input) { }
+    }
+
+    public partial class MaxConcurrencySyncContext : System.Threading.SynchronizationContext, System.IDisposable
+    {
+        public MaxConcurrencySyncContext(int maximumConcurrencyLevel) { }
+
+        public static bool IsSupported { get { throw null; } }
+
+        public void Dispose() { }
+
+        public override void Post(System.Threading.SendOrPostCallback d, object state) { }
+
+        public override void Send(System.Threading.SendOrPostCallback d, object state) { }
+    }
+
+    public partial class MessageBus : IMessageBus, System.IDisposable
+    {
+        public MessageBus(Abstractions.IMessageSink messageSink, bool stopOnFail = false) { }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class NullMessageSink : LongLivedMarshalByRefObject, Abstractions.IMessageSink
+    {
+        public void Dispose() { }
+
+        public bool OnMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+
+        public bool OnMessageWithTypes(Abstractions.IMessageSinkMessage message, System.Collections.Generic.HashSet<string> messageTypes) { throw null; }
+    }
+
+    public partial class ReflectionAssemblyInfo : LongLivedMarshalByRefObject, Abstractions.IReflectionAssemblyInfo, Abstractions.IAssemblyInfo
+    {
+        public ReflectionAssemblyInfo(System.Reflection.Assembly assembly) { }
+
+        public ReflectionAssemblyInfo(string assemblyFileName) { }
+
+        public System.Reflection.Assembly Assembly { get { throw null; } }
+
+        public string AssemblyPath { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName) { throw null; }
+
+        public Abstractions.ITypeInfo GetType(string typeName) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITypeInfo> GetTypes(bool includePrivateTypes) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ReflectionAttributeInfo : LongLivedMarshalByRefObject, Abstractions.IReflectionAttributeInfo, Abstractions.IAttributeInfo
+    {
+        public ReflectionAttributeInfo(System.Reflection.CustomAttributeData attribute) { }
+
+        public System.Attribute Attribute { get { throw null; } }
+
+        public System.Reflection.CustomAttributeData AttributeData { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<object> GetConstructorArguments() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName) { throw null; }
+
+        public TValue GetNamedArgument<TValue>(string argumentName) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ReflectionMethodInfo : LongLivedMarshalByRefObject, Abstractions.IReflectionMethodInfo, Abstractions.IMethodInfo
+    {
+        public ReflectionMethodInfo(System.Reflection.MethodInfo method) { }
+
+        public bool IsAbstract { get { throw null; } }
+
+        public bool IsGenericMethodDefinition { get { throw null; } }
+
+        public bool IsPublic { get { throw null; } }
+
+        public bool IsStatic { get { throw null; } }
+
+        public System.Reflection.MethodInfo MethodInfo { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public Abstractions.ITypeInfo ReturnType { get { throw null; } }
+
+        public Abstractions.ITypeInfo Type { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITypeInfo> GetGenericArguments() { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IParameterInfo> GetParameters() { throw null; }
+
+        public Abstractions.IMethodInfo MakeGenericMethod(params Abstractions.ITypeInfo[] typeArguments) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial class ReflectionParameterInfo : LongLivedMarshalByRefObject, Abstractions.IReflectionParameterInfo, Abstractions.IParameterInfo
+    {
+        public ReflectionParameterInfo(System.Reflection.ParameterInfo parameterInfo) { }
+
+        public string Name { get { throw null; } }
+
+        public System.Reflection.ParameterInfo ParameterInfo { get { throw null; } }
+
+        public Abstractions.ITypeInfo ParameterType { get { throw null; } }
+    }
+
+    public partial class ReflectionTypeInfo : LongLivedMarshalByRefObject, Abstractions.IReflectionTypeInfo, Abstractions.ITypeInfo
+    {
+        public ReflectionTypeInfo(System.Type type) { }
+
+        public Abstractions.IAssemblyInfo Assembly { get { throw null; } }
+
+        public Abstractions.ITypeInfo BaseType { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITypeInfo> Interfaces { get { throw null; } }
+
+        public bool IsAbstract { get { throw null; } }
+
+        public bool IsGenericParameter { get { throw null; } }
+
+        public bool IsGenericType { get { throw null; } }
+
+        public bool IsSealed { get { throw null; } }
+
+        public bool IsValueType { get { throw null; } }
+
+        public string Name { get { throw null; } }
+
+        public System.Type Type { get { throw null; } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITypeInfo> GetGenericArguments() { throw null; }
+
+        public Abstractions.IMethodInfo GetMethod(string methodName, bool includePrivateMethod) { throw null; }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.IMethodInfo> GetMethods(bool includePrivateMethods) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class Reflector
+    {
+        public static object[] ConvertArguments(object[] args, System.Type[] types) { throw null; }
+
+        public static Abstractions.IReflectionAssemblyInfo Wrap(System.Reflection.Assembly assembly) { throw null; }
+
+        public static Abstractions.IReflectionAttributeInfo Wrap(System.Reflection.CustomAttributeData attribute) { throw null; }
+
+        public static Abstractions.IReflectionMethodInfo Wrap(System.Reflection.MethodInfo method) { throw null; }
+
+        public static Abstractions.IReflectionParameterInfo Wrap(System.Reflection.ParameterInfo parameter) { throw null; }
+
+        public static Abstractions.IReflectionTypeInfo Wrap(System.Type type) { throw null; }
+    }
+
+    public static partial class SerializationHelper
+    {
+        public static T Deserialize<T>(string serializedValue) { throw null; }
+
+        public static System.Type GetType(string assemblyName, string typeName) { throw null; }
+
+        public static System.Type GetType(string assemblyQualifiedTypeName) { throw null; }
+
+        public static string GetTypeNameForSerialization(System.Type type) { throw null; }
+
+        public static bool IsSerializable(object value) { throw null; }
+
+        public static string Serialize(object value) { throw null; }
+    }
+
+    public partial class Sha1Digest : GeneralDigest
+    {
+        public Sha1Digest() { }
+
+        public Sha1Digest(Sha1Digest t) { }
+
+        public override string AlgorithmName { get { throw null; } }
+
+        public override int DoFinal(byte[] output, int outOff) { throw null; }
+
+        public override int GetDigestSize() { throw null; }
+
+        public override void Reset() { }
+
+        public void Reset(Sha1Digest other) { }
+    }
+
+    public partial class SourceInformation : LongLivedMarshalByRefObject, Abstractions.ISourceInformation, Abstractions.IXunitSerializable
+    {
+        public string FileName { get { throw null; } set { } }
+
+        public int? LineNumber { get { throw null; } set { } }
+
+        public void Deserialize(Abstractions.IXunitSerializationInfo info) { }
+
+        public void Serialize(Abstractions.IXunitSerializationInfo info) { }
+    }
+
+    public partial class SynchronousMessageBus : IMessageBus, System.IDisposable
+    {
+        public SynchronousMessageBus(Abstractions.IMessageSink messageSink) { }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+    }
+
+    public partial class TestAssembly : LongLivedMarshalByRefObject, Abstractions.ITestAssembly, Abstractions.IXunitSerializable
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public TestAssembly() { }
+
+        public TestAssembly(Abstractions.IAssemblyInfo assembly, string configFileName = null, System.Version version = null) { }
+
+        public Abstractions.IAssemblyInfo Assembly { get { throw null; } set { } }
+
+        public string ConfigFileName { get { throw null; } set { } }
+
+        public System.Version Version { get { throw null; } }
+
+        public void Deserialize(Abstractions.IXunitSerializationInfo info) { }
+
+        public void Serialize(Abstractions.IXunitSerializationInfo info) { }
+    }
+
+    public partial class TestAssemblyCleanupFailure : TestAssemblyMessage, Abstractions.ITestAssemblyCleanupFailure, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestAssemblyCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestAssembly testAssembly, System.Exception ex) : base(default!, default!) { }
+
+        public TestAssemblyCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestAssembly testAssembly, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!, default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestAssemblyFinished : TestAssemblyMessage, Abstractions.ITestAssemblyFinished, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFinishedMessage
+    {
+        public TestAssemblyFinished(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestAssembly testAssembly, decimal executionTime, int testsRun, int testsFailed, int testsSkipped) : base(default!, default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public int TestsFailed { get { throw null; } }
+
+        public int TestsRun { get { throw null; } }
+
+        public int TestsSkipped { get { throw null; } }
+    }
+
+    public partial class TestAssemblyMessage : LongLivedMarshalByRefObject, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestAssemblyMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestAssembly testAssembly) { }
+
+        public Abstractions.ITestAssembly TestAssembly { get { throw null; } set { } }
+
+        public System.Collections.Generic.IEnumerable<Abstractions.ITestCase> TestCases { get { throw null; } }
+    }
+
+    public abstract partial class TestAssemblyRunner<TTestCase> : System.IDisposable where TTestCase : Abstractions.ITestCase
+    {
+        protected TestAssemblyRunner(Abstractions.ITestAssembly testAssembly, System.Collections.Generic.IEnumerable<TTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkExecutionOptions executionOptions) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink ExecutionMessageSink { get { throw null; } set { } }
+
+        protected Abstractions.ITestFrameworkExecutionOptions ExecutionOptions { get { throw null; } set { } }
+
+        protected Abstractions.ITestAssembly TestAssembly { get { throw null; } set { } }
+
+        protected ITestCaseOrderer TestCaseOrderer { get { throw null; } set { } }
+
+        protected System.Collections.Generic.IEnumerable<TTestCase> TestCases { get { throw null; } set { } }
+
+        protected ITestCollectionOrderer TestCollectionOrderer { get { throw null; } set { } }
+
+        protected virtual System.Threading.Tasks.Task AfterTestAssemblyStartingAsync() { throw null; }
+
+        protected virtual System.Threading.Tasks.Task BeforeTestAssemblyFinishedAsync() { throw null; }
+
+        protected virtual IMessageBus CreateMessageBus() { throw null; }
+
+        public virtual void Dispose() { }
+
+        protected abstract string GetTestFrameworkDisplayName();
+        protected virtual string GetTestFrameworkEnvironment() { throw null; }
+
+        protected System.Collections.Generic.List<System.Tuple<Abstractions.ITestCollection, System.Collections.Generic.List<TTestCase>>> OrderTestCollections() { throw null; }
+
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+
+        protected abstract System.Threading.Tasks.Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, Abstractions.ITestCollection testCollection, System.Collections.Generic.IEnumerable<TTestCase> testCases, System.Threading.CancellationTokenSource cancellationTokenSource);
+        protected virtual System.Threading.Tasks.Task<RunSummary> RunTestCollectionsAsync(IMessageBus messageBus, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+    }
+
+    public partial class TestAssemblyStarting : TestAssemblyMessage, Abstractions.ITestAssemblyStarting, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestAssemblyStarting(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestAssembly testAssembly, System.DateTime startTime, string testEnvironment, string testFrameworkDisplayName) : base(default!, default!) { }
+
+        public System.DateTime StartTime { get { throw null; } set { } }
+
+        public string TestEnvironment { get { throw null; } set { } }
+
+        public string TestFrameworkDisplayName { get { throw null; } set { } }
+    }
+
+    public partial class TestCaseBulkDeserializer : LongLivedMarshalByRefObject
+    {
+        public TestCaseBulkDeserializer(object discovererObject, object executorObject, object serializedTestCasesObject, object callbackObject) { }
+    }
+
+    public partial class TestCaseCleanupFailure : TestCaseMessage, Abstractions.ITestCaseCleanupFailure, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestCaseCleanupFailure(Abstractions.ITestCase testCase, System.Exception ex) : base(default!) { }
+
+        public TestCaseCleanupFailure(Abstractions.ITestCase testCase, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestCaseDescriptorFactory : LongLivedMarshalByRefObject
+    {
+        public TestCaseDescriptorFactory(object discovererObject, object testCasesObject, object callbackObject) { }
+    }
+
+    public partial class TestCaseDiscoveryMessage : TestCaseMessage, Abstractions.ITestCaseDiscoveryMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestCaseDiscoveryMessage(Abstractions.ITestCase testCase) : base(default!) { }
+    }
+
+    public partial class TestCaseFinished : TestCaseMessage, Abstractions.ITestCaseFinished, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFinishedMessage
+    {
+        public TestCaseFinished(Abstractions.ITestCase testCase, decimal executionTime, int testsRun, int testsFailed, int testsSkipped) : base(default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public int TestsFailed { get { throw null; } }
+
+        public int TestsRun { get { throw null; } }
+
+        public int TestsSkipped { get { throw null; } }
+    }
+
+    public partial class TestCaseMessage : TestMethodMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestCaseMessage(Abstractions.ITestCase testCase) : base(default!, default!) { }
+
+        public Abstractions.ITestCase TestCase { get { throw null; } }
+    }
+
+    public abstract partial class TestCaseRunner<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestCaseRunner(TTestCase testCase, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected TTestCase TestCase { get { throw null; } set { } }
+
+        protected virtual System.Threading.Tasks.Task AfterTestCaseStartingAsync() { throw null; }
+
+        protected virtual System.Threading.Tasks.Task BeforeTestCaseFinishedAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+
+        protected abstract System.Threading.Tasks.Task<RunSummary> RunTestAsync();
+    }
+
+    public partial class TestCaseStarting : TestCaseMessage, Abstractions.ITestCaseStarting, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestCaseStarting(Abstractions.ITestCase testCase) : base(default!) { }
+    }
+
+    public partial class TestClass : LongLivedMarshalByRefObject, Abstractions.ITestClass, Abstractions.IXunitSerializable
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public TestClass() { }
+
+        public TestClass(Abstractions.ITestCollection testCollection, Abstractions.ITypeInfo @class) { }
+
+        public Abstractions.ITypeInfo Class { get { throw null; } set { } }
+
+        public Abstractions.ITestCollection TestCollection { get { throw null; } set { } }
+
+        public void Deserialize(Abstractions.IXunitSerializationInfo info) { }
+
+        public void Serialize(Abstractions.IXunitSerializationInfo info) { }
+    }
+
+    public partial class TestClassCleanupFailure : TestClassMessage, Abstractions.ITestClassCleanupFailure, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestClassCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestClass testClass, System.Exception ex) : base(default!, default!) { }
+
+        public TestClassCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestClass testClass, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!, default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestClassComparer : System.Collections.Generic.IEqualityComparer<Abstractions.ITestClass>
+    {
+        public static readonly TestClassComparer Instance;
+        public bool Equals(Abstractions.ITestClass x, Abstractions.ITestClass y) { throw null; }
+
+        public int GetHashCode(Abstractions.ITestClass obj) { throw null; }
+    }
+
+    public partial class TestClassConstructionFinished : TestMessage, Abstractions.ITestClassConstructionFinished, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestClassConstructionFinished(Abstractions.ITest test) : base(default!) { }
+    }
+
+    public partial class TestClassConstructionStarting : TestMessage, Abstractions.ITestClassConstructionStarting, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestClassConstructionStarting(Abstractions.ITest test) : base(default!) { }
+    }
+
+    public partial class TestClassDisposeFinished : TestMessage, Abstractions.ITestClassDisposeFinished, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestClassDisposeFinished(Abstractions.ITest test) : base(default!) { }
+    }
+
+    public partial class TestClassDisposeStarting : TestMessage, Abstractions.ITestClassDisposeStarting, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestClassDisposeStarting(Abstractions.ITest test) : base(default!) { }
+    }
+
+    public partial class TestClassException : System.Exception
+    {
+        public TestClassException(string message) { }
+    }
+
+    public partial class TestClassFinished : TestClassMessage, Abstractions.ITestClassFinished, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFinishedMessage
+    {
+        public TestClassFinished(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestClass testClass, decimal executionTime, int testsRun, int testsFailed, int testsSkipped) : base(default!, default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public int TestsFailed { get { throw null; } }
+
+        public int TestsRun { get { throw null; } }
+
+        public int TestsSkipped { get { throw null; } }
+    }
+
+    public partial class TestClassMessage : TestCollectionMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestClassMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestClass testClass) : base(default!, default!) { }
+
+        public Abstractions.ITestClass TestClass { get { throw null; } set { } }
+    }
+
+    public abstract partial class TestClassRunner<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestClassRunner(Abstractions.ITestClass testClass, Abstractions.IReflectionTypeInfo @class, System.Collections.Generic.IEnumerable<TTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected Abstractions.IReflectionTypeInfo Class { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected ITestCaseOrderer TestCaseOrderer { get { throw null; } set { } }
+
+        protected System.Collections.Generic.IEnumerable<TTestCase> TestCases { get { throw null; } set { } }
+
+        protected Abstractions.ITestClass TestClass { get { throw null; } set { } }
+
+        protected virtual System.Threading.Tasks.Task AfterTestClassStartingAsync() { throw null; }
+
+        protected virtual System.Threading.Tasks.Task BeforeTestClassFinishedAsync() { throw null; }
+
+        protected virtual object[] CreateTestClassConstructorArguments() { throw null; }
+
+        protected virtual string FormatConstructorArgsMissingMessage(System.Reflection.ConstructorInfo constructor, System.Collections.Generic.IReadOnlyList<System.Tuple<int, System.Reflection.ParameterInfo>> unusedArguments) { throw null; }
+
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+
+        protected abstract System.Threading.Tasks.Task<RunSummary> RunTestMethodAsync(Abstractions.ITestMethod testMethod, Abstractions.IReflectionMethodInfo method, System.Collections.Generic.IEnumerable<TTestCase> testCases, object[] constructorArguments);
+        protected virtual System.Threading.Tasks.Task<RunSummary> RunTestMethodsAsync() { throw null; }
+
+        protected virtual System.Reflection.ConstructorInfo SelectTestClassConstructor() { throw null; }
+
+        protected virtual bool TryGetConstructorArgument(System.Reflection.ConstructorInfo constructor, int index, System.Reflection.ParameterInfo parameter, out object argumentValue) { throw null; }
+    }
+
+    public partial class TestClassStarting : TestClassMessage, Abstractions.ITestClassStarting, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestClassStarting(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestClass testClass) : base(default!, default!) { }
+    }
+
+    public partial class TestCleanupFailure : TestMessage, Abstractions.ITestCleanupFailure, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestCleanupFailure(Abstractions.ITest test, System.Exception ex) : base(default!) { }
+
+        public TestCleanupFailure(Abstractions.ITest test, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestCollection : LongLivedMarshalByRefObject, Abstractions.ITestCollection, Abstractions.IXunitSerializable
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public TestCollection() { }
+
+        public TestCollection(Abstractions.ITestAssembly testAssembly, Abstractions.ITypeInfo collectionDefinition, string displayName, System.Guid? uniqueId) { }
+
+        public TestCollection(Abstractions.ITestAssembly testAssembly, Abstractions.ITypeInfo collectionDefinition, string displayName) { }
+
+        public Abstractions.ITypeInfo CollectionDefinition { get { throw null; } set { } }
+
+        public string DisplayName { get { throw null; } set { } }
+
+        public Abstractions.ITestAssembly TestAssembly { get { throw null; } set { } }
+
+        public System.Guid UniqueID { get { throw null; } set { } }
+
+        public virtual void Deserialize(Abstractions.IXunitSerializationInfo info) { }
+
+        public virtual void Serialize(Abstractions.IXunitSerializationInfo info) { }
+    }
+
+    public partial class TestCollectionCleanupFailure : TestCollectionMessage, Abstractions.ITestCollectionCleanupFailure, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestCollectionCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestCollection testCollection, System.Exception ex) : base(default!, default!) { }
+
+        public TestCollectionCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestCollection testCollection, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!, default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestCollectionComparer : System.Collections.Generic.IEqualityComparer<Abstractions.ITestCollection>
+    {
+        public static readonly TestCollectionComparer Instance;
+        public bool Equals(Abstractions.ITestCollection x, Abstractions.ITestCollection y) { throw null; }
+
+        public int GetHashCode(Abstractions.ITestCollection obj) { throw null; }
+    }
+
+    public static partial class TestCollectionFactoryHelper
+    {
+        public static System.Collections.Generic.Dictionary<string, Abstractions.ITypeInfo> GetTestCollectionDefinitions(Abstractions.IAssemblyInfo assemblyInfo, Abstractions.IMessageSink diagnosticMessageSink) { throw null; }
+    }
+
+    public partial class TestCollectionFinished : TestCollectionMessage, Abstractions.ITestCollectionFinished, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFinishedMessage
+    {
+        public TestCollectionFinished(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestCollection testCollection, decimal executionTime, int testsRun, int testsFailed, int testsSkipped) : base(default!, default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public int TestsFailed { get { throw null; } }
+
+        public int TestsRun { get { throw null; } }
+
+        public int TestsSkipped { get { throw null; } }
+    }
+
+    public partial class TestCollectionMessage : TestAssemblyMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestCollectionMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestCollection testCollection) : base(default!, default!) { }
+
+        public Abstractions.ITestCollection TestCollection { get { throw null; } }
+    }
+
+    public abstract partial class TestCollectionRunner<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestCollectionRunner(Abstractions.ITestCollection testCollection, System.Collections.Generic.IEnumerable<TTestCase> testCases, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected ITestCaseOrderer TestCaseOrderer { get { throw null; } set { } }
+
+        protected System.Collections.Generic.IEnumerable<TTestCase> TestCases { get { throw null; } set { } }
+
+        protected Abstractions.ITestCollection TestCollection { get { throw null; } set { } }
+
+        protected virtual System.Threading.Tasks.Task AfterTestCollectionStartingAsync() { throw null; }
+
+        protected virtual System.Threading.Tasks.Task BeforeTestCollectionFinishedAsync() { throw null; }
+
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+
+        protected abstract System.Threading.Tasks.Task<RunSummary> RunTestClassAsync(Abstractions.ITestClass testClass, Abstractions.IReflectionTypeInfo @class, System.Collections.Generic.IEnumerable<TTestCase> testCases);
+        protected virtual System.Threading.Tasks.Task<RunSummary> RunTestClassesAsync() { throw null; }
+    }
+
+    public partial class TestCollectionStarting : TestCollectionMessage, Abstractions.ITestCollectionStarting, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestCollectionStarting(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestCollection testCollection) : base(default!, default!) { }
+    }
+
+    public partial class TestFailed : TestResultMessage, Abstractions.ITestFailed, Abstractions.ITestResultMessage, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestFailed(Abstractions.ITest test, decimal executionTime, string output, System.Exception ex) : base(default!, default, default!) { }
+
+        public TestFailed(Abstractions.ITest test, decimal executionTime, string output, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!, default, default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestFinished : TestMessage, Abstractions.ITestFinished, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestFinished(Abstractions.ITest test, decimal executionTime, string output) : base(default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public string Output { get { throw null; } }
+    }
+
+    public abstract partial class TestFramework : LongLivedMarshalByRefObject, Abstractions.ITestFramework, System.IDisposable
+    {
+        protected TestFramework(Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        public Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        protected DisposalTracker DisposalTracker { get { throw null; } set { } }
+
+        public Abstractions.ISourceInformationProvider SourceInformationProvider { get { throw null; } set { } }
+
+        protected abstract Abstractions.ITestFrameworkDiscoverer CreateDiscoverer(Abstractions.IAssemblyInfo assemblyInfo);
+        protected abstract Abstractions.ITestFrameworkExecutor CreateExecutor(System.Reflection.AssemblyName assemblyName);
+        public void Dispose() { }
+
+        public Abstractions.ITestFrameworkDiscoverer GetDiscoverer(Abstractions.IAssemblyInfo assemblyInfo) { throw null; }
+
+        public Abstractions.ITestFrameworkExecutor GetExecutor(System.Reflection.AssemblyName assemblyName) { throw null; }
+    }
+
+    public abstract partial class TestFrameworkDiscoverer : LongLivedMarshalByRefObject, Abstractions.ITestFrameworkDiscoverer, System.IDisposable
+    {
+        protected TestFrameworkDiscoverer(Abstractions.IAssemblyInfo assemblyInfo, Abstractions.ISourceInformationProvider sourceProvider, Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        protected internal Abstractions.IAssemblyInfo AssemblyInfo { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } set { } }
+
+        protected DisposalTracker DisposalTracker { get { throw null; } set { } }
+
+        protected Abstractions.ISourceInformationProvider SourceProvider { get { throw null; } set { } }
+
+        public string TargetFramework { get { throw null; } }
+
+        public string TestFrameworkDisplayName { get { throw null; } protected set { } }
+
+        protected internal abstract Abstractions.ITestClass CreateTestClass(Abstractions.ITypeInfo @class);
+        public void Dispose() { }
+
+        public void Find(bool includeSourceInformation, Abstractions.IMessageSink discoveryMessageSink, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { }
+
+        public void Find(string typeName, bool includeSourceInformation, Abstractions.IMessageSink discoveryMessageSink, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { }
+
+        protected abstract bool FindTestsForType(Abstractions.ITestClass testClass, bool includeSourceInformation, IMessageBus messageBus, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions);
+        protected virtual bool IsValidTestClass(Abstractions.ITypeInfo type) { throw null; }
+
+        protected bool ReportDiscoveredTestCase(Abstractions.ITestCase testCase, bool includeSourceInformation, IMessageBus messageBus) { throw null; }
+
+        public virtual string Serialize(Abstractions.ITestCase testCase) { throw null; }
+    }
+
+    public abstract partial class TestFrameworkExecutor<TTestCase> : LongLivedMarshalByRefObject, Abstractions.ITestFrameworkExecutor, System.IDisposable where TTestCase : Abstractions.ITestCase
+    {
+        protected TestFrameworkExecutor(System.Reflection.AssemblyName assemblyName, Abstractions.ISourceInformationProvider sourceInformationProvider, Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        protected Abstractions.IAssemblyInfo AssemblyInfo { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } set { } }
+
+        protected DisposalTracker DisposalTracker { get { throw null; } set { } }
+
+        protected Abstractions.ISourceInformationProvider SourceInformationProvider { get { throw null; } set { } }
+
+        protected abstract Abstractions.ITestFrameworkDiscoverer CreateDiscoverer();
+        public virtual Abstractions.ITestCase Deserialize(string value) { throw null; }
+
+        public void Dispose() { }
+
+        public virtual void RunAll(Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestFrameworkExecutionOptions executionOptions) { }
+
+        protected abstract void RunTestCases(System.Collections.Generic.IEnumerable<TTestCase> testCases, Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkExecutionOptions executionOptions);
+        public virtual void RunTests(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkExecutionOptions executionOptions) { }
+    }
+
+    public partial class TestFrameworkProxy : LongLivedMarshalByRefObject, Abstractions.ITestFramework, System.IDisposable
+    {
+        public TestFrameworkProxy(object testAssemblyObject, object sourceInformationProviderObject, object diagnosticMessageSinkObject) { }
+
+        public Abstractions.ITestFramework InnerTestFramework { get { throw null; } }
+
+        public Abstractions.ISourceInformationProvider SourceInformationProvider { set { } }
+
+        public void Dispose() { }
+
+        public Abstractions.ITestFrameworkDiscoverer GetDiscoverer(Abstractions.IAssemblyInfo assembly) { throw null; }
+
+        public Abstractions.ITestFrameworkExecutor GetExecutor(System.Reflection.AssemblyName assemblyName) { throw null; }
+
+        public partial class MessageSinkWrapper : LongLivedMarshalByRefObject, Abstractions.IMessageSink
+        {
+            public readonly Abstractions.IMessageSink InnerSink;
+            public MessageSinkWrapper(Abstractions.IMessageSink innerSink) { }
+
+            public bool OnMessage(Abstractions.IMessageSinkMessage message) { throw null; }
+        }
+    }
+
+    public partial class TestFrameworkTypeDiscoverer : ITestFrameworkTypeDiscoverer
+    {
+        public System.Type GetTestFrameworkType(Abstractions.IAttributeInfo attribute) { throw null; }
+    }
+
+    public abstract partial class TestInvoker<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestInvoker(Abstractions.ITest test, IMessageBus messageBus, System.Type testClass, object[] constructorArguments, System.Reflection.MethodInfo testMethod, object[] testMethodArguments, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected object[] ConstructorArguments { get { throw null; } set { } }
+
+        protected string DisplayName { get { throw null; } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected Abstractions.ITest Test { get { throw null; } set { } }
+
+        protected TTestCase TestCase { get { throw null; } }
+
+        protected System.Type TestClass { get { throw null; } set { } }
+
+        protected System.Reflection.MethodInfo TestMethod { get { throw null; } set { } }
+
+        protected object[] TestMethodArguments { get { throw null; } set { } }
+
+        protected ExecutionTimer Timer { get { throw null; } set { } }
+
+        protected virtual System.Threading.Tasks.Task AfterTestMethodInvokedAsync() { throw null; }
+
+        protected virtual System.Threading.Tasks.Task BeforeTestMethodInvokedAsync() { throw null; }
+
+        protected virtual object CallTestMethod(object testClassInstance) { throw null; }
+
+        protected virtual object CreateTestClass() { throw null; }
+
+        public static System.Threading.Tasks.Task GetTaskFromResult(object obj) { throw null; }
+
+        protected virtual System.Threading.Tasks.Task<decimal> InvokeTestMethodAsync(object testClassInstance) { throw null; }
+
+        public System.Threading.Tasks.Task<decimal> RunAsync() { throw null; }
+    }
+
+    public partial class TestMessage : TestCaseMessage, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestMessage(Abstractions.ITest test) : base(default!) { }
+
+        public Abstractions.ITest Test { get { throw null; } }
+    }
+
+    public partial class TestMethod : LongLivedMarshalByRefObject, Abstractions.ITestMethod, Abstractions.IXunitSerializable
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public TestMethod() { }
+
+        public TestMethod(Abstractions.ITestClass @class, Abstractions.IMethodInfo method) { }
+
+        public Abstractions.IMethodInfo Method { get { throw null; } set { } }
+
+        public Abstractions.ITestClass TestClass { get { throw null; } set { } }
+
+        public void Deserialize(Abstractions.IXunitSerializationInfo info) { }
+
+        public void Serialize(Abstractions.IXunitSerializationInfo info) { }
+    }
+
+    public partial class TestMethodCleanupFailure : TestMethodMessage, Abstractions.ITestMethodCleanupFailure, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFailureInformation
+    {
+        public TestMethodCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestMethod testMethod, System.Exception ex) : base(default!, default!) { }
+
+        public TestMethodCleanupFailure(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestMethod testMethod, string[] exceptionTypes, string[] messages, string[] stackTraces, int[] exceptionParentIndices) : base(default!, default!) { }
+
+        public int[] ExceptionParentIndices { get { throw null; } }
+
+        public string[] ExceptionTypes { get { throw null; } }
+
+        public string[] Messages { get { throw null; } }
+
+        public string[] StackTraces { get { throw null; } }
+    }
+
+    public partial class TestMethodComparer : System.Collections.Generic.IEqualityComparer<Abstractions.ITestMethod>
+    {
+        public static readonly TestMethodComparer Instance;
+        public bool Equals(Abstractions.ITestMethod x, Abstractions.ITestMethod y) { throw null; }
+
+        public int GetHashCode(Abstractions.ITestMethod obj) { throw null; }
+    }
+
+    public partial class TestMethodFinished : TestMethodMessage, Abstractions.ITestMethodFinished, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage, Abstractions.IFinishedMessage
+    {
+        public TestMethodFinished(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestMethod testMethod, decimal executionTime, int testsRun, int testsFailed, int testsSkipped) : base(default!, default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public int TestsFailed { get { throw null; } }
+
+        public int TestsRun { get { throw null; } }
+
+        public int TestsSkipped { get { throw null; } }
+    }
+
+    public partial class TestMethodMessage : TestClassMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestMethodMessage(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestMethod testMethod) : base(default!, default!) { }
+
+        public Abstractions.ITestMethod TestMethod { get { throw null; } set { } }
+    }
+
+    public abstract partial class TestMethodRunner<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestMethodRunner(Abstractions.ITestMethod testMethod, Abstractions.IReflectionTypeInfo @class, Abstractions.IReflectionMethodInfo method, System.Collections.Generic.IEnumerable<TTestCase> testCases, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected Abstractions.IReflectionTypeInfo Class { get { throw null; } set { } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected Abstractions.IReflectionMethodInfo Method { get { throw null; } set { } }
+
+        protected System.Collections.Generic.IEnumerable<TTestCase> TestCases { get { throw null; } set { } }
+
+        protected Abstractions.ITestMethod TestMethod { get { throw null; } set { } }
+
+        protected virtual void AfterTestMethodStarting() { }
+
+        protected virtual void BeforeTestMethodFinished() { }
+
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+
+        protected abstract System.Threading.Tasks.Task<RunSummary> RunTestCaseAsync(TTestCase testCase);
+        protected virtual System.Threading.Tasks.Task<RunSummary> RunTestCasesAsync() { throw null; }
+    }
+
+    public partial class TestMethodStarting : TestMethodMessage, Abstractions.ITestMethodStarting, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestMethodStarting(System.Collections.Generic.IEnumerable<Abstractions.ITestCase> testCases, Abstractions.ITestMethod testMethod) : base(default!, default!) { }
+    }
+
+    public abstract partial class TestMethodTestCase : LongLivedMarshalByRefObject, Abstractions.ITestCase, Abstractions.IXunitSerializable, System.IDisposable
+    {
+        protected TestMethodTestCase() { }
+
+        [System.Obsolete("Please call the constructor which takes TestMethodDisplayOptions")]
+        protected TestMethodTestCase(TestMethodDisplay defaultMethodDisplay, Abstractions.ITestMethod testMethod, object[] testMethodArguments = null) { }
+
+        protected TestMethodTestCase(TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, Abstractions.ITestMethod testMethod, object[] testMethodArguments = null) { }
+
+        protected string BaseDisplayName { get { throw null; } }
+
+        protected internal TestMethodDisplay DefaultMethodDisplay { get { throw null; } }
+
+        protected internal TestMethodDisplayOptions DefaultMethodDisplayOptions { get { throw null; } }
+
+        public string DisplayName { get { throw null; } protected set { } }
+
+        public System.Exception InitializationException { get { throw null; } protected set { } }
+
+        public Abstractions.IMethodInfo Method { get { throw null; } protected set { } }
+
+        protected Abstractions.ITypeInfo[] MethodGenericTypes { get { throw null; } }
+
+        public string SkipReason { get { throw null; } protected set { } }
+
+        public Abstractions.ISourceInformation SourceInformation { get { throw null; } set { } }
+
+        public Abstractions.ITestMethod TestMethod { get { throw null; } protected set { } }
+
+        public object[] TestMethodArguments { get { throw null; } protected set { } }
+
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> Traits { get { throw null; } protected set { } }
+
+        public string UniqueID { get { throw null; } }
+
+        public virtual void Deserialize(Abstractions.IXunitSerializationInfo data) { }
+
+        public virtual void Dispose() { }
+
+        protected void EnsureInitialized() { }
+
+        protected virtual string GetUniqueID() { throw null; }
+
+        protected virtual void Initialize() { }
+
+        public virtual void Serialize(Abstractions.IXunitSerializationInfo data) { }
+    }
+
+    public partial class TestOutput : TestMessage, Abstractions.ITestOutput, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestOutput(Abstractions.ITest test, string output) : base(default!) { }
+
+        public string Output { get { throw null; } }
+    }
+
+    public partial class TestOutputHelper : Abstractions.ITestOutputHelper
+    {
+        public string Output { get { throw null; } }
+
+        public void Initialize(IMessageBus messageBus, Abstractions.ITest test) { }
+
+        public void Uninitialize() { }
+
+        public void WriteLine(string format, params object[] args) { }
+
+        public void WriteLine(string message) { }
+    }
+
+    public partial class TestPassed : TestResultMessage, Abstractions.ITestPassed, Abstractions.ITestResultMessage, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestPassed(Abstractions.ITest test, decimal executionTime, string output) : base(default!, default, default!) { }
+    }
+
+    public partial class TestResultMessage : TestMessage, Abstractions.ITestResultMessage, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage
+    {
+        public TestResultMessage(Abstractions.ITest test, decimal executionTime, string output) : base(default!) { }
+
+        public decimal ExecutionTime { get { throw null; } }
+
+        public string Output { get { throw null; } }
+    }
+
+    public abstract partial class TestRunner<TTestCase>
+        where TTestCase : Abstractions.ITestCase
+    {
+        protected TestRunner(Abstractions.ITest test, IMessageBus messageBus, System.Type testClass, object[] constructorArguments, System.Reflection.MethodInfo testMethod, object[] testMethodArguments, string skipReason, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { }
+
+        protected ExceptionAggregator Aggregator { get { throw null; } set { } }
+
+        protected System.Threading.CancellationTokenSource CancellationTokenSource { get { throw null; } set { } }
+
+        protected object[] ConstructorArguments { get { throw null; } set { } }
+
+        protected string DisplayName { get { throw null; } }
+
+        protected IMessageBus MessageBus { get { throw null; } set { } }
+
+        protected string SkipReason { get { throw null; } set { } }
+
+        protected Abstractions.ITest Test { get { throw null; } set { } }
+
+        protected TTestCase TestCase { get { throw null; } }
+
+        protected System.Type TestClass { get { throw null; } set { } }
+
+        protected System.Reflection.MethodInfo TestMethod { get { throw null; } set { } }
+
+        protected object[] TestMethodArguments { get { throw null; } set { } }
+
+        protected virtual void AfterTestStarting() { }
+
+        protected virtual void BeforeTestFinished() { }
+
+        protected abstract System.Threading.Tasks.Task<System.Tuple<decimal, string>> InvokeTestAsync(ExceptionAggregator aggregator);
+        public System.Threading.Tasks.Task<RunSummary> RunAsync() { throw null; }
+    }
+
+    public partial class TestSkipped : TestResultMessage, Abstractions.ITestSkipped, Abstractions.ITestResultMessage, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestSkipped(Abstractions.ITest test, string reason) : base(default!, default, default!) { }
+
+        public string Reason { get { throw null; } }
+    }
+
+    public partial class TestStarting : TestMessage, Abstractions.ITestStarting, Abstractions.ITestMessage, Abstractions.ITestCaseMessage, Abstractions.ITestMethodMessage, Abstractions.ITestClassMessage, Abstractions.ITestCollectionMessage, Abstractions.ITestAssemblyMessage, Abstractions.IMessageSinkMessage, Abstractions.IExecutionMessage
+    {
+        public TestStarting(Abstractions.ITest test) : base(default!) { }
+    }
+
+    public partial class TestTimeoutException : System.Exception
+    {
+        public TestTimeoutException(int timeout) { }
+    }
+
+    public partial class TheoryDiscoverer : IXunitTestCaseDiscoverer
+    {
+        public TheoryDiscoverer(Abstractions.IMessageSink diagnosticMessageSink) { }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        [System.Obsolete("Please override CreateTestCasesForDataRow instead")]
+        protected virtual IXunitTestCase CreateTestCaseForDataRow(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, object[] dataRow) { throw null; }
+
+        [System.Obsolete("Please override CreateTestCasesForSkip instead")]
+        protected virtual IXunitTestCase CreateTestCaseForSkip(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, string skipReason) { throw null; }
+
+        [System.Obsolete("Please override CreateTestCasesForSkippedDataRow instead")]
+        protected virtual IXunitTestCase CreateTestCaseForSkippedDataRow(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, object[] dataRow, string skipReason) { throw null; }
+
+        [System.Obsolete("Please override CreateTestCasesForTheory instead")]
+        protected virtual IXunitTestCase CreateTestCaseForTheory(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute) { throw null; }
+
+        protected virtual System.Collections.Generic.IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, object[] dataRow) { throw null; }
+
+        protected virtual System.Collections.Generic.IEnumerable<IXunitTestCase> CreateTestCasesForSkip(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, string skipReason) { throw null; }
+
+        protected virtual System.Collections.Generic.IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute, object[] dataRow, string skipReason) { throw null; }
+
+        protected virtual System.Collections.Generic.IEnumerable<IXunitTestCase> CreateTestCasesForTheory(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute) { throw null; }
+
+        public virtual System.Collections.Generic.IEnumerable<IXunitTestCase> Discover(Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions, Abstractions.ITestMethod testMethod, Abstractions.IAttributeInfo theoryAttribute) { throw null; }
+    }
+
+    public static partial class TraitHelper
+    {
+        public static System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, string>> GetTraits(System.Reflection.MemberInfo member) { throw null; }
+    }
+
+    public static partial class TypeUtility
+    {
+        public static string ConvertToSimpleTypeName(Abstractions.ITypeInfo type) { throw null; }
+
+        public static string GetDisplayNameWithArguments(this Abstractions.IMethodInfo method, string baseDisplayName, object[] arguments, Abstractions.ITypeInfo[] genericTypes) { throw null; }
+
+        public static Abstractions.ITypeInfo ResolveGenericType(this Abstractions.ITypeInfo genericType, object[] parameters, Abstractions.IParameterInfo[] parameterInfos) { throw null; }
+
+        public static Abstractions.ITypeInfo[] ResolveGenericTypes(this Abstractions.IMethodInfo method, object[] parameters) { throw null; }
+
+        public static object[] ResolveMethodArguments(this System.Reflection.MethodBase testMethod, object[] arguments) { throw null; }
+    }
+
+    public partial class XunitSkippedDataRowTestCase : XunitTestCase
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public XunitSkippedDataRowTestCase() { }
+
+        [System.Obsolete("Please call the constructor which takes TestMethodDisplayOptions")]
+        public XunitSkippedDataRowTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, Abstractions.ITestMethod testMethod, string skipReason, object[] testMethodArguments = null) { }
+
+        public XunitSkippedDataRowTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, Abstractions.ITestMethod testMethod, string skipReason, object[] testMethodArguments = null) { }
+
+        public override void Deserialize(Abstractions.IXunitSerializationInfo data) { }
+
+        protected override string GetSkipReason(Abstractions.IAttributeInfo factAttribute) { throw null; }
+
+        public override void Serialize(Abstractions.IXunitSerializationInfo data) { }
+    }
+
+    public partial class XunitTest : LongLivedMarshalByRefObject, Abstractions.ITest
+    {
+        public XunitTest(IXunitTestCase testCase, string displayName) { }
+
+        public string DisplayName { get { throw null; } }
+
+        public IXunitTestCase TestCase { get { throw null; } }
+
+        Abstractions.ITestCase Abstractions.ITest.TestCase { get { throw null; } }
+    }
+
+    public partial class XunitTestAssemblyRunner : TestAssemblyRunner<IXunitTestCase>
+    {
+        public XunitTestAssemblyRunner(Abstractions.ITestAssembly testAssembly, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkExecutionOptions executionOptions) : base(default!, default!, default!, default!, default!) { }
+
+        protected override System.Threading.Tasks.Task AfterTestAssemblyStartingAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task BeforeTestAssemblyFinishedAsync() { throw null; }
+
+        public override void Dispose() { }
+
+        protected override string GetTestFrameworkDisplayName() { throw null; }
+
+        protected override string GetTestFrameworkEnvironment() { throw null; }
+
+        protected void Initialize() { }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, Abstractions.ITestCollection testCollection, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestCollectionsAsync(IMessageBus messageBus, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        protected virtual void SetupSyncContext(int maxParallelThreads) { }
+    }
+
+    public partial class XunitTestCase : TestMethodTestCase, IXunitTestCase, Abstractions.ITestCase, Abstractions.IXunitSerializable
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public XunitTestCase() { }
+
+        [System.Obsolete("Please call the constructor which takes TestMethodDisplayOptions")]
+        public XunitTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, Abstractions.ITestMethod testMethod, object[] testMethodArguments = null) { }
+
+        public XunitTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, Abstractions.ITestMethod testMethod, object[] testMethodArguments = null) { }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        public int Timeout { get { throw null; } protected set { } }
+
+        public override void Deserialize(Abstractions.IXunitSerializationInfo data) { }
+
+        protected virtual string GetDisplayName(Abstractions.IAttributeInfo factAttribute, string displayName) { throw null; }
+
+        protected virtual string GetSkipReason(Abstractions.IAttributeInfo factAttribute) { throw null; }
+
+        protected virtual int GetTimeout(Abstractions.IAttributeInfo factAttribute) { throw null; }
+
+        protected override void Initialize() { }
+
+        public virtual System.Threading.Tasks.Task<RunSummary> RunAsync(Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        public override void Serialize(Abstractions.IXunitSerializationInfo data) { }
+    }
+
+    public partial class XunitTestCaseRunner : TestCaseRunner<IXunitTestCase>
+    {
+        public XunitTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, object[] testMethodArguments, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!) { }
+
+        public System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> BeforeAfterAttributes { get { throw null; } }
+
+        protected object[] ConstructorArguments { get { throw null; } set { } }
+
+        protected string DisplayName { get { throw null; } set { } }
+
+        protected string SkipReason { get { throw null; } set { } }
+
+        protected System.Type TestClass { get { throw null; } set { } }
+
+        protected System.Reflection.MethodInfo TestMethod { get { throw null; } set { } }
+
+        protected object[] TestMethodArguments { get { throw null; } set { } }
+
+        protected virtual Abstractions.ITest CreateTest(IXunitTestCase testCase, string displayName) { throw null; }
+
+        protected virtual XunitTestRunner CreateTestRunner(Abstractions.ITest test, IMessageBus messageBus, System.Type testClass, object[] constructorArguments, System.Reflection.MethodInfo testMethod, object[] testMethodArguments, string skipReason, System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+
+        protected virtual System.Collections.Generic.List<BeforeAfterTestAttribute> GetBeforeAfterTestAttributes() { throw null; }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestAsync() { throw null; }
+    }
+
+    public partial class XunitTestClassRunner : TestClassRunner<IXunitTestCase>
+    {
+        public XunitTestClassRunner(Abstractions.ITestClass testClass, Abstractions.IReflectionTypeInfo @class, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource, System.Collections.Generic.IDictionary<System.Type, object> collectionFixtureMappings) : base(default!, default!, default!, default!, default!, default!, default!, default!) { }
+
+        protected System.Collections.Generic.Dictionary<System.Type, object> ClassFixtureMappings { get { throw null; } set { } }
+
+        protected System.Collections.Generic.HashSet<IAsyncLifetime> InitializedAsyncFixtures { get { throw null; } set { } }
+
+        protected override System.Threading.Tasks.Task AfterTestClassStartingAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task BeforeTestClassFinishedAsync() { throw null; }
+
+        protected virtual void CreateClassFixture(System.Type fixtureType) { }
+
+        protected override string FormatConstructorArgsMissingMessage(System.Reflection.ConstructorInfo constructor, System.Collections.Generic.IReadOnlyList<System.Tuple<int, System.Reflection.ParameterInfo>> unusedArguments) { throw null; }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestMethodAsync(Abstractions.ITestMethod testMethod, Abstractions.IReflectionMethodInfo method, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, object[] constructorArguments) { throw null; }
+
+        protected override System.Reflection.ConstructorInfo SelectTestClassConstructor() { throw null; }
+
+        protected override bool TryGetConstructorArgument(System.Reflection.ConstructorInfo constructor, int index, System.Reflection.ParameterInfo parameter, out object argumentValue) { throw null; }
+    }
+
+    public partial class XunitTestCollectionRunner : TestCollectionRunner<IXunitTestCase>
+    {
+        public XunitTestCollectionRunner(Abstractions.ITestCollection testCollection, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!, default!, default!) { }
+
+        protected System.Collections.Generic.Dictionary<System.Type, object> CollectionFixtureMappings { get { throw null; } set { } }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        protected override System.Threading.Tasks.Task AfterTestCollectionStartingAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task BeforeTestCollectionFinishedAsync() { throw null; }
+
+        protected virtual void CreateCollectionFixture(System.Type fixtureType) { }
+
+        protected virtual ITestCaseOrderer GetTestCaseOrderer() { throw null; }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestClassAsync(Abstractions.ITestClass testClass, Abstractions.IReflectionTypeInfo @class, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases) { throw null; }
+    }
+
+    public partial class XunitTestFramework : TestFramework
+    {
+        public XunitTestFramework(Abstractions.IMessageSink messageSink) : base(default!) { }
+
+        protected override Abstractions.ITestFrameworkDiscoverer CreateDiscoverer(Abstractions.IAssemblyInfo assemblyInfo) { throw null; }
+
+        protected override Abstractions.ITestFrameworkExecutor CreateExecutor(System.Reflection.AssemblyName assemblyName) { throw null; }
+    }
+
+    public partial class XunitTestFrameworkDiscoverer : TestFrameworkDiscoverer
+    {
+        public static readonly string DisplayName;
+        public XunitTestFrameworkDiscoverer(Abstractions.IAssemblyInfo assemblyInfo, Abstractions.ISourceInformationProvider sourceProvider, Abstractions.IMessageSink diagnosticMessageSink, IXunitTestCollectionFactory collectionFactory = null) : base(default!, default!, default!) { }
+
+        protected System.Collections.Generic.Dictionary<System.Type, System.Type> DiscovererTypeCache { get { throw null; } }
+
+        public IXunitTestCollectionFactory TestCollectionFactory { get { throw null; } }
+
+        protected internal override Abstractions.ITestClass CreateTestClass(Abstractions.ITypeInfo @class) { throw null; }
+
+        protected internal virtual bool FindTestsForMethod(Abstractions.ITestMethod testMethod, bool includeSourceInformation, IMessageBus messageBus, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        protected override bool FindTestsForType(Abstractions.ITestClass testClass, bool includeSourceInformation, IMessageBus messageBus, Abstractions.ITestFrameworkDiscoveryOptions discoveryOptions) { throw null; }
+
+        protected IXunitTestCaseDiscoverer GetDiscoverer(System.Type discovererType) { throw null; }
+
+        public override string Serialize(Abstractions.ITestCase testCase) { throw null; }
+    }
+
+    public partial class XunitTestFrameworkExecutor : TestFrameworkExecutor<IXunitTestCase>
+    {
+        public XunitTestFrameworkExecutor(System.Reflection.AssemblyName assemblyName, Abstractions.ISourceInformationProvider sourceInformationProvider, Abstractions.IMessageSink diagnosticMessageSink) : base(default!, default!, default!) { }
+
+        protected TestAssembly TestAssembly { get { throw null; } set { } }
+
+        protected override Abstractions.ITestFrameworkDiscoverer CreateDiscoverer() { throw null; }
+
+        public override Abstractions.ITestCase Deserialize(string value) { throw null; }
+
+        protected override void RunTestCases(System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, Abstractions.IMessageSink executionMessageSink, Abstractions.ITestFrameworkExecutionOptions executionOptions) { }
+    }
+
+    public partial class XunitTestInvoker : TestInvoker<IXunitTestCase>
+    {
+        public XunitTestInvoker(Abstractions.ITest test, IMessageBus messageBus, System.Type testClass, object[] constructorArguments, System.Reflection.MethodInfo testMethod, object[] testMethodArguments, System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!, default!, default!, default!, default!) { }
+
+        protected System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> BeforeAfterAttributes { get { throw null; } }
+
+        protected override System.Threading.Tasks.Task AfterTestMethodInvokedAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task BeforeTestMethodInvokedAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task<decimal> InvokeTestMethodAsync(object testClassInstance) { throw null; }
+    }
+
+    public partial class XunitTestMethodRunner : TestMethodRunner<IXunitTestCase>
+    {
+        public XunitTestMethodRunner(Abstractions.ITestMethod testMethod, Abstractions.IReflectionTypeInfo @class, Abstractions.IReflectionMethodInfo method, System.Collections.Generic.IEnumerable<IXunitTestCase> testCases, Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource, object[] constructorArguments) : base(default!, default!, default!, default!, default!, default!, default!) { }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase) { throw null; }
+    }
+
+    public partial class XunitTestRunner : TestRunner<IXunitTestCase>
+    {
+        public XunitTestRunner(Abstractions.ITest test, IMessageBus messageBus, System.Type testClass, object[] constructorArguments, System.Reflection.MethodInfo testMethod, object[] testMethodArguments, string skipReason, System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!, default!, default!, default!, default!, default!) { }
+
+        protected System.Collections.Generic.IReadOnlyList<BeforeAfterTestAttribute> BeforeAfterAttributes { get { throw null; } }
+
+        protected override System.Threading.Tasks.Task<System.Tuple<decimal, string>> InvokeTestAsync(ExceptionAggregator aggregator) { throw null; }
+
+        protected virtual System.Threading.Tasks.Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator) { throw null; }
+    }
+
+    public partial class XunitTheoryTestCase : XunitTestCase
+    {
+        [System.Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public XunitTheoryTestCase() { }
+
+        [System.Obsolete("Please call the constructor which takes TestMethodDisplayOptions")]
+        public XunitTheoryTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, Abstractions.ITestMethod testMethod) { }
+
+        public XunitTheoryTestCase(Abstractions.IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, Abstractions.ITestMethod testMethod) { }
+
+        public override System.Threading.Tasks.Task<RunSummary> RunAsync(Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) { throw null; }
+    }
+
+    public partial class XunitTheoryTestCaseRunner : XunitTestCaseRunner
+    {
+        public XunitTheoryTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, Abstractions.IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, System.Threading.CancellationTokenSource cancellationTokenSource) : base(default!, default!, default!, default!, default!, default!, default!, default!) { }
+
+        protected Abstractions.IMessageSink DiagnosticMessageSink { get { throw null; } }
+
+        protected override System.Threading.Tasks.Task AfterTestCaseStartingAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task BeforeTestCaseFinishedAsync() { throw null; }
+
+        protected override System.Threading.Tasks.Task<RunSummary> RunTestAsync() { throw null; }
+    }
+}

--- a/src/referencePackages/src/xunit.extensibility.execution/2.6.1/xunit.extensibility.execution.2.6.1.csproj
+++ b/src/referencePackages/src/xunit.extensibility.execution/2.6.1/xunit.extensibility.execution.2.6.1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
+    <AssemblyName>xunit.execution.dotnet</AssemblyName>
+    <StrongNameKeyId>XUnit.Core</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <PackageReference Include="xunit.extensibility.core" Version="2.6.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/xunit.extensibility.execution/2.6.1/xunit.extensibility.execution.nuspec
+++ b/src/referencePackages/src/xunit.extensibility.execution/2.6.1/xunit.extensibility.execution.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>xunit.extensibility.execution</id>
+    <version>2.6.1</version>
+    <title>xUnit.net [Extensibility: Execution]</title>
+    <authors>jnewkirk,bradwilson</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
+    <description>Includes xunit.execution.*.dll for extensibility purposes. Supports .NET 4.5.2 or later, and .NET Standard 1.1.</description>
+    <releaseNotes>https://xunit.net/releases/v2/2.6.1</releaseNotes>
+    <copyright>Copyright (C) .NET Foundation</copyright>
+    <repository type="git" url="https://github.com/xunit/xunit" commit="9f1684f5f74196d952f0085d7bde21aa20df6229" />
+    <dependencies>
+      <group targetFramework=".NETStandard1.1">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="xunit.extensibility.core" version="[2.6.1]" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Resolves arcade related prebuilts https://github.com/dotnet/source-build/issues/3813 and https://github.com/dotnet/source-build/issues/3665

(Build related to v2.5.3, but arcade has recently updated to v2.6.1. Once arcade SDK is updated, the version will match the added SBRP).

**Leaving as a draft due to the following build errors**:

```
Restored /root/repos/source-build-reference-packages/artifacts/sb/src/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.csproj (in 108 ms).
  /root/repos/source-build-reference-packages/artifacts/sb/package-cache/microsoft.dotnet.arcade.sdk/9.0.0-beta.23628.1/tools/StrongName.targets(89,5): error : PublicKey, PublicKeyToken and AssemblyOriginatorKeyFile must be specified [/root/repos/source-build-reference-packages/artifacts/sb/src/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.csproj::TargetFramework=netstandard2.0] [/root/.nuget/packages/microsoft.dotnet.arcade.sdk/9.0.0-beta.23628.1/tools/Build.proj]
  /root/repos/source-build-reference-packages/artifacts/sb/package-cache/microsoft.dotnet.arcade.sdk/9.0.0-beta.23628.1/tools/StrongName.targets(89,5): error : PublicKey, PublicKeyToken and AssemblyOriginatorKeyFile must be specified [/root/repos/source-build-reference-packages/artifacts/sb/src/src/referencePackages/src/xunit.abstractions/2.0.3/xunit.abstractions.2.0.3.csproj::TargetFramework=netstandard1.0] [/root/.nuget/packages/microsoft.dotnet.arcade.sdk/9.0.0-beta.23628.1/tools/Build.proj]
```