### PR TITLE
Update source-build team references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When generating a package(s), the tooling will detect and generate all dependent
 
 **Note:** All new packages should be for released stable versions. Adding preview/release candidate
 packages are for exceptional cases only and require approval from
-[dotnet/source-build-internal](https://github.com/orgs/dotnet/teams/source-build-internal).
+[dotnet/source-build](https://github.com/orgs/dotnet/teams/source-build).
 
 **Note:** Reference packages should only be added to this repo if they are required during the product
 source build (e.g. a [VMR](https://github.com/dotnet/dotnet) build). Reference packages that are only

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file, please include @dotnet/product-construction as a reviewer. -->
 
 <Project>
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
 <!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>


### PR DESCRIPTION
The source-build-internal team is being deprecated. All references to it were updated.

Related to https://github.com/dotnet/source-build/issues/4645