### PR TITLE
Update property name for additional build arguments

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -13,7 +13,7 @@
     <PropertyGroup>
       <LocalNuGetPackageCacheDirectory Condition="'$(LocalNuGetPackageCacheDirectory)' == ''">$(CurrentRepoSourceBuiltNupkgCacheDir)</LocalNuGetPackageCacheDirectory>
       <_AdditionalDependencyProjectsBuildArgs />
-      <_AdditionalDependencyProjectsBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalRepoTaskBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</_AdditionalDependencyProjectsBuildArgs>
+      <_AdditionalDependencyProjectsBuildArgs Condition="'$(RestoreConfigFile)' != ''" >$(_AdditionalDependencyProjectsBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</_AdditionalDependencyProjectsBuildArgs>
     </PropertyGroup>
 
     <MakeDir Condition="'$(LocalNuGetPackageCacheDirectory)' != ''"


### PR DESCRIPTION
Fixes the property name that was introduced with https://github.com/dotnet/source-build-reference-packages/pull/880
