### PR TITLE
Manually add API that isn't present in the contract assembly

### DIFF
--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.4.3.0.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <!-- Needs additional APIs that don't exist in the contract. -->
+    <Compile Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.Manual.cs" />
+
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
@@ -40,6 +43,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+    <!-- Needs additional APIs that don't exist in the contract. -->
+    <Compile Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.Manual.cs" />
+
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.Manual.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/System.Runtime.InteropServices.Manual.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+// See https://github.com/dotnet/source-build/issues/4000 for why this is necessary.
+
+namespace System.Runtime.InteropServices
+{
+    public partial class ComAwareEventInfo : Reflection.EventInfo
+    {
+        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
+
+        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netcoreapp1.1/System.Runtime.InteropServices.cs
@@ -142,12 +142,6 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
-
-        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
+++ b/src/referencePackages/src/system.runtime.interopservices/4.3.0/ref/netstandard1.5/System.Runtime.InteropServices.cs
@@ -142,12 +142,6 @@ namespace System.Runtime.InteropServices
         public override void AddEventHandler(object target, Delegate handler) { }
 
         public override void RemoveEventHandler(object target, Delegate handler) { }
-
-        public override Reflection.MethodInfo GetAddMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRaiseMethod(bool nonPublic) { throw null; }
-
-        public override Reflection.MethodInfo GetRemoveMethod(bool nonPublic) { throw null; }
     }
 
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]


### PR DESCRIPTION
... but that is required by the compiler (base type abstract member). For more details see discussion in
https://github.com/dotnet/source-build/issues/4000

Fixes https://github.com/dotnet/source-build/issues/4000

Without this change, GenAPI removes these API members every time the package is re-generated.