### PR TITLE
Add Microsoft.CodeAnalysis/4.9 dependencies

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -26,6 +26,15 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.CodeAnalysis.CSharp.4.6.0.csproj" />
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Reflection.MetadataLoadContext.8.0.0.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.TypedParts.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Runtime.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Hosting.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Convention.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.AttributedModel.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.IO.Pipelines.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Encoding.CodePages.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Threading.Channels.8.0.0.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -27,11 +27,12 @@
 
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Reflection.MetadataLoadContext.8.0.0.csproj" />
 
-    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.TypedParts.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Runtime.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Hosting.8.0.0.csproj" />
-    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Convention.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.AttributedModel.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.Convention.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.TypedParts.8.0.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Composition.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.IO.Pipelines.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Encoding.CodePages.8.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Threading.Channels.8.0.0.csproj" />

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -112,8 +112,7 @@
           AfterTargets="CopyFilesToOutputDirectory">
 
     <ItemGroup>
-      <CompileForRelativePath Include="@(Compile)" />
-      <CompileForRelativePath Remove="$(RepoRoot)src\SourceBuildAssemblyMetdata.cs" />
+      <CompileWithRelativePath Include="@(Compile)" Condition="!$([System.String]::new('%(Identity)').StartsWith('/'))" />
     </ItemGroup>
 
     <Error

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -116,11 +116,11 @@
     </ItemGroup>
 
     <Error
-      Condition="@(CompileForRelativePath->Count()) != 1"
+      Condition="@(CompileWithRelativePath->Count()) != 1"
       Text="Number of Compile items != 1. We need just one, to determine the path of the resulting DLL in the package including ref/lib and TFM." />
 
     <ItemGroup>
-      <FullCompileDir Include="$([System.IO.Directory]::GetParent('%(CompileForRelativePath.Identity)'))" />
+      <FullCompileDir Include="$([System.IO.Directory]::GetParent('%(CompileWithRelativePath.Identity)'))" />
       <RelativeCompileDir Include="$([MSBuild]::MakeRelative('$(MSBuildProjectDirectory)\', '%(FullCompileDir.Identity)'))" />
     </ItemGroup>
 

--- a/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.0/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.0/System.Collections.cs
@@ -104,7 +104,7 @@ namespace System.Collections.Generic
 
         public TValue this[TKey key] { get { throw null; } set { } }
 
-        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+        public KeyCollection Keys { get { throw null; } }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
 
@@ -130,7 +130,7 @@ namespace System.Collections.Generic
 
         ICollection IDictionary.Values { get { throw null; } }
 
-        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+        public ValueCollection Values { get { throw null; } }
 
         public void Add(TKey key, TValue value) { }
 
@@ -140,7 +140,7 @@ namespace System.Collections.Generic
 
         public bool ContainsValue(TValue value) { throw null; }
 
-        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(TKey key) { throw null; }
 
@@ -201,7 +201,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TKey[] array, int index) { }
 
-            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TKey>.Add(TKey item) { }
 
@@ -245,7 +245,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TValue[] array, int index) { }
 
-            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TValue>.Add(TValue item) { }
 
@@ -317,7 +317,7 @@ namespace System.Collections.Generic
 
         public void ExceptWith(IEnumerable<T> other) { }
 
-        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public void IntersectWith(IEnumerable<T> other) { }
 
@@ -420,7 +420,7 @@ namespace System.Collections.Generic
 
         public LinkedListNode<T> FindLast(T value) { throw null; }
 
-        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(T value) { throw null; }
 
@@ -518,7 +518,7 @@ namespace System.Collections.Generic
 
         public int FindLastIndex(Predicate<T> match) { throw null; }
 
-        public List<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public List<T> GetRange(int index, int count) { throw null; }
 
@@ -618,7 +618,7 @@ namespace System.Collections.Generic
 
         public void Enqueue(T item) { }
 
-        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public T Peek() { throw null; }
 
@@ -662,7 +662,7 @@ namespace System.Collections.Generic
 
         public TValue this[TKey key] { get { throw null; } set { } }
 
-        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+        public KeyCollection Keys { get { throw null; } }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
 
@@ -684,7 +684,7 @@ namespace System.Collections.Generic
 
         ICollection IDictionary.Values { get { throw null; } }
 
-        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+        public ValueCollection Values { get { throw null; } }
 
         public void Add(TKey key, TValue value) { }
 
@@ -696,7 +696,7 @@ namespace System.Collections.Generic
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
 
-        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(TKey key) { throw null; }
 
@@ -755,7 +755,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TKey[] array, int index) { }
 
-            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TKey>.Add(TKey item) { }
 
@@ -799,7 +799,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TValue[] array, int index) { }
 
-            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TValue>.Add(TValue item) { }
 
@@ -868,7 +868,7 @@ namespace System.Collections.Generic
 
         public void ExceptWith(IEnumerable<T> other) { }
 
-        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
 
@@ -938,7 +938,7 @@ namespace System.Collections.Generic
 
         public void CopyTo(T[] array, int arrayIndex) { }
 
-        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public T Peek() { throw null; }
 

--- a/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.3/System.Collections.cs
+++ b/src/referencePackages/src/system.collections/4.3.0/ref/netstandard1.3/System.Collections.cs
@@ -107,7 +107,7 @@ namespace System.Collections.Generic
 
         public TValue this[TKey key] { get { throw null; } set { } }
 
-        public Dictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+        public KeyCollection Keys { get { throw null; } }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
 
@@ -133,7 +133,7 @@ namespace System.Collections.Generic
 
         ICollection IDictionary.Values { get { throw null; } }
 
-        public Dictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+        public ValueCollection Values { get { throw null; } }
 
         public void Add(TKey key, TValue value) { }
 
@@ -143,7 +143,7 @@ namespace System.Collections.Generic
 
         public bool ContainsValue(TValue value) { throw null; }
 
-        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(TKey key) { throw null; }
 
@@ -204,7 +204,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TKey[] array, int index) { }
 
-            public Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TKey>.Add(TKey item) { }
 
@@ -248,7 +248,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TValue[] array, int index) { }
 
-            public Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TValue>.Add(TValue item) { }
 
@@ -320,7 +320,7 @@ namespace System.Collections.Generic
 
         public void ExceptWith(IEnumerable<T> other) { }
 
-        public HashSet<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public void IntersectWith(IEnumerable<T> other) { }
 
@@ -423,7 +423,7 @@ namespace System.Collections.Generic
 
         public LinkedListNode<T> FindLast(T value) { throw null; }
 
-        public LinkedList<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(T value) { throw null; }
 
@@ -525,7 +525,7 @@ namespace System.Collections.Generic
 
         public void ForEach(Action<T> action) { }
 
-        public List<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public List<T> GetRange(int index, int count) { throw null; }
 
@@ -625,7 +625,7 @@ namespace System.Collections.Generic
 
         public void Enqueue(T item) { }
 
-        public Queue<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public T Peek() { throw null; }
 
@@ -669,7 +669,7 @@ namespace System.Collections.Generic
 
         public TValue this[TKey key] { get { throw null; } set { } }
 
-        public SortedDictionary<TKey, TValue>.KeyCollection Keys { get { throw null; } }
+        public KeyCollection Keys { get { throw null; } }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly { get { throw null; } }
 
@@ -695,7 +695,7 @@ namespace System.Collections.Generic
 
         ICollection IDictionary.Values { get { throw null; } }
 
-        public SortedDictionary<TKey, TValue>.ValueCollection Values { get { throw null; } }
+        public ValueCollection Values { get { throw null; } }
 
         public void Add(TKey key, TValue value) { }
 
@@ -707,7 +707,7 @@ namespace System.Collections.Generic
 
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) { }
 
-        public SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public bool Remove(TKey key) { throw null; }
 
@@ -766,7 +766,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TKey[] array, int index) { }
 
-            public SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TKey>.Add(TKey item) { }
 
@@ -810,7 +810,7 @@ namespace System.Collections.Generic
 
             public void CopyTo(TValue[] array, int index) { }
 
-            public SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() { throw null; }
+            public Enumerator GetEnumerator() { throw null; }
 
             void ICollection<TValue>.Add(TValue item) { }
 
@@ -974,7 +974,7 @@ namespace System.Collections.Generic
 
         public void ExceptWith(IEnumerable<T> other) { }
 
-        public SortedSet<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public virtual SortedSet<T> GetViewBetween(T lowerValue, T upperValue) { throw null; }
 
@@ -1044,7 +1044,7 @@ namespace System.Collections.Generic
 
         public void CopyTo(T[] array, int arrayIndex) { }
 
