### PR TITLE
Add direct reference to System.Formats.Asn1.6.0.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>
+    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
     <!-- SDK dependencies -->
     <MicrosoftDotNetGenAPITaskPackageVersion>9.0.100-rc.1.24409.1</MicrosoftDotNetGenAPITaskPackageVersion>
     <!-- xUnit dependencies -->

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
+    <!-- Transitive dependency of Nuget.Packaging. Needed to fix CVE for 6.0.0. -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
   </ItemGroup>
 
 </Project>

--- a/tests/SbrpTests/Sbrp.Tests.csproj
+++ b/tests/SbrpTests/Sbrp.Tests.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
     <PackageReference Include="Xunit.SkippableFact" Version="$(XunitSkippableFactVersion)" />
+    <!-- Transitive dependency of Nuget.Packaging. Needed to fix CVE for 6.0.0. -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4518

https://github.com/dotnet/source-build-reference-packages/pull/1006 didn't fix the issue like I had initially thought.

After looking through the binlogs, it appears that the min version required is still 6.0.0. Since Nuget.Packaging.6.11.0 (the primary package pulling in Asn1) is the latest version, the fix to address the vulnerability is to take an explicit dependency on Asn1 6.0.1. I verified that this pulls in 6.0.1 by investigating the binlogs and using the `dotnet depends` tool.