### PR TITLE
CodeQL suppression for CipherMode

### DIFF
--- a/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/ref/netstandard1.3/System.Security.Cryptography.Primitives.cs
+++ b/src/referencePackages/src/system.security.cryptography.primitives/4.3.0/ref/netstandard1.3/System.Security.Cryptography.Primitives.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography
     public enum CipherMode
     {
         CBC = 1,
-        ECB = 2,
+        ECB = 2, // CodeQL [SM02299] This just defines the API and doesn't represent usage // CodeQL [SM00395] This just defines the API and doesn't represent usage
         CTS = 5
     }
 


### PR DESCRIPTION
CodeQL is complaining about the definition of `CipherMode.ECB` since usage of it is [vulnerable](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5358).

But this code doesn't represent usage. It's purely a definition of the API that's triggering the CodeQL alert. Because of that, I've added suppressions for the two separate alerts. And yes, this is the syntax that's necessary for multiple alerts.