### PR TITLE
Migrate off deprecated "pt" pool image

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -27,11 +27,11 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-ubuntu-2204-pt
+      image: 1es-ubuntu-2204
       os: linux
     customBuildTags:
     - ES365AIMigrationTooling

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -12,7 +12,7 @@ stages:
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-ubuntu-2204-pt
+        image: 1es-ubuntu-2204
         os: linux
     container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
     steps:
@@ -39,7 +39,7 @@ stages:
         demands: ImageOverride -equals 1es-windows-2022-open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022-pt
+        image: 1es-windows-2022
         os: windows
     container: mcr.microsoft.com/windows/servercore:ltsc2022
     steps:


### PR DESCRIPTION
The `-pt` pool images are deprecated and will be deleted soon. Migrating to the supported image names instead.