### PR TITLE
Migrate to 1ES templates

### DIFF
--- a/azure-pipelines/builds/ci-public.yml
+++ b/azure-pipelines/builds/ci-public.yml
@@ -1,0 +1,20 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+
+variables:
+- template: /azure-pipelines/templates/variables/common.yml
+
+stages:
+- template: /azure-pipelines/templates/stages/build.yml
+  parameters:
+    engCommonTemplatesDir: ${{ variables.EngCommonTemplatesDir }}

--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -12,71 +12,30 @@ pr:
     - release/*
 
 variables:
-  - template: /eng/common/templates/variables/pool-providers.yml
+- template: /azure-pipelines/templates/variables/common.yml
 
-  - name: Codeql.Enabled
-    value: true
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - job: Linux
-    pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-      ${{ else }}:
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
-    container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
-    steps:
-    - template: /eng/common/templates/steps/source-build.yml
-
-    - script: $(Build.SourcesDirectory)/test.sh
-      displayName: Run Tests
-    
-    - task: PublishTestResults@2
-      displayName: Publish Test Results
-      inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
-        testRunTitle: 'Linux_SBRP_tests'
-      condition: always()
-
-  ## The job below is a temporary workaround for running the tests on Windows.
-  ## Currently, the source-build-reference-packages repository does not support building on Windows, but it is capable of running the generate tooling tests on Windows.
-  ## This job should be modified once the source-build-reference-packages repository supports building on Windows by transitioning to the template above.
-  - job: Windows
+        image: 1es-windows-2022-pt
+        os: windows
     pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals 1es-windows-2022-open
-      ${{ else }}:
-        name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals 1es-windows-2022
-    container: mcr.microsoft.com/windows/servercore:ltsc2022
-    steps:
-    - checkout: self
-      clean: true
-  
-    - script: $(Build.SourcesDirectory)/test.cmd
-      displayName: Run Tests
-  
-    - task: PublishTestResults@2
-      displayName: Publish Test Results
-      inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
-        testRunTitle: 'Windows_SBRP_tests'
-      condition: always()
-
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/publish-build-assets.yml
+      name: $(DncEngInternalBuildPool)
+      image: 1es-ubuntu-2204-pt
+      os: linux
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - template: /azure-pipelines/templates/stages/build.yml@self
       parameters:
-        dependsOn:
-        - Linux
-        - Windows
-        publishUsingPipelines: true
-        publishAssetsImmediately: true
-        enablePublishBuildArtifacts: true
+        engCommonTemplatesDir: ${{ variables.EngCommonTemplatesDir }}

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -1,0 +1,67 @@
+parameters:
+  engCommonTemplatesDir: ''
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - job: Linux
+    pool:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: $(DncEngPublicBuildPool)
+        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-ubuntu-2204-pt
+        os: linux
+    container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+    steps:
+    - template: ${{ parameters.engCommonTemplatesDir }}/steps/source-build.yml
+
+    - script: $(Build.SourcesDirectory)/test.sh
+      displayName: Run Tests
+
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
+        testRunTitle: 'Linux_SBRP_tests'
+      condition: always()
+
+  ## The job below is a temporary workaround for running the tests on Windows.
+  ## Currently, the source-build-reference-packages repository does not support building on Windows, but it is capable of running the generate tooling tests on Windows.
+  ## This job should be modified once the source-build-reference-packages repository supports building on Windows by transitioning to the template above.
+  - job: Windows
+    pool:
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        name: $(DncEngPublicBuildPool)
+        demands: ImageOverride -equals 1es-windows-2022-open
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022-pt
+        os: windows
+    container: mcr.microsoft.com/windows/servercore:ltsc2022
+    steps:
+    - checkout: self
+      clean: true
+
+    - script: $(Build.SourcesDirectory)/test.cmd
+      displayName: Run Tests
+
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
+        testRunTitle: 'Windows_SBRP_tests'
+      condition: always()
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+      parameters:
+        dependsOn:
+        - Linux
+        - Windows
+        publishUsingPipelines: true
+        publishAssetsImmediately: true
+        enablePublishBuildArtifacts: true

--- a/azure-pipelines/templates/variables/common.yml
+++ b/azure-pipelines/templates/variables/common.yml
@@ -1,0 +1,11 @@
+variables:
+- name: EngCommonTemplatesDir
+  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    value: /eng/common/templates
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    value: /eng/common/templates-official
+- template: ${{ variables.EngCommonTemplatesDir }}/variables/pool-providers.yml@self
+- name: Codeql.Enabled
+  value: true
+- name: TeamName
+  value: DotNetSourceBuild


### PR DESCRIPTION
Splits the existing CI pipeline into two separate pipelines:
* ci-public.yml: for public builds - This is the same as the original content except that conditional logic has been removed that was meant to support internal builds.
* ci.yml: for internal builds - Uses the 1ES pipeline template pattern

Unlike the changes in https://github.com/dotnet/source-build-externals/pull/274, I was able to factor the jobs into a separate template since this pipeline uses Arcade differently and doesn't run into the same [issue](https://github.com/dotnet/source-build-externals/pull/274#discussion_r1517948643).

Due to an SDL failure, this is blocked until the changes from https://github.com/dotnet/arcade/pull/14553 flow in.