### PR TITLE
Add direct reference to System.Formats.Asn1.6.0.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,6 +19,7 @@
     <!-- Runtime dependencies -->
     <MicrosoftNETCoreILAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreILDAsmVersion>6.0.0-preview.6.21352.12</MicrosoftNETCoreILDAsmVersion>
+    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
     <!-- SDK dependencies -->
     <MicrosoftDotNetGenAPITaskPackageVersion>8.0.100-rc.2.23460.8</MicrosoftDotNetGenAPITaskPackageVersion>
   </PropertyGroup>

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/PackageSourceGeneratorTask.csproj
@@ -10,6 +10,8 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" ExcludeAssets="runtime" PrivateAssets="all" />
+    <!-- Transitive dependency of Nuget.Packaging. Needed to fix CVE for 6.0.0. -->
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4518

Port of https://github.com/dotnet/source-build-reference-packages/pull/1008 to 8.0 branch. The dependency is not being used in the test projects like in the main branch, so the dependency only needs to be specified for the PackageSourceGeneratorTask in 8.0.