### PR TITLE
Use NuGet.Packaging 6.7.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
     <!-- NuGet dependencies -->
-    <NuGetPackagingVersion>6.7.0</NuGetPackagingVersion>
+    <NuGetPackagingVersion>6.7.1</NuGetPackagingVersion>
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>


### PR DESCRIPTION
Fixes the CG alert for NuGet.Packaging.6.7.0 by upgrading to NuGet.Packaging.6.7.1