### PR TITLE
Flow the DotNetBuildOrchestrator property to the DependencyPackageProject inner build

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -26,18 +26,7 @@
          and because this target executes before Execute, the build will infinitely recurse. This probably could be fixed in other ways, but
          given that SBRP is slated at some point to get proper support for project refs as a replacement for this invocation, this isn't really worth doing. -->
     <Exec
-      Command="./build.sh ^
-        --configuration $(Configuration) ^
-        /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog ^
-        /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) ^
-        /p:SourceBuildOutputDir=$(SourceBuildOutputDir) ^
-        /p:BuildDependencyPackageProjects=true ^
-        /p:SetUpSourceBuildIntermediateNupkgCache=true ^
-        /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator) ^
-        /p:DotNetBuildSourceOnly=true ^
-        /p:DotNetBuildInnerRepo=true ^
-        /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId) ^
-        $(_AdditionalDependencyProjectsBuildArgs)"
+      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:SourceBuildOutputDir=$(SourceBuildOutputDir) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator) /p:DotNetBuildSourceOnly=true /p:DotNetBuildInnerRepo=true /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId) $(_AdditionalDependencyProjectsBuildArgs)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -26,7 +26,18 @@
          and because this target executes before Execute, the build will infinitely recurse. This probably could be fixed in other ways, but
          given that SBRP is slated at some point to get proper support for project refs as a replacement for this invocation, this isn't really worth doing. -->
     <Exec
-      Command="./build.sh --configuration $(Configuration) /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) /p:SourceBuildOutputDir=$(SourceBuildOutputDir) /p:BuildDependencyPackageProjects=true /p:SetUpSourceBuildIntermediateNupkgCache=true /p:DotNetBuildSourceOnly=true /p:DotNetBuildInnerRepo=true /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId) $(_AdditionalDependencyProjectsBuildArgs)"
+      Command="./build.sh ^
+        --configuration $(Configuration) ^
+        /bl:$(ArtifactsDir)sourcebuild-dependency-projects.binlog ^
+        /p:LocalNuGetPackageCacheDirectory=$(LocalNuGetPackageCacheDirectory) ^
+        /p:SourceBuildOutputDir=$(SourceBuildOutputDir) ^
+        /p:BuildDependencyPackageProjects=true ^
+        /p:SetUpSourceBuildIntermediateNupkgCache=true ^
+        /p:DotNetBuildOrchestrator=$(DotNetBuildOrchestrator) ^
+        /p:DotNetBuildSourceOnly=true ^
+        /p:DotNetBuildInnerRepo=true ^
+        /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(MicrosoftNetCoreIlasmPackageRuntimeId) ^
+        $(_AdditionalDependencyProjectsBuildArgs)"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)"
       EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4701

The underlying issue is that the `DotNetBuildOrchestrator` property is not being passed to the inner build of the `DependencyPackageProject`.  This in turn causes arcade to restore the intermediate packages which don't exist in the n-1 artifacts.

[Test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2571290) (Microsoft internal link) that shows the change unblocks the SBRP build in an offline leg.