### PR TITLE
Update self-reference to address CG alert

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.22570.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="6.0.0-servicing.24222.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>38385bc8b19cebe7ae7d20771646158785ee5bdc</Sha>
+      <Sha>86390422715f8f11400ff7fca9c2449888e47b6e</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.24204.4">


### PR DESCRIPTION
Updates SBRP's self-reference in order to address the CG alert originally mentioned in https://github.com/dotnet/source-build/issues/4243