-        public Stack<T>.Enumerator GetEnumerator() { throw null; }
+        public Enumerator GetEnumerator() { throw null; }
 
         public T Peek() { throw null; }
 

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/System.Composition.AttributedModel.8.0.0.csproj
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/System.Composition.AttributedModel.8.0.0.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Composition.AttributedModel</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net6.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net6.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides common attributes used by System.Composition types.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.ExportAttribute\r\nSystem.Composition.ImportAttribute\r\nSystem.Composition.Convention.AttributedModelProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public partial class ExportAttribute : Attribute
+    {
+        public ExportAttribute() { }
+
+        public ExportAttribute(string contractName, Type contractType) { }
+
+        public ExportAttribute(string contractName) { }
+
+        public ExportAttribute(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public sealed partial class ExportMetadataAttribute : Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportAttribute : Attribute
+    {
+        public ImportAttribute() { }
+
+        public ImportAttribute(string contractName) { }
+
+        public bool AllowDefault { get { throw null; } set { } }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed partial class ImportingConstructorAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportManyAttribute : Attribute
+    {
+        public ImportManyAttribute() { }
+
+        public ImportManyAttribute(string contractName) { }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    public sealed partial class ImportMetadataConstraintAttribute : Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class MetadataAttributeAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed partial class OnImportsSatisfiedAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public partial class PartMetadataAttribute : Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class PartNotDiscoverableAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public partial class SharedAttribute : PartMetadataAttribute
+    {
+        public SharedAttribute() : base(default!, default!) { }
+
+        public SharedAttribute(string sharingBoundaryName) : base(default!, default!) { }
+
+        public string SharingBoundary { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, Inherited = false)]
+    [MetadataAttribute]
+    [CLSCompliant(false)]
+    public sealed partial class SharingBoundaryAttribute : Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member);
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net7.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net7.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides common attributes used by System.Composition types.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.ExportAttribute\r\nSystem.Composition.ImportAttribute\r\nSystem.Composition.Convention.AttributedModelProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public partial class ExportAttribute : Attribute
+    {
+        public ExportAttribute() { }
+
+        public ExportAttribute(string contractName, Type contractType) { }
+
+        public ExportAttribute(string contractName) { }
+
+        public ExportAttribute(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public sealed partial class ExportMetadataAttribute : Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportAttribute : Attribute
+    {
+        public ImportAttribute() { }
+
+        public ImportAttribute(string contractName) { }
+
+        public bool AllowDefault { get { throw null; } set { } }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed partial class ImportingConstructorAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportManyAttribute : Attribute
+    {
+        public ImportManyAttribute() { }
+
+        public ImportManyAttribute(string contractName) { }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    public sealed partial class ImportMetadataConstraintAttribute : Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class MetadataAttributeAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed partial class OnImportsSatisfiedAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public partial class PartMetadataAttribute : Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class PartNotDiscoverableAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public partial class SharedAttribute : PartMetadataAttribute
+    {
+        public SharedAttribute() : base(default!, default!) { }
+
+        public SharedAttribute(string sharingBoundaryName) : base(default!, default!) { }
+
+        public string SharingBoundary { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, Inherited = false)]
+    [MetadataAttribute]
+    [CLSCompliant(false)]
+    public sealed partial class SharingBoundaryAttribute : Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member);
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net8.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/net8.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides common attributes used by System.Composition types.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.ExportAttribute\r\nSystem.Composition.ImportAttribute\r\nSystem.Composition.Convention.AttributedModelProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public partial class ExportAttribute : Attribute
+    {
+        public ExportAttribute() { }
+
+        public ExportAttribute(string contractName, Type contractType) { }
+
+        public ExportAttribute(string contractName) { }
+
+        public ExportAttribute(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public sealed partial class ExportMetadataAttribute : Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportAttribute : Attribute
+    {
+        public ImportAttribute() { }
+
+        public ImportAttribute(string contractName) { }
+
+        public bool AllowDefault { get { throw null; } set { } }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed partial class ImportingConstructorAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportManyAttribute : Attribute
+    {
+        public ImportManyAttribute() { }
+
+        public ImportManyAttribute(string contractName) { }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    public sealed partial class ImportMetadataConstraintAttribute : Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class MetadataAttributeAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed partial class OnImportsSatisfiedAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public partial class PartMetadataAttribute : Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class PartNotDiscoverableAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public partial class SharedAttribute : PartMetadataAttribute
+    {
+        public SharedAttribute() : base(default!, default!) { }
+
+        public SharedAttribute(string sharingBoundaryName) : base(default!, default!) { }
+
+        public string SharingBoundary { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, Inherited = false)]
+    [MetadataAttribute]
+    [CLSCompliant(false)]
+    public sealed partial class SharingBoundaryAttribute : Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member);
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/netstandard2.0/System.Composition.AttributedModel.cs
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/lib/netstandard2.0/System.Composition.AttributedModel.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.AttributedModel")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides common attributes used by System.Composition types.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.ExportAttribute\r\nSystem.Composition.ImportAttribute\r\nSystem.Composition.Convention.AttributedModelProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.AttributedModel")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public partial class ExportAttribute : Attribute
+    {
+        public ExportAttribute() { }
+
+        public ExportAttribute(string contractName, Type contractType) { }
+
+        public ExportAttribute(string contractName) { }
+
+        public ExportAttribute(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public sealed partial class ExportMetadataAttribute : Attribute
+    {
+        public ExportMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportAttribute : Attribute
+    {
+        public ImportAttribute() { }
+
+        public ImportAttribute(string contractName) { }
+
+        public bool AllowDefault { get { throw null; } set { } }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed partial class ImportingConstructorAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public partial class ImportManyAttribute : Attribute
+    {
+        public ImportManyAttribute() { }
+
+        public ImportManyAttribute(string contractName) { }
+
+        public string ContractName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    public sealed partial class ImportMetadataConstraintAttribute : Attribute
+    {
+        public ImportMetadataConstraintAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public sealed partial class MetadataAttributeAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed partial class OnImportsSatisfiedAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public partial class PartMetadataAttribute : Attribute
+    {
+        public PartMetadataAttribute(string name, object value) { }
+
+        public string Name { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed partial class PartNotDiscoverableAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public partial class SharedAttribute : PartMetadataAttribute
+    {
+        public SharedAttribute() : base(default!, default!) { }
+
+        public SharedAttribute(string sharingBoundaryName) : base(default!, default!) { }
+
+        public string SharingBoundary { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, Inherited = false)]
+    [MetadataAttribute]
+    [CLSCompliant(false)]
+    public sealed partial class SharingBoundaryAttribute : Attribute
+    {
+        public SharingBoundaryAttribute(params string[] sharingBoundaryNames) { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<string> SharingBoundaryNames { get { throw null; } }
+    }
+}
+
+namespace System.Composition.Convention
+{
+    public abstract partial class AttributedModelProvider
+    {
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member);
+        public abstract Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter);
+    }
+}

--- a/src/referencePackages/src/system.composition.attributedmodel/8.0.0/system.composition.attributedmodel.nuspec
+++ b/src/referencePackages/src/system.composition.attributedmodel/8.0.0/system.composition.attributedmodel.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Composition.AttributedModel</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides common attributes used by System.Composition types.
+
+Commonly Used Types:
+System.Composition.ExportAttribute
+System.Composition.ImportAttribute
+System.Composition.Convention.AttributedModelProvider</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.convention/8.0.0/System.Composition.Convention.8.0.0.csproj
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/System.Composition.Convention.8.0.0.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Composition.Convention</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.composition.convention/8.0.0/lib/net6.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/lib/net6.0/System.Composition.Convention.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types that support using Managed Extensibility Framework with a convention-based configuration model.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Convention.ConventionBuilder\r\nSystem.Composition.Convention.ExportConventionBuilder\r\nSystem.Composition.Convention.ImportConventionBuilder\r\nSystem.Composition.Convention.PartConventionBuilder\r\nSystem.Composition.Convention.ParameterImportConventionBuilder")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Convention")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : AttributedModelProvider
+    {
+        public PartConventionBuilder ForType(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForType<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesDerivedFrom(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesMatching(Predicate<Type> typeFilter) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesMatching<T>(Predicate<Type> typeFilter) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter) { throw null; }
+    }
+
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+
+        public ExportConventionBuilder AddMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+
+        public ExportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ExportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ExportConventionBuilder AsContractType(Type type) { throw null; }
+
+        public ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, Func<Type, object> getConstraintValueFromPartType) { throw null; }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+
+        public ImportConventionBuilder AllowDefault() { throw null; }
+
+        public ImportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ImportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ImportConventionBuilder AsMany() { throw null; }
+
+        public ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+
+        public T Import<T>() { throw null; }
+
+        public T Import<T>(Action<ImportConventionBuilder> configure) { throw null; }
+    }
+
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder AddPartMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+
+        public PartConventionBuilder Export() { throw null; }
+
+        public PartConventionBuilder Export(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder Export<T>() { throw null; }
+
+        public PartConventionBuilder Export<T>(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces() { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter, Action<Type, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder NotifyImportsSatisfied(Predicate<Reflection.MethodInfo> methodFilter) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector, Action<Reflection.ParameterInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector) { throw null; }
+
+        public PartConventionBuilder Shared() { throw null; }
+
+        public PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+
+    public partial class PartConventionBuilder<T> : PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> NotifyImportsSatisfied(Linq.Expressions.Expression<Action<T>> methodSelector) { throw null; }
+
+        public PartConventionBuilder<T> SelectConstructor(Linq.Expressions.Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/8.0.0/lib/net7.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/lib/net7.0/System.Composition.Convention.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types that support using Managed Extensibility Framework with a convention-based configuration model.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Convention.ConventionBuilder\r\nSystem.Composition.Convention.ExportConventionBuilder\r\nSystem.Composition.Convention.ImportConventionBuilder\r\nSystem.Composition.Convention.PartConventionBuilder\r\nSystem.Composition.Convention.ParameterImportConventionBuilder")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Convention")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : AttributedModelProvider
+    {
+        public PartConventionBuilder ForType(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForType<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesDerivedFrom(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesMatching(Predicate<Type> typeFilter) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesMatching<T>(Predicate<Type> typeFilter) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter) { throw null; }
+    }
+
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+
+        public ExportConventionBuilder AddMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+
+        public ExportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ExportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ExportConventionBuilder AsContractType(Type type) { throw null; }
+
+        public ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, Func<Type, object> getConstraintValueFromPartType) { throw null; }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+
+        public ImportConventionBuilder AllowDefault() { throw null; }
+
+        public ImportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ImportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ImportConventionBuilder AsMany() { throw null; }
+
+        public ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+
+        public T Import<T>() { throw null; }
+
+        public T Import<T>(Action<ImportConventionBuilder> configure) { throw null; }
+    }
+
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder AddPartMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+
+        public PartConventionBuilder Export() { throw null; }
+
+        public PartConventionBuilder Export(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder Export<T>() { throw null; }
+
+        public PartConventionBuilder Export<T>(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces() { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter, Action<Type, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder NotifyImportsSatisfied(Predicate<Reflection.MethodInfo> methodFilter) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector, Action<Reflection.ParameterInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector) { throw null; }
+
+        public PartConventionBuilder Shared() { throw null; }
+
+        public PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+
+    public partial class PartConventionBuilder<T> : PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> NotifyImportsSatisfied(Linq.Expressions.Expression<Action<T>> methodSelector) { throw null; }
+
+        public PartConventionBuilder<T> SelectConstructor(Linq.Expressions.Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/8.0.0/lib/net8.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/lib/net8.0/System.Composition.Convention.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types that support using Managed Extensibility Framework with a convention-based configuration model.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Convention.ConventionBuilder\r\nSystem.Composition.Convention.ExportConventionBuilder\r\nSystem.Composition.Convention.ImportConventionBuilder\r\nSystem.Composition.Convention.PartConventionBuilder\r\nSystem.Composition.Convention.ParameterImportConventionBuilder")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Convention")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : AttributedModelProvider
+    {
+        public PartConventionBuilder ForType(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForType<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesDerivedFrom(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesMatching(Predicate<Type> typeFilter) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesMatching<T>(Predicate<Type> typeFilter) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter) { throw null; }
+    }
+
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+
+        public ExportConventionBuilder AddMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+
+        public ExportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ExportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ExportConventionBuilder AsContractType(Type type) { throw null; }
+
+        public ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, Func<Type, object> getConstraintValueFromPartType) { throw null; }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+
+        public ImportConventionBuilder AllowDefault() { throw null; }
+
+        public ImportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ImportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ImportConventionBuilder AsMany() { throw null; }
+
+        public ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+
+        public T Import<T>() { throw null; }
+
+        public T Import<T>(Action<ImportConventionBuilder> configure) { throw null; }
+    }
+
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder AddPartMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+
+        public PartConventionBuilder Export() { throw null; }
+
+        public PartConventionBuilder Export(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder Export<T>() { throw null; }
+
+        public PartConventionBuilder Export<T>(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces() { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter, Action<Type, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder NotifyImportsSatisfied(Predicate<Reflection.MethodInfo> methodFilter) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector, Action<Reflection.ParameterInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector) { throw null; }
+
+        public PartConventionBuilder Shared() { throw null; }
+
+        public PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+
+    public partial class PartConventionBuilder<T> : PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> NotifyImportsSatisfied(Linq.Expressions.Expression<Action<T>> methodSelector) { throw null; }
+
+        public PartConventionBuilder<T> SelectConstructor(Linq.Expressions.Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/8.0.0/lib/netstandard2.0/System.Composition.Convention.cs
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/lib/netstandard2.0/System.Composition.Convention.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Convention")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types that support using Managed Extensibility Framework with a convention-based configuration model.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Convention.ConventionBuilder\r\nSystem.Composition.Convention.ExportConventionBuilder\r\nSystem.Composition.Convention.ImportConventionBuilder\r\nSystem.Composition.Convention.PartConventionBuilder\r\nSystem.Composition.Convention.ParameterImportConventionBuilder")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Convention")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Convention
+{
+    public partial class ConventionBuilder : AttributedModelProvider
+    {
+        public PartConventionBuilder ForType(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForType<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesDerivedFrom(Type type) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesDerivedFrom<T>() { throw null; }
+
+        public PartConventionBuilder ForTypesMatching(Predicate<Type> typeFilter) { throw null; }
+
+        public PartConventionBuilder<T> ForTypesMatching<T>(Predicate<Type> typeFilter) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.MemberInfo member) { throw null; }
+
+        public override Collections.Generic.IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, Reflection.ParameterInfo parameter) { throw null; }
+    }
+
+    public sealed partial class ExportConventionBuilder
+    {
+        internal ExportConventionBuilder() { }
+
+        public ExportConventionBuilder AddMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public ExportConventionBuilder AddMetadata(string name, object value) { throw null; }
+
+        public ExportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ExportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ExportConventionBuilder AsContractType(Type type) { throw null; }
+
+        public ExportConventionBuilder AsContractType<T>() { throw null; }
+    }
+
+    public sealed partial class ImportConventionBuilder
+    {
+        internal ImportConventionBuilder() { }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, Func<Type, object> getConstraintValueFromPartType) { throw null; }
+
+        public ImportConventionBuilder AddMetadataConstraint(string name, object value) { throw null; }
+
+        public ImportConventionBuilder AllowDefault() { throw null; }
+
+        public ImportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType) { throw null; }
+
+        public ImportConventionBuilder AsContractName(string contractName) { throw null; }
+
+        public ImportConventionBuilder AsMany() { throw null; }
+
+        public ImportConventionBuilder AsMany(bool isMany) { throw null; }
+    }
+
+    public abstract partial class ParameterImportConventionBuilder
+    {
+        internal ParameterImportConventionBuilder() { }
+
+        public T Import<T>() { throw null; }
+
+        public T Import<T>(Action<ImportConventionBuilder> configure) { throw null; }
+    }
+
+    public partial class PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder AddPartMetadata(string name, Func<Type, object> getValueFromPartType) { throw null; }
+
+        public PartConventionBuilder AddPartMetadata(string name, object value) { throw null; }
+
+        public PartConventionBuilder Export() { throw null; }
+
+        public PartConventionBuilder Export(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder Export<T>() { throw null; }
+
+        public PartConventionBuilder Export<T>(Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces() { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter, Action<Type, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder ExportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter, Action<Reflection.PropertyInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder ImportProperties<T>(Predicate<Reflection.PropertyInfo> propertyFilter) { throw null; }
+
+        public PartConventionBuilder NotifyImportsSatisfied(Predicate<Reflection.MethodInfo> methodFilter) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector, Action<Reflection.ParameterInfo, ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder SelectConstructor(Func<Collections.Generic.IEnumerable<Reflection.ConstructorInfo>, Reflection.ConstructorInfo> constructorSelector) { throw null; }
+
+        public PartConventionBuilder Shared() { throw null; }
+
+        public PartConventionBuilder Shared(string sharingBoundary) { throw null; }
+    }
+
+    public partial class PartConventionBuilder<T> : PartConventionBuilder
+    {
+        internal PartConventionBuilder() { }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ExportConventionBuilder> exportConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ExportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector, Action<ImportConventionBuilder> importConfiguration) { throw null; }
+
+        public PartConventionBuilder<T> ImportProperty<TContract>(Linq.Expressions.Expression<Func<T, object>> propertySelector) { throw null; }
+
+        public PartConventionBuilder<T> NotifyImportsSatisfied(Linq.Expressions.Expression<Action<T>> methodSelector) { throw null; }
+
+        public PartConventionBuilder<T> SelectConstructor(Linq.Expressions.Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.convention/8.0.0/system.composition.convention.nuspec
+++ b/src/referencePackages/src/system.composition.convention/8.0.0/system.composition.convention.nuspec
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Composition.Convention</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides types that support using Managed Extensibility Framework with a convention-based configuration model.
+
+Commonly Used Types:
+System.Composition.Convention.ConventionBuilder
+System.Composition.Convention.ExportConventionBuilder
+System.Composition.Convention.ImportConventionBuilder
+System.Composition.Convention.PartConventionBuilder
+System.Composition.Convention.ParameterImportConventionBuilder</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/System.Composition.Hosting.8.0.0.csproj
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/System.Composition.Hosting.8.0.0.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Composition.Hosting</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net6.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net6.0/System.Composition.Hosting.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Hosting.CompositionHost")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Hosting")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : CompositionContext, IDisposable
+    {
+        internal CompositionHost() { }
+
+        public static CompositionHost CreateCompositionHost(Collections.Generic.IEnumerable<Core.ExportDescriptorProvider> providers) { throw null; }
+
+        public static CompositionHost CreateCompositionHost(params Core.ExportDescriptorProvider[] providers) { throw null; }
+
+        public void Dispose() { }
+
+        public override bool TryGetExport(Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(LifetimeContext context, CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public bool IsPrerequisite { get { throw null; } }
+
+        public object Site { get { throw null; } }
+
+        public ExportDescriptorPromise Target { get { throw null; } }
+
+        public static CompositionDependency Missing(CompositionContract contract, object site) { throw null; }
+
+        public static CompositionDependency Oversupplied(CompositionContract contract, Collections.Generic.IEnumerable<ExportDescriptorPromise> targets, object site) { throw null; }
+
+        public static CompositionDependency Satisfied(CompositionContract contract, ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CompositionOperation : IDisposable
+    {
+        internal CompositionOperation() { }
+
+        public void AddNonPrerequisiteAction(Action action) { }
+
+        public void AddPostCompositionAction(Action action) { }
+
+        public void Dispose() { }
+
+        public static object Run(LifetimeContext outermostLifetimeContext, CompositeActivator compositionRootActivator) { throw null; }
+    }
+
+    public abstract partial class DependencyAccessor
+    {
+        protected abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetPromises(CompositionContract exportKey);
+        public Collections.Generic.IEnumerable<CompositionDependency> ResolveDependencies(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public CompositionDependency ResolveRequiredDependency(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public bool TryResolveOptionalDependency(object site, CompositionContract contract, bool isPrerequisite, out CompositionDependency dependency) { throw null; }
+    }
+
+    public abstract partial class ExportDescriptor
+    {
+        public abstract CompositeActivator Activator { get; }
+        public abstract Collections.Generic.IDictionary<string, object> Metadata { get; }
+
+        public static ExportDescriptor Create(CompositeActivator activator, Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(CompositionContract contract, string origin, bool isShared, Func<Collections.Generic.IEnumerable<CompositionDependency>> dependencies, Func<Collections.Generic.IEnumerable<CompositionDependency>, ExportDescriptor> getDescriptor) { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public Collections.ObjectModel.ReadOnlyCollection<CompositionDependency> Dependencies { get { throw null; } }
+
+        public bool IsShared { get { throw null; } }
+
+        public string Origin { get { throw null; } }
+
+        public ExportDescriptor GetDescriptor() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly Func<Collections.Generic.IEnumerable<CompositionDependency>> NoDependencies;
+        protected static readonly Collections.Generic.IEnumerable<ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly Collections.Generic.IDictionary<string, object> NoMetadata;
+        public abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor);
+    }
+
+    public sealed partial class LifetimeContext : CompositionContext, IDisposable
+    {
+        internal LifetimeContext() { }
+
+        public void AddBoundInstance(IDisposable instance) { }
+
+        public static int AllocateSharingId() { throw null; }
+
+        public void Dispose() { }
+
+        public LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+
+        public object GetOrCreate(int sharingId, CompositionOperation operation, CompositeActivator creator) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public override bool TryGetExport(CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net7.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net7.0/System.Composition.Hosting.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Hosting.CompositionHost")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Hosting")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : CompositionContext, IDisposable
+    {
+        internal CompositionHost() { }
+
+        public static CompositionHost CreateCompositionHost(Collections.Generic.IEnumerable<Core.ExportDescriptorProvider> providers) { throw null; }
+
+        public static CompositionHost CreateCompositionHost(params Core.ExportDescriptorProvider[] providers) { throw null; }
+
+        public void Dispose() { }
+
+        public override bool TryGetExport(Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(LifetimeContext context, CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public bool IsPrerequisite { get { throw null; } }
+
+        public object Site { get { throw null; } }
+
+        public ExportDescriptorPromise Target { get { throw null; } }
+
+        public static CompositionDependency Missing(CompositionContract contract, object site) { throw null; }
+
+        public static CompositionDependency Oversupplied(CompositionContract contract, Collections.Generic.IEnumerable<ExportDescriptorPromise> targets, object site) { throw null; }
+
+        public static CompositionDependency Satisfied(CompositionContract contract, ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CompositionOperation : IDisposable
+    {
+        internal CompositionOperation() { }
+
+        public void AddNonPrerequisiteAction(Action action) { }
+
+        public void AddPostCompositionAction(Action action) { }
+
+        public void Dispose() { }
+
+        public static object Run(LifetimeContext outermostLifetimeContext, CompositeActivator compositionRootActivator) { throw null; }
+    }
+
+    public abstract partial class DependencyAccessor
+    {
+        protected abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetPromises(CompositionContract exportKey);
+        public Collections.Generic.IEnumerable<CompositionDependency> ResolveDependencies(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public CompositionDependency ResolveRequiredDependency(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public bool TryResolveOptionalDependency(object site, CompositionContract contract, bool isPrerequisite, out CompositionDependency dependency) { throw null; }
+    }
+
+    public abstract partial class ExportDescriptor
+    {
+        public abstract CompositeActivator Activator { get; }
+        public abstract Collections.Generic.IDictionary<string, object> Metadata { get; }
+
+        public static ExportDescriptor Create(CompositeActivator activator, Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(CompositionContract contract, string origin, bool isShared, Func<Collections.Generic.IEnumerable<CompositionDependency>> dependencies, Func<Collections.Generic.IEnumerable<CompositionDependency>, ExportDescriptor> getDescriptor) { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public Collections.ObjectModel.ReadOnlyCollection<CompositionDependency> Dependencies { get { throw null; } }
+
+        public bool IsShared { get { throw null; } }
+
+        public string Origin { get { throw null; } }
+
+        public ExportDescriptor GetDescriptor() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly Func<Collections.Generic.IEnumerable<CompositionDependency>> NoDependencies;
+        protected static readonly Collections.Generic.IEnumerable<ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly Collections.Generic.IDictionary<string, object> NoMetadata;
+        public abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor);
+    }
+
+    public sealed partial class LifetimeContext : CompositionContext, IDisposable
+    {
+        internal LifetimeContext() { }
+
+        public void AddBoundInstance(IDisposable instance) { }
+
+        public static int AllocateSharingId() { throw null; }
+
+        public void Dispose() { }
+
+        public LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+
+        public object GetOrCreate(int sharingId, CompositionOperation operation, CompositeActivator creator) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public override bool TryGetExport(CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net8.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/lib/net8.0/System.Composition.Hosting.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Hosting.CompositionHost")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Hosting")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : CompositionContext, IDisposable
+    {
+        internal CompositionHost() { }
+
+        public static CompositionHost CreateCompositionHost(Collections.Generic.IEnumerable<Core.ExportDescriptorProvider> providers) { throw null; }
+
+        public static CompositionHost CreateCompositionHost(params Core.ExportDescriptorProvider[] providers) { throw null; }
+
+        public void Dispose() { }
+
+        public override bool TryGetExport(Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(LifetimeContext context, CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public bool IsPrerequisite { get { throw null; } }
+
+        public object Site { get { throw null; } }
+
+        public ExportDescriptorPromise Target { get { throw null; } }
+
+        public static CompositionDependency Missing(CompositionContract contract, object site) { throw null; }
+
+        public static CompositionDependency Oversupplied(CompositionContract contract, Collections.Generic.IEnumerable<ExportDescriptorPromise> targets, object site) { throw null; }
+
+        public static CompositionDependency Satisfied(CompositionContract contract, ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CompositionOperation : IDisposable
+    {
+        internal CompositionOperation() { }
+
+        public void AddNonPrerequisiteAction(Action action) { }
+
+        public void AddPostCompositionAction(Action action) { }
+
+        public void Dispose() { }
+
+        public static object Run(LifetimeContext outermostLifetimeContext, CompositeActivator compositionRootActivator) { throw null; }
+    }
+
+    public abstract partial class DependencyAccessor
+    {
+        protected abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetPromises(CompositionContract exportKey);
+        public Collections.Generic.IEnumerable<CompositionDependency> ResolveDependencies(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public CompositionDependency ResolveRequiredDependency(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public bool TryResolveOptionalDependency(object site, CompositionContract contract, bool isPrerequisite, out CompositionDependency dependency) { throw null; }
+    }
+
+    public abstract partial class ExportDescriptor
+    {
+        public abstract CompositeActivator Activator { get; }
+        public abstract Collections.Generic.IDictionary<string, object> Metadata { get; }
+
+        public static ExportDescriptor Create(CompositeActivator activator, Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(CompositionContract contract, string origin, bool isShared, Func<Collections.Generic.IEnumerable<CompositionDependency>> dependencies, Func<Collections.Generic.IEnumerable<CompositionDependency>, ExportDescriptor> getDescriptor) { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public Collections.ObjectModel.ReadOnlyCollection<CompositionDependency> Dependencies { get { throw null; } }
+
+        public bool IsShared { get { throw null; } }
+
+        public string Origin { get { throw null; } }
+
+        public ExportDescriptor GetDescriptor() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly Func<Collections.Generic.IEnumerable<CompositionDependency>> NoDependencies;
+        protected static readonly Collections.Generic.IEnumerable<ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly Collections.Generic.IDictionary<string, object> NoMetadata;
+        public abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor);
+    }
+
+    public sealed partial class LifetimeContext : CompositionContext, IDisposable
+    {
+        internal LifetimeContext() { }
+
+        public void AddBoundInstance(IDisposable instance) { }
+
+        public static int AllocateSharingId() { throw null; }
+
+        public void Dispose() { }
+
+        public LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+
+        public object GetOrCreate(int sharingId, CompositionOperation operation, CompositeActivator creator) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public override bool TryGetExport(CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/lib/netstandard2.0/System.Composition.Hosting.cs
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/lib/netstandard2.0/System.Composition.Hosting.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Hosting")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.Hosting.CompositionHost")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Hosting")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition.Hosting
+{
+    public sealed partial class CompositionHost : CompositionContext, IDisposable
+    {
+        internal CompositionHost() { }
+
+        public static CompositionHost CreateCompositionHost(Collections.Generic.IEnumerable<Core.ExportDescriptorProvider> providers) { throw null; }
+
+        public static CompositionHost CreateCompositionHost(params Core.ExportDescriptorProvider[] providers) { throw null; }
+
+        public void Dispose() { }
+
+        public override bool TryGetExport(Core.CompositionContract contract, out object export) { throw null; }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public delegate object CompositeActivator(LifetimeContext context, CompositionOperation operation);
+    public partial class CompositionDependency
+    {
+        internal CompositionDependency() { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public bool IsPrerequisite { get { throw null; } }
+
+        public object Site { get { throw null; } }
+
+        public ExportDescriptorPromise Target { get { throw null; } }
+
+        public static CompositionDependency Missing(CompositionContract contract, object site) { throw null; }
+
+        public static CompositionDependency Oversupplied(CompositionContract contract, Collections.Generic.IEnumerable<ExportDescriptorPromise> targets, object site) { throw null; }
+
+        public static CompositionDependency Satisfied(CompositionContract contract, ExportDescriptorPromise target, bool isPrerequisite, object site) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class CompositionOperation : IDisposable
+    {
+        internal CompositionOperation() { }
+
+        public void AddNonPrerequisiteAction(Action action) { }
+
+        public void AddPostCompositionAction(Action action) { }
+
+        public void Dispose() { }
+
+        public static object Run(LifetimeContext outermostLifetimeContext, CompositeActivator compositionRootActivator) { throw null; }
+    }
+
+    public abstract partial class DependencyAccessor
+    {
+        protected abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetPromises(CompositionContract exportKey);
+        public Collections.Generic.IEnumerable<CompositionDependency> ResolveDependencies(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public CompositionDependency ResolveRequiredDependency(object site, CompositionContract contract, bool isPrerequisite) { throw null; }
+
+        public bool TryResolveOptionalDependency(object site, CompositionContract contract, bool isPrerequisite, out CompositionDependency dependency) { throw null; }
+    }
+
+    public abstract partial class ExportDescriptor
+    {
+        public abstract CompositeActivator Activator { get; }
+        public abstract Collections.Generic.IDictionary<string, object> Metadata { get; }
+
+        public static ExportDescriptor Create(CompositeActivator activator, Collections.Generic.IDictionary<string, object> metadata) { throw null; }
+    }
+
+    public partial class ExportDescriptorPromise
+    {
+        public ExportDescriptorPromise(CompositionContract contract, string origin, bool isShared, Func<Collections.Generic.IEnumerable<CompositionDependency>> dependencies, Func<Collections.Generic.IEnumerable<CompositionDependency>, ExportDescriptor> getDescriptor) { }
+
+        public CompositionContract Contract { get { throw null; } }
+
+        public Collections.ObjectModel.ReadOnlyCollection<CompositionDependency> Dependencies { get { throw null; } }
+
+        public bool IsShared { get { throw null; } }
+
+        public string Origin { get { throw null; } }
+
+        public ExportDescriptor GetDescriptor() { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class ExportDescriptorProvider
+    {
+        protected static readonly Func<Collections.Generic.IEnumerable<CompositionDependency>> NoDependencies;
+        protected static readonly Collections.Generic.IEnumerable<ExportDescriptorPromise> NoExportDescriptors;
+        protected static readonly Collections.Generic.IDictionary<string, object> NoMetadata;
+        public abstract Collections.Generic.IEnumerable<ExportDescriptorPromise> GetExportDescriptors(CompositionContract contract, DependencyAccessor descriptorAccessor);
+    }
+
+    public sealed partial class LifetimeContext : CompositionContext, IDisposable
+    {
+        internal LifetimeContext() { }
+
+        public void AddBoundInstance(IDisposable instance) { }
+
+        public static int AllocateSharingId() { throw null; }
+
+        public void Dispose() { }
+
+        public LifetimeContext FindContextWithin(string sharingBoundary) { throw null; }
+
+        public object GetOrCreate(int sharingId, CompositionOperation operation, CompositeActivator creator) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public override bool TryGetExport(CompositionContract contract, out object export) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.hosting/8.0.0/system.composition.hosting.nuspec
+++ b/src/referencePackages/src/system.composition.hosting/8.0.0/system.composition.hosting.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Composition.Hosting</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides Managed Extensibility Framework types that are useful to developers of extensible applications, or hosts.
+
+Commonly Used Types:
+System.Composition.Hosting.CompositionHost</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/System.Composition.Runtime.8.0.0.csproj
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/System.Composition.Runtime.8.0.0.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Composition.Runtime</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net6.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net6.0/System.Composition.Runtime.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Contains runtime components of the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContext")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Runtime")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        public object GetExport(Hosting.Core.CompositionContract contract) { throw null; }
+
+        public object GetExport(Type exportType, string contractName) { throw null; }
+
+        public object GetExport(Type exportType) { throw null; }
+
+        public TExport GetExport<TExport>() { throw null; }
+
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType, string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType) { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+
+        public abstract bool TryGetExport(Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(Type exportType, out object export) { throw null; }
+
+        public bool TryGetExport(Type exportType, string contractName, out object export) { throw null; }
+
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+    }
+
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator) { }
+
+        public Export<T> CreateExport() { throw null; }
+    }
+
+    public partial class ExportFactory<T, TMetadata> : ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator, TMetadata metadata) : base(default!) { }
+
+        public TMetadata Metadata { get { throw null; } }
+    }
+
+    public sealed partial class Export<T> : IDisposable
+    {
+        public Export(T value, Action disposeAction) { }
+
+        public T Value { get { throw null; } }
+
+        public void Dispose() { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : Exception
+    {
+        public CompositionFailedException() { }
+
+        public CompositionFailedException(string message, Exception innerException) { }
+
+        public CompositionFailedException(string message) { }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(Type contractType, string contractName, Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+
+        public CompositionContract(Type contractType, string contractName) { }
+
+        public CompositionContract(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+
+        public CompositionContract ChangeType(Type newContractType) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net7.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net7.0/System.Composition.Runtime.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Contains runtime components of the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContext")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Runtime")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        public object GetExport(Hosting.Core.CompositionContract contract) { throw null; }
+
+        public object GetExport(Type exportType, string contractName) { throw null; }
+
+        public object GetExport(Type exportType) { throw null; }
+
+        public TExport GetExport<TExport>() { throw null; }
+
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType, string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType) { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+
+        public abstract bool TryGetExport(Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(Type exportType, out object export) { throw null; }
+
+        public bool TryGetExport(Type exportType, string contractName, out object export) { throw null; }
+
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+    }
+
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator) { }
+
+        public Export<T> CreateExport() { throw null; }
+    }
+
+    public partial class ExportFactory<T, TMetadata> : ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator, TMetadata metadata) : base(default!) { }
+
+        public TMetadata Metadata { get { throw null; } }
+    }
+
+    public sealed partial class Export<T> : IDisposable
+    {
+        public Export(T value, Action disposeAction) { }
+
+        public T Value { get { throw null; } }
+
+        public void Dispose() { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : Exception
+    {
+        public CompositionFailedException() { }
+
+        public CompositionFailedException(string message, Exception innerException) { }
+
+        public CompositionFailedException(string message) { }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(Type contractType, string contractName, Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+
+        public CompositionContract(Type contractType, string contractName) { }
+
+        public CompositionContract(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+
+        public CompositionContract ChangeType(Type newContractType) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net8.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/lib/net8.0/System.Composition.Runtime.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Contains runtime components of the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContext")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Runtime")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        public object GetExport(Hosting.Core.CompositionContract contract) { throw null; }
+
+        public object GetExport(Type exportType, string contractName) { throw null; }
+
+        public object GetExport(Type exportType) { throw null; }
+
+        public TExport GetExport<TExport>() { throw null; }
+
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType, string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType) { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+
+        public abstract bool TryGetExport(Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(Type exportType, out object export) { throw null; }
+
+        public bool TryGetExport(Type exportType, string contractName, out object export) { throw null; }
+
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+    }
+
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator) { }
+
+        public Export<T> CreateExport() { throw null; }
+    }
+
+    public partial class ExportFactory<T, TMetadata> : ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator, TMetadata metadata) : base(default!) { }
+
+        public TMetadata Metadata { get { throw null; } }
+    }
+
+    public sealed partial class Export<T> : IDisposable
+    {
+        public Export(T value, Action disposeAction) { }
+
+        public T Value { get { throw null; } }
+
+        public void Dispose() { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : Exception
+    {
+        public CompositionFailedException() { }
+
+        public CompositionFailedException(string message, Exception innerException) { }
+
+        public CompositionFailedException(string message) { }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(Type contractType, string contractName, Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+
+        public CompositionContract(Type contractType, string contractName) { }
+
+        public CompositionContract(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+
+        public CompositionContract ChangeType(Type newContractType) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/lib/netstandard2.0/System.Composition.Runtime.cs
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/lib/netstandard2.0/System.Composition.Runtime.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.Runtime")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Contains runtime components of the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContext")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.Runtime")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public abstract partial class CompositionContext
+    {
+        public object GetExport(Hosting.Core.CompositionContract contract) { throw null; }
+
+        public object GetExport(Type exportType, string contractName) { throw null; }
+
+        public object GetExport(Type exportType) { throw null; }
+
+        public TExport GetExport<TExport>() { throw null; }
+
+        public TExport GetExport<TExport>(string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType, string contractName) { throw null; }
+
+        public Collections.Generic.IEnumerable<object> GetExports(Type exportType) { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>() { throw null; }
+
+        public Collections.Generic.IEnumerable<TExport> GetExports<TExport>(string contractName) { throw null; }
+
+        public abstract bool TryGetExport(Hosting.Core.CompositionContract contract, out object export);
+        public bool TryGetExport(Type exportType, out object export) { throw null; }
+
+        public bool TryGetExport(Type exportType, string contractName, out object export) { throw null; }
+
+        public bool TryGetExport<TExport>(out TExport export) { throw null; }
+
+        public bool TryGetExport<TExport>(string contractName, out TExport export) { throw null; }
+    }
+
+    public partial class ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator) { }
+
+        public Export<T> CreateExport() { throw null; }
+    }
+
+    public partial class ExportFactory<T, TMetadata> : ExportFactory<T>
+    {
+        public ExportFactory(Func<Tuple<T, Action>> exportCreator, TMetadata metadata) : base(default!) { }
+
+        public TMetadata Metadata { get { throw null; } }
+    }
+
+    public sealed partial class Export<T> : IDisposable
+    {
+        public Export(T value, Action disposeAction) { }
+
+        public T Value { get { throw null; } }
+
+        public void Dispose() { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class CompositionFailedException : Exception
+    {
+        public CompositionFailedException() { }
+
+        public CompositionFailedException(string message, Exception innerException) { }
+
+        public CompositionFailedException(string message) { }
+    }
+}
+
+namespace System.Composition.Hosting.Core
+{
+    public sealed partial class CompositionContract
+    {
+        public CompositionContract(Type contractType, string contractName, Collections.Generic.IDictionary<string, object> metadataConstraints) { }
+
+        public CompositionContract(Type contractType, string contractName) { }
+
+        public CompositionContract(Type contractType) { }
+
+        public string ContractName { get { throw null; } }
+
+        public Type ContractType { get { throw null; } }
+
+        public Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, object>> MetadataConstraints { get { throw null; } }
+
+        public CompositionContract ChangeType(Type newContractType) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public bool TryUnwrapMetadataConstraint<T>(string constraintName, out T constraintValue, out CompositionContract remainingContract) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.runtime/8.0.0/system.composition.runtime.nuspec
+++ b/src/referencePackages/src/system.composition.runtime/8.0.0/system.composition.runtime.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Composition.Runtime</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Contains runtime components of the Managed Extensibility Framework.
+
+Commonly Used Types:
+System.Composition.CompositionContext</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/System.Composition.TypedParts.8.0.0.csproj
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/System.Composition.TypedParts.8.0.0.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Composition.TypedParts</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Composition.AttributedModel" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.Composition.Runtime" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net6.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net6.0/System.Composition.TypedParts.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides some extension methods for the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContextExtensions\r\nSystem.Composition.Hosting.ContainerConfiguration")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.TypedParts")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports, Convention.AttributedModelProvider conventions) { }
+
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports) { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public CompositionHost CreateContainer() { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly) { throw null; }
+
+        public ContainerConfiguration WithDefaultConventions(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType) { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>() { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes) { throw null; }
+
+        public ContainerConfiguration WithParts(params Type[] partTypes) { throw null; }
+
+        public ContainerConfiguration WithProvider(Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net7.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net7.0/System.Composition.TypedParts.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides some extension methods for the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContextExtensions\r\nSystem.Composition.Hosting.ContainerConfiguration")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.TypedParts")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports, Convention.AttributedModelProvider conventions) { }
+
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports) { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public CompositionHost CreateContainer() { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly) { throw null; }
+
+        public ContainerConfiguration WithDefaultConventions(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType) { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>() { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes) { throw null; }
+
+        public ContainerConfiguration WithParts(params Type[] partTypes) { throw null; }
+
+        public ContainerConfiguration WithProvider(Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net8.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/net8.0/System.Composition.TypedParts.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides some extension methods for the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContextExtensions\r\nSystem.Composition.Hosting.ContainerConfiguration")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.TypedParts")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports, Convention.AttributedModelProvider conventions) { }
+
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports) { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public CompositionHost CreateContainer() { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly) { throw null; }
+
+        public ContainerConfiguration WithDefaultConventions(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType) { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>() { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes) { throw null; }
+
+        public ContainerConfiguration WithParts(params Type[] partTypes) { throw null; }
+
+        public ContainerConfiguration WithProvider(Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/netstandard2.0/System.Composition.TypedParts.cs
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/lib/netstandard2.0/System.Composition.TypedParts.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Composition.TypedParts")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides some extension methods for the Managed Extensibility Framework.\r\n\r\nCommonly Used Types:\r\nSystem.Composition.CompositionContextExtensions\r\nSystem.Composition.Hosting.ContainerConfiguration")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Composition.TypedParts")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Composition
+{
+    public static partial class CompositionContextExtensions
+    {
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports, Convention.AttributedModelProvider conventions) { }
+
+        public static void SatisfyImports(this CompositionContext compositionContext, object objectWithLooseImports) { }
+    }
+}
+
+namespace System.Composition.Hosting
+{
+    public partial class ContainerConfiguration
+    {
+        public CompositionHost CreateContainer() { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssemblies(Collections.Generic.IEnumerable<Reflection.Assembly> assemblies) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithAssembly(Reflection.Assembly assembly) { throw null; }
+
+        public ContainerConfiguration WithDefaultConventions(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport(Type contractType, object exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance, string contractName = null, Collections.Generic.IDictionary<string, object> metadata = null) { throw null; }
+
+        public ContainerConfiguration WithExport<TExport>(TExport exportedInstance) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithPart(Type partType) { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>() { throw null; }
+
+        public ContainerConfiguration WithPart<TPart>(Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes, Convention.AttributedModelProvider conventions) { throw null; }
+
+        public ContainerConfiguration WithParts(Collections.Generic.IEnumerable<Type> partTypes) { throw null; }
+
+        public ContainerConfiguration WithParts(params Type[] partTypes) { throw null; }
+
+        public ContainerConfiguration WithProvider(Core.ExportDescriptorProvider exportDescriptorProvider) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.composition.typedparts/8.0.0/system.composition.typedparts.nuspec
+++ b/src/referencePackages/src/system.composition.typedparts/8.0.0/system.composition.typedparts.nuspec
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Composition.TypedParts</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides some extension methods for the Managed Extensibility Framework.
+
+Commonly Used Types:
+System.Composition.CompositionContextExtensions
+System.Composition.Hosting.ContainerConfiguration</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Hosting" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Hosting" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Hosting" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Composition.AttributedModel" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Hosting" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Composition.Runtime" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/System.IO.Pipelines.8.0.0.csproj
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/System.IO.Pipelines.8.0.0.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.IO.Pipelines</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net6.0/System.IO.Pipelines.cs
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net6.0/System.IO.Pipelines.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.IO.Pipelines.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.IO.Pipelines")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Single producer single consumer byte buffer management.\r\n\r\nCommonly Used Types:\r\nSystem.IO.Pipelines.Pipe\r\nSystem.IO.Pipelines.PipeWriter\r\nSystem.IO.Pipelines.PipeReader")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.IO.Pipelines")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.IO.Pipelines
+{
+    public partial struct FlushResult
+    {
+        private int _dummyPrimitive;
+        public FlushResult(bool isCanceled, bool isCompleted) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public partial interface IDuplexPipe
+    {
+        PipeReader Input { get; }
+
+        PipeWriter Output { get; }
+    }
+
+    public sealed partial class Pipe
+    {
+        public Pipe() { }
+
+        public Pipe(PipeOptions options) { }
+
+        public PipeReader Reader { get { throw null; } }
+
+        public PipeWriter Writer { get { throw null; } }
+
+        public void Reset() { }
+    }
+
+    public partial class PipeOptions
+    {
+        public PipeOptions(Buffers.MemoryPool<byte>? pool = null, PipeScheduler? readerScheduler = null, PipeScheduler? writerScheduler = null, long pauseWriterThreshold = -1, long resumeWriterThreshold = -1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
+
+        public static PipeOptions Default { get { throw null; } }
+
+        public int MinimumSegmentSize { get { throw null; } }
+
+        public long PauseWriterThreshold { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public PipeScheduler ReaderScheduler { get { throw null; } }
+
+        public long ResumeWriterThreshold { get { throw null; } }
+
+        public bool UseSynchronizationContext { get { throw null; } }
+
+        public PipeScheduler WriterScheduler { get { throw null; } }
+    }
+
+    public abstract partial class PipeReader
+    {
+        public abstract void AdvanceTo(SequencePosition consumed, SequencePosition examined);
+        public abstract void AdvanceTo(SequencePosition consumed);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingRead();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(Stream destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeReader Create(Buffers.ReadOnlySequence<byte> sequence) { throw null; }
+
+        public static PipeReader Create(Stream stream, StreamPipeReaderOptions? readerOptions = null) { throw null; }
+
+        [Obsolete("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
+        public virtual void OnWriterCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public abstract Threading.Tasks.ValueTask<ReadResult> ReadAsync(Threading.CancellationToken cancellationToken = default);
+        public Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        protected virtual Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract bool TryRead(out ReadResult result);
+    }
+
+    public abstract partial class PipeScheduler
+    {
+        public static PipeScheduler Inline { get { throw null; } }
+
+        public static PipeScheduler ThreadPool { get { throw null; } }
+
+        public abstract void Schedule(Action<object?> action, object? state);
+    }
+
+    public abstract partial class PipeWriter : Buffers.IBufferWriter<byte>
+    {
+        public virtual bool CanGetUnflushedBytes { get { throw null; } }
+
+        public virtual long UnflushedBytes { get { throw null; } }
+
+        public abstract void Advance(int bytes);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingFlush();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        protected internal virtual Threading.Tasks.Task CopyFromAsync(Stream source, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeWriter Create(Stream stream, StreamPipeWriterOptions? writerOptions = null) { throw null; }
+
+        public abstract Threading.Tasks.ValueTask<FlushResult> FlushAsync(Threading.CancellationToken cancellationToken = default);
+        public abstract Memory<byte> GetMemory(int sizeHint = 0);
+        public abstract Span<byte> GetSpan(int sizeHint = 0);
+        [Obsolete("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
+        public virtual void OnReaderCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public virtual Threading.Tasks.ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public readonly partial struct ReadResult
+    {
+        private readonly int _dummyPrimitive;
+        public ReadResult(Buffers.ReadOnlySequence<byte> buffer, bool isCanceled, bool isCompleted) { }
+
+        public Buffers.ReadOnlySequence<byte> Buffer { get { throw null; } }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public static partial class StreamPipeExtensions
+    {
+        public static Threading.Tasks.Task CopyToAsync(this Stream source, PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public partial class StreamPipeReaderOptions
+    {
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool = null, int bufferSize = -1, int minimumReadSize = -1, bool leaveOpen = false, bool useZeroByteReads = false) { }
+
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool, int bufferSize, int minimumReadSize, bool leaveOpen) { }
+
+        public int BufferSize { get { throw null; } }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumReadSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public bool UseZeroByteReads { get { throw null; } }
+    }
+
+    public partial class StreamPipeWriterOptions
+    {
+        public StreamPipeWriterOptions(Buffers.MemoryPool<byte>? pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumBufferSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net7.0/System.IO.Pipelines.cs
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net7.0/System.IO.Pipelines.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.IO.Pipelines.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.IO.Pipelines")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Single producer single consumer byte buffer management.\r\n\r\nCommonly Used Types:\r\nSystem.IO.Pipelines.Pipe\r\nSystem.IO.Pipelines.PipeWriter\r\nSystem.IO.Pipelines.PipeReader")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.IO.Pipelines")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.IO.Pipelines
+{
+    public partial struct FlushResult
+    {
+        private int _dummyPrimitive;
+        public FlushResult(bool isCanceled, bool isCompleted) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public partial interface IDuplexPipe
+    {
+        PipeReader Input { get; }
+
+        PipeWriter Output { get; }
+    }
+
+    public sealed partial class Pipe
+    {
+        public Pipe() { }
+
+        public Pipe(PipeOptions options) { }
+
+        public PipeReader Reader { get { throw null; } }
+
+        public PipeWriter Writer { get { throw null; } }
+
+        public void Reset() { }
+    }
+
+    public partial class PipeOptions
+    {
+        public PipeOptions(Buffers.MemoryPool<byte>? pool = null, PipeScheduler? readerScheduler = null, PipeScheduler? writerScheduler = null, long pauseWriterThreshold = -1, long resumeWriterThreshold = -1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
+
+        public static PipeOptions Default { get { throw null; } }
+
+        public int MinimumSegmentSize { get { throw null; } }
+
+        public long PauseWriterThreshold { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public PipeScheduler ReaderScheduler { get { throw null; } }
+
+        public long ResumeWriterThreshold { get { throw null; } }
+
+        public bool UseSynchronizationContext { get { throw null; } }
+
+        public PipeScheduler WriterScheduler { get { throw null; } }
+    }
+
+    public abstract partial class PipeReader
+    {
+        public abstract void AdvanceTo(SequencePosition consumed, SequencePosition examined);
+        public abstract void AdvanceTo(SequencePosition consumed);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingRead();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(Stream destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeReader Create(Buffers.ReadOnlySequence<byte> sequence) { throw null; }
+
+        public static PipeReader Create(Stream stream, StreamPipeReaderOptions? readerOptions = null) { throw null; }
+
+        [Obsolete("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
+        public virtual void OnWriterCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public abstract Threading.Tasks.ValueTask<ReadResult> ReadAsync(Threading.CancellationToken cancellationToken = default);
+        public Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        protected virtual Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract bool TryRead(out ReadResult result);
+    }
+
+    public abstract partial class PipeScheduler
+    {
+        public static PipeScheduler Inline { get { throw null; } }
+
+        public static PipeScheduler ThreadPool { get { throw null; } }
+
+        public abstract void Schedule(Action<object?> action, object? state);
+    }
+
+    public abstract partial class PipeWriter : Buffers.IBufferWriter<byte>
+    {
+        public virtual bool CanGetUnflushedBytes { get { throw null; } }
+
+        public virtual long UnflushedBytes { get { throw null; } }
+
+        public abstract void Advance(int bytes);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingFlush();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        protected internal virtual Threading.Tasks.Task CopyFromAsync(Stream source, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeWriter Create(Stream stream, StreamPipeWriterOptions? writerOptions = null) { throw null; }
+
+        public abstract Threading.Tasks.ValueTask<FlushResult> FlushAsync(Threading.CancellationToken cancellationToken = default);
+        public abstract Memory<byte> GetMemory(int sizeHint = 0);
+        public abstract Span<byte> GetSpan(int sizeHint = 0);
+        [Obsolete("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
+        public virtual void OnReaderCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public virtual Threading.Tasks.ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public readonly partial struct ReadResult
+    {
+        private readonly int _dummyPrimitive;
+        public ReadResult(Buffers.ReadOnlySequence<byte> buffer, bool isCanceled, bool isCompleted) { }
+
+        public Buffers.ReadOnlySequence<byte> Buffer { get { throw null; } }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public static partial class StreamPipeExtensions
+    {
+        public static Threading.Tasks.Task CopyToAsync(this Stream source, PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public partial class StreamPipeReaderOptions
+    {
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool = null, int bufferSize = -1, int minimumReadSize = -1, bool leaveOpen = false, bool useZeroByteReads = false) { }
+
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool, int bufferSize, int minimumReadSize, bool leaveOpen) { }
+
+        public int BufferSize { get { throw null; } }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumReadSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public bool UseZeroByteReads { get { throw null; } }
+    }
+
+    public partial class StreamPipeWriterOptions
+    {
+        public StreamPipeWriterOptions(Buffers.MemoryPool<byte>? pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumBufferSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net8.0/System.IO.Pipelines.cs
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/lib/net8.0/System.IO.Pipelines.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.IO.Pipelines.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.IO.Pipelines")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Single producer single consumer byte buffer management.\r\n\r\nCommonly Used Types:\r\nSystem.IO.Pipelines.Pipe\r\nSystem.IO.Pipelines.PipeWriter\r\nSystem.IO.Pipelines.PipeReader")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.IO.Pipelines")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.IO.Pipelines
+{
+    public partial struct FlushResult
+    {
+        private int _dummyPrimitive;
+        public FlushResult(bool isCanceled, bool isCompleted) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public partial interface IDuplexPipe
+    {
+        PipeReader Input { get; }
+
+        PipeWriter Output { get; }
+    }
+
+    public sealed partial class Pipe
+    {
+        public Pipe() { }
+
+        public Pipe(PipeOptions options) { }
+
+        public PipeReader Reader { get { throw null; } }
+
+        public PipeWriter Writer { get { throw null; } }
+
+        public void Reset() { }
+    }
+
+    public partial class PipeOptions
+    {
+        public PipeOptions(Buffers.MemoryPool<byte>? pool = null, PipeScheduler? readerScheduler = null, PipeScheduler? writerScheduler = null, long pauseWriterThreshold = -1, long resumeWriterThreshold = -1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
+
+        public static PipeOptions Default { get { throw null; } }
+
+        public int MinimumSegmentSize { get { throw null; } }
+
+        public long PauseWriterThreshold { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public PipeScheduler ReaderScheduler { get { throw null; } }
+
+        public long ResumeWriterThreshold { get { throw null; } }
+
+        public bool UseSynchronizationContext { get { throw null; } }
+
+        public PipeScheduler WriterScheduler { get { throw null; } }
+    }
+
+    public abstract partial class PipeReader
+    {
+        public abstract void AdvanceTo(SequencePosition consumed, SequencePosition examined);
+        public abstract void AdvanceTo(SequencePosition consumed);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingRead();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(Stream destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeReader Create(Buffers.ReadOnlySequence<byte> sequence) { throw null; }
+
+        public static PipeReader Create(Stream stream, StreamPipeReaderOptions? readerOptions = null) { throw null; }
+
+        [Obsolete("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
+        public virtual void OnWriterCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public abstract Threading.Tasks.ValueTask<ReadResult> ReadAsync(Threading.CancellationToken cancellationToken = default);
+        public Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        protected virtual Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract bool TryRead(out ReadResult result);
+    }
+
+    public abstract partial class PipeScheduler
+    {
+        public static PipeScheduler Inline { get { throw null; } }
+
+        public static PipeScheduler ThreadPool { get { throw null; } }
+
+        public abstract void Schedule(Action<object?> action, object? state);
+    }
+
+    public abstract partial class PipeWriter : Buffers.IBufferWriter<byte>
+    {
+        public virtual bool CanGetUnflushedBytes { get { throw null; } }
+
+        public virtual long UnflushedBytes { get { throw null; } }
+
+        public abstract void Advance(int bytes);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingFlush();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        protected internal virtual Threading.Tasks.Task CopyFromAsync(Stream source, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeWriter Create(Stream stream, StreamPipeWriterOptions? writerOptions = null) { throw null; }
+
+        public abstract Threading.Tasks.ValueTask<FlushResult> FlushAsync(Threading.CancellationToken cancellationToken = default);
+        public abstract Memory<byte> GetMemory(int sizeHint = 0);
+        public abstract Span<byte> GetSpan(int sizeHint = 0);
+        [Obsolete("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
+        public virtual void OnReaderCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public virtual Threading.Tasks.ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public readonly partial struct ReadResult
+    {
+        private readonly int _dummyPrimitive;
+        public ReadResult(Buffers.ReadOnlySequence<byte> buffer, bool isCanceled, bool isCompleted) { }
+
+        public Buffers.ReadOnlySequence<byte> Buffer { get { throw null; } }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public static partial class StreamPipeExtensions
+    {
+        public static Threading.Tasks.Task CopyToAsync(this Stream source, PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public partial class StreamPipeReaderOptions
+    {
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool = null, int bufferSize = -1, int minimumReadSize = -1, bool leaveOpen = false, bool useZeroByteReads = false) { }
+
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool, int bufferSize, int minimumReadSize, bool leaveOpen) { }
+
+        public int BufferSize { get { throw null; } }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumReadSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public bool UseZeroByteReads { get { throw null; } }
+    }
+
+    public partial class StreamPipeWriterOptions
+    {
+        public StreamPipeWriterOptions(Buffers.MemoryPool<byte>? pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumBufferSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/lib/netstandard2.0/System.IO.Pipelines.cs
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/lib/netstandard2.0/System.IO.Pipelines.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("System.IO.Pipelines.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.IO.Pipelines")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Single producer single consumer byte buffer management.\r\n\r\nCommonly Used Types:\r\nSystem.IO.Pipelines.Pipe\r\nSystem.IO.Pipelines.PipeWriter\r\nSystem.IO.Pipelines.PipeReader")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.IO.Pipelines")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.IO.Pipelines
+{
+    public partial struct FlushResult
+    {
+        private int _dummyPrimitive;
+        public FlushResult(bool isCanceled, bool isCompleted) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public partial interface IDuplexPipe
+    {
+        PipeReader Input { get; }
+
+        PipeWriter Output { get; }
+    }
+
+    public sealed partial class Pipe
+    {
+        public Pipe() { }
+
+        public Pipe(PipeOptions options) { }
+
+        public PipeReader Reader { get { throw null; } }
+
+        public PipeWriter Writer { get { throw null; } }
+
+        public void Reset() { }
+    }
+
+    public partial class PipeOptions
+    {
+        public PipeOptions(Buffers.MemoryPool<byte>? pool = null, PipeScheduler? readerScheduler = null, PipeScheduler? writerScheduler = null, long pauseWriterThreshold = -1, long resumeWriterThreshold = -1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
+
+        public static PipeOptions Default { get { throw null; } }
+
+        public int MinimumSegmentSize { get { throw null; } }
+
+        public long PauseWriterThreshold { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public PipeScheduler ReaderScheduler { get { throw null; } }
+
+        public long ResumeWriterThreshold { get { throw null; } }
+
+        public bool UseSynchronizationContext { get { throw null; } }
+
+        public PipeScheduler WriterScheduler { get { throw null; } }
+    }
+
+    public abstract partial class PipeReader
+    {
+        public abstract void AdvanceTo(SequencePosition consumed, SequencePosition examined);
+        public abstract void AdvanceTo(SequencePosition consumed);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingRead();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Threading.Tasks.Task CopyToAsync(Stream destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeReader Create(Buffers.ReadOnlySequence<byte> sequence) { throw null; }
+
+        public static PipeReader Create(Stream stream, StreamPipeReaderOptions? readerOptions = null) { throw null; }
+
+        [Obsolete("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
+        public virtual void OnWriterCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public abstract Threading.Tasks.ValueTask<ReadResult> ReadAsync(Threading.CancellationToken cancellationToken = default);
+        public Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        protected virtual Threading.Tasks.ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, Threading.CancellationToken cancellationToken) { throw null; }
+
+        public abstract bool TryRead(out ReadResult result);
+    }
+
+    public abstract partial class PipeScheduler
+    {
+        public static PipeScheduler Inline { get { throw null; } }
+
+        public static PipeScheduler ThreadPool { get { throw null; } }
+
+        public abstract void Schedule(Action<object?> action, object? state);
+    }
+
+    public abstract partial class PipeWriter : Buffers.IBufferWriter<byte>
+    {
+        public virtual bool CanGetUnflushedBytes { get { throw null; } }
+
+        public virtual long UnflushedBytes { get { throw null; } }
+
+        public abstract void Advance(int bytes);
+        public virtual Stream AsStream(bool leaveOpen = false) { throw null; }
+
+        public abstract void CancelPendingFlush();
+        public abstract void Complete(Exception? exception = null);
+        public virtual Threading.Tasks.ValueTask CompleteAsync(Exception? exception = null) { throw null; }
+
+        protected internal virtual Threading.Tasks.Task CopyFromAsync(Stream source, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static PipeWriter Create(Stream stream, StreamPipeWriterOptions? writerOptions = null) { throw null; }
+
+        public abstract Threading.Tasks.ValueTask<FlushResult> FlushAsync(Threading.CancellationToken cancellationToken = default);
+        public abstract Memory<byte> GetMemory(int sizeHint = 0);
+        public abstract Span<byte> GetSpan(int sizeHint = 0);
+        [Obsolete("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
+        public virtual void OnReaderCompleted(Action<Exception?, object?> callback, object? state) { }
+
+        public virtual Threading.Tasks.ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public readonly partial struct ReadResult
+    {
+        private readonly int _dummyPrimitive;
+        public ReadResult(Buffers.ReadOnlySequence<byte> buffer, bool isCanceled, bool isCompleted) { }
+
+        public Buffers.ReadOnlySequence<byte> Buffer { get { throw null; } }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+    }
+
+    public static partial class StreamPipeExtensions
+    {
+        public static Threading.Tasks.Task CopyToAsync(this Stream source, PipeWriter destination, Threading.CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public partial class StreamPipeReaderOptions
+    {
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool = null, int bufferSize = -1, int minimumReadSize = -1, bool leaveOpen = false, bool useZeroByteReads = false) { }
+
+        public StreamPipeReaderOptions(Buffers.MemoryPool<byte>? pool, int bufferSize, int minimumReadSize, bool leaveOpen) { }
+
+        public int BufferSize { get { throw null; } }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumReadSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+
+        public bool UseZeroByteReads { get { throw null; } }
+    }
+
+    public partial class StreamPipeWriterOptions
+    {
+        public StreamPipeWriterOptions(Buffers.MemoryPool<byte>? pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
+
+        public bool LeaveOpen { get { throw null; } }
+
+        public int MinimumBufferSize { get { throw null; } }
+
+        public Buffers.MemoryPool<byte> Pool { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.io.pipelines/8.0.0/system.io.pipelines.nuspec
+++ b/src/referencePackages/src/system.io.pipelines/8.0.0/system.io.pipelines.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.IO.Pipelines</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Single producer single consumer byte buffer management.
+
+Commonly Used Types:
+System.IO.Pipelines.Pipe
+System.IO.Pipelines.PipeWriter
+System.IO.Pipelines.PipeReader</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.memory/4.5.5/lib/netstandard1.1/System.Memory.cs
+++ b/src/referencePackages/src/system.memory/4.5.5/lib/netstandard1.1/System.Memory.cs
@@ -303,7 +303,7 @@ namespace System
         public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
     }
 
-    public readonly partial struct ReadOnlySpan<T>
+    public readonly ref partial struct ReadOnlySpan<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -352,7 +352,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public partial struct Enumerator
+        public ref partial struct Enumerator
         {
             private ReadOnlySpan<T> _span;
             private object _dummy;
@@ -380,7 +380,7 @@ namespace System
         public readonly object GetObject() { throw null; }
     }
 
-    public readonly partial struct Span<T>
+    public readonly ref partial struct Span<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -435,7 +435,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public partial struct Enumerator
+        public ref partial struct Enumerator
         {
             private Span<T> _span;
             private object _dummy;

--- a/src/referencePackages/src/system.memory/4.5.5/lib/netstandard1.1/System.Memory.cs
+++ b/src/referencePackages/src/system.memory/4.5.5/lib/netstandard1.1/System.Memory.cs
@@ -303,7 +303,7 @@ namespace System
         public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
     }
 
-    public readonly ref partial struct ReadOnlySpan<T>
+    public readonly partial struct ReadOnlySpan<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -327,7 +327,7 @@ namespace System
         [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
         public override readonly bool Equals(object obj) { throw null; }
 
-        public readonly ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         [Obsolete("GetHashCode() on ReadOnlySpan will always throw an exception.")]
         public override readonly int GetHashCode() { throw null; }
@@ -352,7 +352,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public ref partial struct Enumerator
+        public partial struct Enumerator
         {
             private ReadOnlySpan<T> _span;
             private object _dummy;
@@ -380,7 +380,7 @@ namespace System
         public readonly object GetObject() { throw null; }
     }
 
-    public readonly ref partial struct Span<T>
+    public readonly partial struct Span<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -408,7 +408,7 @@ namespace System
 
         public readonly void Fill(T value) { }
 
-        public readonly Span<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         [Obsolete("GetHashCode() on Span will always throw an exception.")]
         public override readonly int GetHashCode() { throw null; }
@@ -435,7 +435,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public ref partial struct Enumerator
+        public partial struct Enumerator
         {
             private Span<T> _span;
             private object _dummy;
@@ -562,7 +562,7 @@ namespace System.Buffers
 
         public SequencePosition Start { get { throw null; } }
 
-        public readonly ReadOnlySequence<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         public readonly SequencePosition GetPosition(long offset, SequencePosition origin) { throw null; }
 

--- a/src/referencePackages/src/system.memory/4.5.5/lib/netstandard2.0/System.Memory.cs
+++ b/src/referencePackages/src/system.memory/4.5.5/lib/netstandard2.0/System.Memory.cs
@@ -303,7 +303,7 @@ namespace System
         public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
     }
 
-    public readonly partial struct ReadOnlySpan<T>
+    public readonly ref partial struct ReadOnlySpan<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -352,7 +352,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public partial struct Enumerator
+        public ref partial struct Enumerator
         {
             private ReadOnlySpan<T> _span;
             private object _dummy;
@@ -380,7 +380,7 @@ namespace System
         public readonly object GetObject() { throw null; }
     }
 
-    public readonly partial struct Span<T>
+    public readonly ref partial struct Span<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -435,7 +435,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public partial struct Enumerator
+        public ref partial struct Enumerator
         {
             private Span<T> _span;
             private object _dummy;

--- a/src/referencePackages/src/system.memory/4.5.5/lib/netstandard2.0/System.Memory.cs
+++ b/src/referencePackages/src/system.memory/4.5.5/lib/netstandard2.0/System.Memory.cs
@@ -303,7 +303,7 @@ namespace System
         public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
     }
 
-    public readonly ref partial struct ReadOnlySpan<T>
+    public readonly partial struct ReadOnlySpan<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -327,7 +327,7 @@ namespace System
         [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
         public override readonly bool Equals(object obj) { throw null; }
 
-        public readonly ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         [Obsolete("GetHashCode() on ReadOnlySpan will always throw an exception.")]
         public override readonly int GetHashCode() { throw null; }
@@ -352,7 +352,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public ref partial struct Enumerator
+        public partial struct Enumerator
         {
             private ReadOnlySpan<T> _span;
             private object _dummy;
@@ -380,7 +380,7 @@ namespace System
         public readonly object GetObject() { throw null; }
     }
 
-    public readonly ref partial struct Span<T>
+    public readonly partial struct Span<T>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -408,7 +408,7 @@ namespace System
 
         public readonly void Fill(T value) { }
 
-        public readonly Span<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         [Obsolete("GetHashCode() on Span will always throw an exception.")]
         public override readonly int GetHashCode() { throw null; }
@@ -435,7 +435,7 @@ namespace System
 
         public readonly bool TryCopyTo(Span<T> destination) { throw null; }
 
-        public ref partial struct Enumerator
+        public partial struct Enumerator
         {
             private Span<T> _span;
             private object _dummy;
@@ -562,7 +562,7 @@ namespace System.Buffers
 
         public SequencePosition Start { get { throw null; } }
 
-        public readonly ReadOnlySequence<T>.Enumerator GetEnumerator() { throw null; }
+        public readonly Enumerator GetEnumerator() { throw null; }
 
         public readonly SequencePosition GetPosition(long offset, SequencePosition origin) { throw null; }
 

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
@@ -142,6 +142,12 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
+
+        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
@@ -142,12 +142,6 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
-
-        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
@@ -142,6 +142,12 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
+
+        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
@@ -142,12 +142,6 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
-
-        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.0/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.0/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: System.Runtime.CompilerServices.ReferenceAssembly]
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]

--- a/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.2/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.2/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: AssemblyMetadata("BuildLabel", "130703.2")]
 [assembly: AssemblyMetadata("BuildBranch", "Release\\ReferenceAssemblies\\1.0")]
 [assembly: AssemblyProduct("Microsoft® .NET Framework")]

--- a/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.3/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.3/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]

--- a/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.5/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.1.0/ref/netstandard1.5/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]

--- a/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.0/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.0/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: System.Runtime.CompilerServices.ReferenceAssembly]
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]

--- a/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.2/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.2/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: AssemblyMetadata("BuildLabel", "130703.2")]
 [assembly: AssemblyMetadata("BuildBranch", "Release\\ReferenceAssemblies\\1.0")]
 [assembly: AssemblyProduct("Microsoft® .NET Framework")]

--- a/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.3/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.3/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
@@ -4676,7 +4673,7 @@ namespace System.Runtime.CompilerServices
 
         public TValue GetOrCreateValue(TKey key) { throw null; }
 
-        public TValue GetValue(TKey key, ConditionalWeakTable<TKey, TValue>.CreateValueCallback createValueCallback) { throw null; }
+        public TValue GetValue(TKey key, CreateValueCallback createValueCallback) { throw null; }
 
         public Boolean Remove(TKey key) { throw null; }
 

--- a/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.5/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.0/ref/netstandard1.5/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
@@ -4682,7 +4679,7 @@ namespace System.Runtime.CompilerServices
 
         public TValue GetOrCreateValue(TKey key) { throw null; }
 
-        public TValue GetValue(TKey key, ConditionalWeakTable<TKey, TValue>.CreateValueCallback createValueCallback) { throw null; }
+        public TValue GetValue(TKey key, CreateValueCallback createValueCallback) { throw null; }
 
         public Boolean Remove(TKey key) { throw null; }
 

--- a/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.0/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.0/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: System.Runtime.CompilerServices.ReferenceAssembly]
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]

--- a/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.2/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.2/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: AssemblyMetadata("BuildLabel", "130703.2")]
 [assembly: AssemblyMetadata("BuildBranch", "Release\\ReferenceAssemblies\\1.0")]
 [assembly: AssemblyProduct("Microsoft® .NET Framework")]

--- a/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.3/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.3/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]

--- a/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.5/System.Runtime.cs
+++ b/src/referencePackages/src/system.runtime/4.3.1/ref/netstandard1.5/System.Runtime.cs
@@ -4,9 +4,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the http://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 [assembly: CompilationRelaxations(8)]
 [assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
 [assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]

--- a/src/referencePackages/src/system.runtime/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime/Directory.Build.props
@@ -6,4 +6,8 @@
     <AssemblyName>System.Runtime</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="Usings.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/referencePackages/src/system.runtime/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime/Directory.Build.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Usings.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Usings.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.runtime/Directory.Build.props
+++ b/src/referencePackages/src/system.runtime/Directory.Build.props
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Usings.cs" />
+    <Using Include="System" />
+    <Using Include="System.Reflection" />
+    <Using Include="System.Runtime.CompilerServices" />
   </ItemGroup>
 
 </Project>

--- a/src/referencePackages/src/system.runtime/Usings.cs
+++ b/src/referencePackages/src/system.runtime/Usings.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is necessary to workaround an issue with GenAPI simplifying the compilation unit
+// and removing usings incorrectly, but only for System.Runtime.
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;

--- a/src/referencePackages/src/system.runtime/Usings.cs
+++ b/src/referencePackages/src/system.runtime/Usings.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-// This is necessary to workaround an issue with GenAPI simplifying the compilation unit
-// and removing usings incorrectly, but only for System.Runtime.
-using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/System.Text.Encoding.CodePages.8.0.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/System.Text.Encoding.CodePages.8.0.0.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net6.0/System.Text.Encoding.CodePages.cs
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net6.0/System.Text.Encoding.CodePages.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Encoding.CodePages")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.\r\n\r\nCommonly Used Types:\r\nSystem.Text.CodePagesEncodingProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Encoding.CodePages")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : EncodingProvider
+    {
+        internal CodePagesEncodingProvider() { }
+
+        public static EncodingProvider Instance { get { throw null; } }
+
+        public override Encoding? GetEncoding(int codepage) { throw null; }
+
+        public override Encoding? GetEncoding(string name) { throw null; }
+
+        public override Collections.Generic.IEnumerable<EncodingInfo> GetEncodings() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net7.0/System.Text.Encoding.CodePages.cs
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net7.0/System.Text.Encoding.CodePages.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Encoding.CodePages")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.\r\n\r\nCommonly Used Types:\r\nSystem.Text.CodePagesEncodingProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Encoding.CodePages")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : EncodingProvider
+    {
+        internal CodePagesEncodingProvider() { }
+
+        public static EncodingProvider Instance { get { throw null; } }
+
+        public override Encoding? GetEncoding(int codepage) { throw null; }
+
+        public override Encoding? GetEncoding(string name) { throw null; }
+
+        public override Collections.Generic.IEnumerable<EncodingInfo> GetEncodings() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net8.0/System.Text.Encoding.CodePages.cs
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/net8.0/System.Text.Encoding.CodePages.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Encoding.CodePages")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.\r\n\r\nCommonly Used Types:\r\nSystem.Text.CodePagesEncodingProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Encoding.CodePages")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : EncodingProvider
+    {
+        internal CodePagesEncodingProvider() { }
+
+        public static EncodingProvider Instance { get { throw null; } }
+
+        public override Encoding? GetEncoding(int codepage) { throw null; }
+
+        public override Encoding? GetEncoding(string name) { throw null; }
+
+        public override Collections.Generic.IEnumerable<EncodingInfo> GetEncodings() { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/netstandard2.0/System.Text.Encoding.CodePages.cs
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/lib/netstandard2.0/System.Text.Encoding.CodePages.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Encoding.CodePages")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.\r\n\r\nCommonly Used Types:\r\nSystem.Text.CodePagesEncodingProvider")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Encoding.CodePages")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : EncodingProvider
+    {
+        internal CodePagesEncodingProvider() { }
+
+        public static EncodingProvider Instance { get { throw null; } }
+
+        public override Encoding? GetEncoding(int codepage) { throw null; }
+
+        public override Encoding? GetEncoding(string name) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.nuspec
+++ b/src/referencePackages/src/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Text.Encoding.CodePages</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides support for code-page based encodings, including Windows-1252, Shift-JIS, and GB2312.
+
+Commonly Used Types:
+System.Text.CodePagesEncodingProvider</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.threading.channels/8.0.0/System.Threading.Channels.8.0.0.csproj
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/System.Threading.Channels.8.0.0.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <AssemblyName>System.Threading.Channels</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.threading.channels/8.0.0/lib/net6.0/System.Threading.Channels.cs
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/lib/net6.0/System.Threading.Channels.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Channels")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types for passing data between producers and consumers.\r\n\r\nCommonly Used Types:\r\nSystem.Threading.Channel\r\nSystem.Threading.Channel<T>")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Channels")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Threading.Channels
+{
+    public enum BoundedChannelFullMode
+    {
+        Wait = 0,
+        DropNewest = 1,
+        DropOldest = 2,
+        DropWrite = 3
+    }
+
+    public sealed partial class BoundedChannelOptions : ChannelOptions
+    {
+        public BoundedChannelOptions(int capacity) { }
+
+        public int Capacity { get { throw null; } set { } }
+
+        public BoundedChannelFullMode FullMode { get { throw null; } set { } }
+    }
+
+    public static partial class Channel
+    {
+        public static Channel<T> CreateBounded<T>(int capacity) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>() { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options) { throw null; }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() { }
+
+        public ChannelClosedException(Exception? innerException) { }
+
+        protected ChannelClosedException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public ChannelClosedException(string? message, Exception? innerException) { }
+
+        public ChannelClosedException(string? message) { }
+    }
+
+    public abstract partial class ChannelOptions
+    {
+        public bool AllowSynchronousContinuations { get { throw null; } set { } }
+
+        public bool SingleReader { get { throw null; } set { } }
+
+        public bool SingleWriter { get { throw null; } set { } }
+    }
+
+    public abstract partial class ChannelReader<T>
+    {
+        public virtual bool CanCount { get { throw null; } }
+
+        public virtual bool CanPeek { get { throw null; } }
+
+        public virtual Tasks.Task Completion { get { throw null; } }
+
+        public virtual int Count { get { throw null; } }
+
+        public virtual Collections.Generic.IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Tasks.ValueTask<T> ReadAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual bool TryPeek(out T item) { throw null; }
+
+        public abstract bool TryRead(out T item);
+        public abstract Tasks.ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);
+    }
+
+    public abstract partial class ChannelWriter<T>
+    {
+        public void Complete(Exception? error = null) { }
+
+        public virtual bool TryComplete(Exception? error = null) { throw null; }
+
+        public abstract bool TryWrite(T item);
+        public abstract Tasks.ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
+        public virtual Tasks.ValueTask WriteAsync(T item, CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public abstract partial class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract partial class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get { throw null; } protected set { } }
+
+        public ChannelWriter<TWrite> Writer { get { throw null; } protected set { } }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) { throw null; }
+
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) { throw null; }
+    }
+
+    public sealed partial class UnboundedChannelOptions : ChannelOptions
+    {
+    }
+}

--- a/src/referencePackages/src/system.threading.channels/8.0.0/lib/net7.0/System.Threading.Channels.cs
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/lib/net7.0/System.Threading.Channels.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Channels")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types for passing data between producers and consumers.\r\n\r\nCommonly Used Types:\r\nSystem.Threading.Channel\r\nSystem.Threading.Channel<T>")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Channels")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Threading.Channels
+{
+    public enum BoundedChannelFullMode
+    {
+        Wait = 0,
+        DropNewest = 1,
+        DropOldest = 2,
+        DropWrite = 3
+    }
+
+    public sealed partial class BoundedChannelOptions : ChannelOptions
+    {
+        public BoundedChannelOptions(int capacity) { }
+
+        public int Capacity { get { throw null; } set { } }
+
+        public BoundedChannelFullMode FullMode { get { throw null; } set { } }
+    }
+
+    public static partial class Channel
+    {
+        public static Channel<T> CreateBounded<T>(int capacity) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>() { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options) { throw null; }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() { }
+
+        public ChannelClosedException(Exception? innerException) { }
+
+        protected ChannelClosedException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public ChannelClosedException(string? message, Exception? innerException) { }
+
+        public ChannelClosedException(string? message) { }
+    }
+
+    public abstract partial class ChannelOptions
+    {
+        public bool AllowSynchronousContinuations { get { throw null; } set { } }
+
+        public bool SingleReader { get { throw null; } set { } }
+
+        public bool SingleWriter { get { throw null; } set { } }
+    }
+
+    public abstract partial class ChannelReader<T>
+    {
+        public virtual bool CanCount { get { throw null; } }
+
+        public virtual bool CanPeek { get { throw null; } }
+
+        public virtual Tasks.Task Completion { get { throw null; } }
+
+        public virtual int Count { get { throw null; } }
+
+        public virtual Collections.Generic.IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Tasks.ValueTask<T> ReadAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual bool TryPeek(out T item) { throw null; }
+
+        public abstract bool TryRead(out T item);
+        public abstract Tasks.ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);
+    }
+
+    public abstract partial class ChannelWriter<T>
+    {
+        public void Complete(Exception? error = null) { }
+
+        public virtual bool TryComplete(Exception? error = null) { throw null; }
+
+        public abstract bool TryWrite(T item);
+        public abstract Tasks.ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
+        public virtual Tasks.ValueTask WriteAsync(T item, CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public abstract partial class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract partial class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get { throw null; } protected set { } }
+
+        public ChannelWriter<TWrite> Writer { get { throw null; } protected set { } }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) { throw null; }
+
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) { throw null; }
+    }
+
+    public sealed partial class UnboundedChannelOptions : ChannelOptions
+    {
+    }
+}

--- a/src/referencePackages/src/system.threading.channels/8.0.0/lib/net8.0/System.Threading.Channels.cs
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/lib/net8.0/System.Threading.Channels.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Channels")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types for passing data between producers and consumers.\r\n\r\nCommonly Used Types:\r\nSystem.Threading.Channel\r\nSystem.Threading.Channel<T>")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Channels")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Threading.Channels
+{
+    public enum BoundedChannelFullMode
+    {
+        Wait = 0,
+        DropNewest = 1,
+        DropOldest = 2,
+        DropWrite = 3
+    }
+
+    public sealed partial class BoundedChannelOptions : ChannelOptions
+    {
+        public BoundedChannelOptions(int capacity) { }
+
+        public int Capacity { get { throw null; } set { } }
+
+        public BoundedChannelFullMode FullMode { get { throw null; } set { } }
+    }
+
+    public static partial class Channel
+    {
+        public static Channel<T> CreateBounded<T>(int capacity) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>() { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options) { throw null; }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() { }
+
+        public ChannelClosedException(Exception? innerException) { }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected ChannelClosedException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public ChannelClosedException(string? message, Exception? innerException) { }
+
+        public ChannelClosedException(string? message) { }
+    }
+
+    public abstract partial class ChannelOptions
+    {
+        public bool AllowSynchronousContinuations { get { throw null; } set { } }
+
+        public bool SingleReader { get { throw null; } set { } }
+
+        public bool SingleWriter { get { throw null; } set { } }
+    }
+
+    public abstract partial class ChannelReader<T>
+    {
+        public virtual bool CanCount { get { throw null; } }
+
+        public virtual bool CanPeek { get { throw null; } }
+
+        public virtual Tasks.Task Completion { get { throw null; } }
+
+        public virtual int Count { get { throw null; } }
+
+        public virtual Collections.Generic.IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Tasks.ValueTask<T> ReadAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual bool TryPeek(out T item) { throw null; }
+
+        public abstract bool TryRead(out T item);
+        public abstract Tasks.ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);
+    }
+
+    public abstract partial class ChannelWriter<T>
+    {
+        public void Complete(Exception? error = null) { }
+
+        public virtual bool TryComplete(Exception? error = null) { throw null; }
+
+        public abstract bool TryWrite(T item);
+        public abstract Tasks.ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
+        public virtual Tasks.ValueTask WriteAsync(T item, CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public abstract partial class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract partial class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get { throw null; } protected set { } }
+
+        public ChannelWriter<TWrite> Writer { get { throw null; } protected set { } }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) { throw null; }
+
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) { throw null; }
+    }
+
+    public sealed partial class UnboundedChannelOptions : ChannelOptions
+    {
+    }
+}

--- a/src/referencePackages/src/system.threading.channels/8.0.0/lib/netstandard2.0/System.Threading.Channels.cs
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/lib/netstandard2.0/System.Threading.Channels.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Channels")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types for passing data between producers and consumers.\r\n\r\nCommonly Used Types:\r\nSystem.Threading.Channel\r\nSystem.Threading.Channel<T>")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Channels")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Threading.Channels
+{
+    public enum BoundedChannelFullMode
+    {
+        Wait = 0,
+        DropNewest = 1,
+        DropOldest = 2,
+        DropWrite = 3
+    }
+
+    public sealed partial class BoundedChannelOptions : ChannelOptions
+    {
+        public BoundedChannelOptions(int capacity) { }
+
+        public int Capacity { get { throw null; } set { } }
+
+        public BoundedChannelFullMode FullMode { get { throw null; } set { } }
+    }
+
+    public static partial class Channel
+    {
+        public static Channel<T> CreateBounded<T>(int capacity) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>() { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options) { throw null; }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() { }
+
+        public ChannelClosedException(Exception? innerException) { }
+
+        public ChannelClosedException(string? message, Exception? innerException) { }
+
+        public ChannelClosedException(string? message) { }
+    }
+
+    public abstract partial class ChannelOptions
+    {
+        public bool AllowSynchronousContinuations { get { throw null; } set { } }
+
+        public bool SingleReader { get { throw null; } set { } }
+
+        public bool SingleWriter { get { throw null; } set { } }
+    }
+
+    public abstract partial class ChannelReader<T>
+    {
+        public virtual bool CanCount { get { throw null; } }
+
+        public virtual bool CanPeek { get { throw null; } }
+
+        public virtual Tasks.Task Completion { get { throw null; } }
+
+        public virtual int Count { get { throw null; } }
+
+        public virtual Tasks.ValueTask<T> ReadAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual bool TryPeek(out T item) { throw null; }
+
+        public abstract bool TryRead(out T item);
+        public abstract Tasks.ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);
+    }
+
+    public abstract partial class ChannelWriter<T>
+    {
+        public void Complete(Exception? error = null) { }
+
+        public virtual bool TryComplete(Exception? error = null) { throw null; }
+
+        public abstract bool TryWrite(T item);
+        public abstract Tasks.ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
+        public virtual Tasks.ValueTask WriteAsync(T item, CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public abstract partial class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract partial class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get { throw null; } protected set { } }
+
+        public ChannelWriter<TWrite> Writer { get { throw null; } protected set { } }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) { throw null; }
+
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) { throw null; }
+    }
+
+    public sealed partial class UnboundedChannelOptions : ChannelOptions
+    {
+    }
+}

--- a/src/referencePackages/src/system.threading.channels/8.0.0/lib/netstandard2.1/System.Threading.Channels.cs
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/lib/netstandard2.1/System.Threading.Channels.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName = ".NET Standard 2.1")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Channels")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides types for passing data between producers and consumers.\r\n\r\nCommonly Used Types:\r\nSystem.Threading.Channel\r\nSystem.Threading.Channel<T>")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Channels")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Threading.Channels
+{
+    public enum BoundedChannelFullMode
+    {
+        Wait = 0,
+        DropNewest = 1,
+        DropOldest = 2,
+        DropWrite = 3
+    }
+
+    public sealed partial class BoundedChannelOptions : ChannelOptions
+    {
+        public BoundedChannelOptions(int capacity) { }
+
+        public int Capacity { get { throw null; } set { } }
+
+        public BoundedChannelFullMode FullMode { get { throw null; } set { } }
+    }
+
+    public static partial class Channel
+    {
+        public static Channel<T> CreateBounded<T>(int capacity) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options, Action<T>? itemDropped) { throw null; }
+
+        public static Channel<T> CreateBounded<T>(BoundedChannelOptions options) { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>() { throw null; }
+
+        public static Channel<T> CreateUnbounded<T>(UnboundedChannelOptions options) { throw null; }
+    }
+
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        public ChannelClosedException() { }
+
+        public ChannelClosedException(Exception? innerException) { }
+
+        protected ChannelClosedException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public ChannelClosedException(string? message, Exception? innerException) { }
+
+        public ChannelClosedException(string? message) { }
+    }
+
+    public abstract partial class ChannelOptions
+    {
+        public bool AllowSynchronousContinuations { get { throw null; } set { } }
+
+        public bool SingleReader { get { throw null; } set { } }
+
+        public bool SingleWriter { get { throw null; } set { } }
+    }
+
+    public abstract partial class ChannelReader<T>
+    {
+        public virtual bool CanCount { get { throw null; } }
+
+        public virtual bool CanPeek { get { throw null; } }
+
+        public virtual Tasks.Task Completion { get { throw null; } }
+
+        public virtual int Count { get { throw null; } }
+
+        public virtual Collections.Generic.IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual Tasks.ValueTask<T> ReadAsync(CancellationToken cancellationToken = default) { throw null; }
+
+        public virtual bool TryPeek(out T item) { throw null; }
+
+        public abstract bool TryRead(out T item);
+        public abstract Tasks.ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default);
+    }
+
+    public abstract partial class ChannelWriter<T>
+    {
+        public void Complete(Exception? error = null) { }
+
+        public virtual bool TryComplete(Exception? error = null) { throw null; }
+
+        public abstract bool TryWrite(T item);
+        public abstract Tasks.ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default);
+        public virtual Tasks.ValueTask WriteAsync(T item, CancellationToken cancellationToken = default) { throw null; }
+    }
+
+    public abstract partial class Channel<T> : Channel<T, T>
+    {
+    }
+
+    public abstract partial class Channel<TWrite, TRead>
+    {
+        public ChannelReader<TRead> Reader { get { throw null; } protected set { } }
+
+        public ChannelWriter<TWrite> Writer { get { throw null; } protected set { } }
+
+        public static implicit operator ChannelReader<TRead>(Channel<TWrite, TRead> channel) { throw null; }
+
+        public static implicit operator ChannelWriter<TWrite>(Channel<TWrite, TRead> channel) { throw null; }
+    }
+
+    public sealed partial class UnboundedChannelOptions : ChannelOptions
+    {
+    }
+}

--- a/src/referencePackages/src/system.threading.channels/8.0.0/system.threading.channels.nuspec
+++ b/src/referencePackages/src/system.threading.channels/8.0.0/system.threading.channels.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Threading.Channels</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides types for passing data between producers and consumers.
+
+Commonly Used Types:
+System.Threading.Channel
+System.Threading.Channel&lt;T&gt;</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/lib/netstandard1.0/System.Threading.Tasks.Extensions.cs
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/lib/netstandard1.0/System.Threading.Tasks.Extensions.cs
@@ -105,7 +105,7 @@ namespace System.Runtime.CompilerServices
         private readonly Threading.Tasks.ValueTask<TResult> _value;
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public readonly ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
+        public readonly ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
 
         public readonly partial struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
         {

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/lib/netstandard2.0/System.Threading.Tasks.Extensions.cs
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/lib/netstandard2.0/System.Threading.Tasks.Extensions.cs
@@ -105,7 +105,7 @@ namespace System.Runtime.CompilerServices
         private readonly Threading.Tasks.ValueTask<TResult> _value;
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
-        public readonly ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
+        public readonly ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
 
         public readonly partial struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
         {

--- a/src/referencePackages/src/system.threading.tasks/4.3.0/ref/netstandard1.0/System.Threading.Tasks.cs
+++ b/src/referencePackages/src/system.threading.tasks/4.3.0/ref/netstandard1.0/System.Threading.Tasks.cs
@@ -150,7 +150,7 @@ namespace System.Runtime.CompilerServices
 
     public partial struct ConfiguredTaskAwaitable<TResult>
     {
-        public ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
+        public ConfiguredTaskAwaiter GetAwaiter() { throw null; }
 
         public partial struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
         {

--- a/src/referencePackages/src/system.threading.tasks/4.3.0/ref/netstandard1.3/System.Threading.Tasks.cs
+++ b/src/referencePackages/src/system.threading.tasks/4.3.0/ref/netstandard1.3/System.Threading.Tasks.cs
@@ -153,7 +153,7 @@ namespace System.Runtime.CompilerServices
 
     public partial struct ConfiguredTaskAwaitable<TResult>
     {
-        public ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter GetAwaiter() { throw null; }
+        public ConfiguredTaskAwaiter GetAwaiter() { throw null; }
 
         public partial struct ConfiguredTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
         {


### PR DESCRIPTION
... necessary to consume new Roslyn dependencies. Roslyn recently updated to 8.0.0 dependencies which makes this change necessary.

Unblocks https://github.com/dotnet/runtime/pull/97152