### PR TITLE
Add CollectionBuilderAttribute to System.Collections.Immutable

### DIFF
--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -112,7 +112,7 @@
           AfterTargets="CopyFilesToOutputDirectory">
 
     <ItemGroup>
-      <CompileWithRelativePath Include="@(Compile)" Condition="!$([System.String]::new('%(Identity)').StartsWith('/'))" />
+      <CompileWithRelativePath Include="@(Compile)" Condition="!$([System.String]::new('%(Identity)').StartsWith('%(RootDir)'))" />
     </ItemGroup>
 
     <Error

--- a/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.8.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.8.0.0.csproj
@@ -5,6 +5,11 @@
     <AssemblyName>System.Collections.Immutable</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <!-- Include CollectionBuilderAttribute that is defined internally. -->
+    <Compile Include="$(MSBuildThisFileDirectory)System.Collections.Immutable.Manual.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>

--- a/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.Manual.cs
+++ b/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.Manual.cs
@@ -1,3 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+// See https://github.com/dotnet/sdk/issues/33693 for why this is necessary.
 
 namespace System.Collections.Immutable
 {

--- a/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.Manual.cs
+++ b/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.Manual.cs
@@ -1,0 +1,53 @@
+
+namespace System.Collections.Immutable
+{
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableList), "Create")]
+    public partial interface IImmutableList<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableQueue), "Create")]
+    public partial interface IImmutableQueue<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableHashSet), "Create")]
+    public partial interface IImmutableSet<T> 
+    {}
+    
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableStack), "Create")]
+    public partial interface IImmutableStack<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableArray), "Create")]
+    public readonly partial struct ImmutableArray<T> 
+    {}
+    
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableHashSet), "Create")]
+    public sealed partial class ImmutableHashSet<T>
+    {}
+    
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableList), "Create")]
+    public sealed partial class ImmutableList<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableQueue), "Create")]
+    public sealed partial class ImmutableQueue<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableSortedSet), "Create")]
+    public sealed partial class ImmutableSortedSet<T>
+    {}
+
+    [Runtime.CompilerServices.CollectionBuilder(typeof(ImmutableStack), "Create")]
+    public sealed partial class ImmutableStack<T>
+    {}
+}
+
+namespace System.Runtime.CompilerServices
+{
+    internal sealed class CollectionBuilderAttribute(Type builderType, string methodName) : Attribute
+    {
+        public Type BuilderType { get; } = builderType;
+
+        public string MethodName { get; } = methodName;
+    }
+}


### PR DESCRIPTION
CollectionBuilderAttribute is another attribute that's used to light-up compiler API.  This attribute is filtered by GenAPI.

Add it back manually to support Collection expressions with immutable collections.

https://github.com/dotnet/sdk/issues/33693