### PR TITLE
Clean-up unnecessary dependencies and update msbuild and nuget

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-   <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
-   </PropertyGroup>
-</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,13 +9,10 @@
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Arcade dependencies -->
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.20113.5</MicrosoftDotNetBuildTasksPackagingPackageVersion>
     <!-- MSBuild dependencies -->
-    <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.8.3</MicrosoftBuildUtilitiesCoreVersion>
     <!-- NuGet dependencies -->
-    <NuGetPackagingVersion>6.7.1</NuGetPackagingVersion>
+    <NuGetPackagingVersion>6.8.1</NuGetPackagingVersion>
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
@@ -7,7 +7,6 @@
 
   <!-- Do not include assemblies that ship inside the SDK. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
The Publishing.props file isn't necessary anymore as PublishingVersion already defaults to 3.
The `MicrosoftDotNetBuildTasksPackagingPackageVersion` property isn't used.
The Microsoft.Build package reference is unnecessary.