### PR TITLE
Update Nuget.Packaging reference version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
     <!-- MSBuild dependencies -->
     <MicrosoftBuildUtilitiesCoreVersion>17.8.3</MicrosoftBuildUtilitiesCoreVersion>
     <!-- NuGet dependencies -->
-    <NuGetPackagingVersion>6.8.1</NuGetPackagingVersion>
+    <NuGetPackagingVersion>6.11.0</NuGetPackagingVersion>
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4518 (see https://github.com/dotnet/source-build/issues/4518#issuecomment-2287250159)

The alerts also extended to a transitive dependency for System.Formats.Asn1.6.0.0 which was being pulled in by the version of Nuget.Packaging we were using in our test project and the package source generator project.

I'm not sure if this version of Nuget.Packaging needs to be added as an SBRP or not.