### PR TITLE
Migrate to 1ES templates

### DIFF
--- a/azure-pipelines/builds/ci-public.yml
+++ b/azure-pipelines/builds/ci-public.yml
@@ -1,0 +1,20 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+    - release/*
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*
+
+variables:
+- template: /azure-pipelines/templates/variables/common.yml
+
+stages:
+- template: /azure-pipelines/templates/stages/build.yml
+  parameters:
+    engCommonTemplatesDir: ${{ variables.EngCommonTemplatesDir }}

--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -11,27 +11,27 @@ pr:
     - main
     - release/*
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enablePublishUsingPipelines: true
-      enablePublishBuildArtifacts: true
-      enablePublishBuildAssets: true
-      artifacts:
-        publish:
-          artifacts: true
-          manifests: true
-      enableSourceBuild: true
+variables:
+- template: /azure-pipelines/templates/variables/common.yml
 
-# Based on - https://github.com/dotnet/arcade/blob/9b3f304c7bc9fd4d11be9ca0b466b83e98d2a191/Documentation/CorePackages/Publishing.md#moving-away-from-the-legacy-pushtoblobfeed-task
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      enableSourceLinkValidation: true
-      #Nuget and Signing Validation are not needed as we only produce a transport package.
-      enableSigningValidation: false
-      enableNugetValidation: false
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - template: /azure-pipelines/templates/stages/build.yml
+      parameters:
+        engCommonTemplatesDir: ${{ variables.EngCommonTemplatesDir }}

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -1,0 +1,26 @@
+parameters:
+  engCommonTemplatesDir: ''
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: ${{ parameters.engCommonTemplatesDir }}/jobs/jobs.yml
+    parameters:
+      enablePublishUsingPipelines: true
+      enablePublishBuildArtifacts: true
+      enablePublishBuildAssets: true
+      artifacts:
+        publish:
+          artifacts: true
+          manifests: true
+      enableSourceBuild: true
+# Based on - https://github.com/dotnet/arcade/blob/9b3f304c7bc9fd4d11be9ca0b466b83e98d2a191/Documentation/CorePackages/Publishing.md#moving-away-from-the-legacy-pushtoblobfeed-task
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: ${{ parameters.engCommonTemplatesDir }}/post-build/post-build.yml
+    parameters:
+      publishingInfraVersion: 3
+      enableSourceLinkValidation: true
+      #Nuget and Signing Validation are not needed as we only produce a transport package.
+      enableSigningValidation: false
+      enableNugetValidation: false

--- a/azure-pipelines/templates/variables/common.yml
+++ b/azure-pipelines/templates/variables/common.yml
@@ -1,0 +1,11 @@
+variables:
+- name: EngCommonTemplatesDir
+  ${{ if eq(variables['System.TeamProject'], 'public') }}:
+    value: /eng/common/templates
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    value: /eng/common/templates-official
+- template: ${{ variables.EngCommonTemplatesDir }}/variables/pool-providers.yml@self
+- name: Codeql.Enabled
+  value: true
+- name: TeamName
+  value: DotNetSourceBuild


### PR DESCRIPTION
Port of https://github.com/dotnet/source-build-reference-packages/pull/909

[Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2411962&view=results) (internal link)