### PR TITLE
Update runtime dependency packages to latest from maintenance-packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
+    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -34,8 +34,8 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Credentials.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.ProjectModel.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Commands.6.11.0.csproj" />
-    <DependencyPackageProjects Include="$(RepoRoot)src\textOnlyPackages\src\**\Microsoft.NetCore.Platforms.3.1.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.8.0.5.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\textOnlyPackages\src\**\Microsoft.NetCore.Platforms.3.1.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Buffers.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -36,6 +36,7 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Commands.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.8.0.5.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\textOnlyPackages\src\**\Microsoft.NetCore.Platforms.3.1.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Bcl.HashCode.6.0.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Buffers.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -23,7 +23,6 @@
       <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Options.5.0.0.csproj" />
     -->
 
-    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Bcl.HashCode.6.0.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Frameworks.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Common.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Configuration.6.11.0.csproj" />
@@ -35,12 +34,12 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Credentials.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.ProjectModel.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Commands.6.11.0.csproj" />
-    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.8.0.5.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\textOnlyPackages\src\**\Microsoft.NetCore.Platforms.3.1.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.8.0.5.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Buffers.4.6.0-preview.1.24529.4.csproj" />
-    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Memory.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Memory.4.6.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Threading.Tasks.Extensions.4.6.0-preview.1.24529.4.csproj" />
   </ItemGroup>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -23,6 +23,7 @@
       <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Options.5.0.0.csproj" />
     -->
 
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Bcl.HashCode.6.0.0-preview.1.24529.4.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Frameworks.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Common.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\NuGet.Configuration.6.11.0.csproj" />
@@ -36,6 +37,11 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Nuget.Commands.6.11.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.8.0.5.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\textOnlyPackages\src\**\Microsoft.NetCore.Platforms.3.1.0.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Buffers.4.6.0-preview.1.24529.4.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Memory.4.6.0-preview.1.24529.4.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Threading.Tasks.Extensions.4.6.0-preview.1.24529.4.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/Microsoft.Bcl.HashCode.6.0.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/Microsoft.Bcl.HashCode.6.0.0-preview.1.24529.4.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <AssemblyName>Microsoft.Bcl.HashCode</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/net6.0/Microsoft.Bcl.HashCode.cs
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/net6.0/Microsoft.Bcl.HashCode.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.HashCode")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.HashCode))]

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/netstandard2.0/Microsoft.Bcl.HashCode.cs
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/netstandard2.0/Microsoft.Bcl.HashCode.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.HashCode")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System
+{
+    public partial struct HashCode
+    {
+        private int _dummyPrimitive;
+        public void Add<T>(T value, Collections.Generic.IEqualityComparer<T>? comparer) { }
+
+        public void Add<T>(T value) { }
+
+        public static int Combine<T1>(T1 value1) { throw null; }
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }
+
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4) { throw null; }
+
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) { throw null; }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) { throw null; }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) { throw null; }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) { throw null; }
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", true)]
+        public override bool Equals(object? obj) { throw null; }
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", true)]
+        public override int GetHashCode() { throw null; }
+
+        public int ToHashCode() { throw null; }
+    }
+}

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/netstandard2.1/Microsoft.Bcl.HashCode.cs
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/lib/netstandard2.1/Microsoft.Bcl.HashCode.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName = ".NET Standard 2.1")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.HashCode")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyFileVersion("6.0.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.0.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.HashCode")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.HashCode))]

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/microsoft.bcl.hashcode.nuspec
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0-preview.1.24529.4/microsoft.bcl.hashcode.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Bcl.HashCode</id>
+    <version>6.0.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>Microsoft.Bcl.HashCode</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework=".NETStandard2.0" />
+      <group targetFramework=".NETStandard2.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/System.Buffers.4.6.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/System.Buffers.4.6.0-preview.1.24529.4.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Buffers</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Buffers.cs
+++ b/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Buffers.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Buffers")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Buffers")]
+[assembly: System.Reflection.AssemblyFileVersion("4.600.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Buffers")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.3.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Buffers
+{
+    public abstract partial class ArrayPool<T>
+    {
+        public static ArrayPool<T> Shared { get { throw null; } }
+
+        public static ArrayPool<T> Create() { throw null; }
+
+        public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket) { throw null; }
+
+        public abstract T[] Rent(int minimumLength);
+        public abstract void Return(T[] array, bool clearArray = false);
+    }
+}

--- a/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/system.buffers.nuspec
+++ b/src/referencePackages/src/system.buffers/4.6.0-preview.1.24529.4/system.buffers.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Buffers</id>
+    <version>4.6.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>System.Buffers</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/System.Memory.4.6.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/System.Memory.4.6.0-preview.1.24529.4.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Memory</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.6.0-preview.1.24529.4" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.6.0-preview.1.24529.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0-preview.1.24529.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Memory.cs
+++ b/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Memory.cs
@@ -1,0 +1,941 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Memory")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Memory")]
+[assembly: System.Reflection.AssemblyFileVersion("4.600.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Memory")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.1.2")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System
+{
+    public static partial class MemoryExtensions
+    {
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start, int length) { throw null; }
+
+        public static ReadOnlyMemory<char> AsMemory(this string text, int start) { throw null; }
+
+        public static ReadOnlyMemory<char> AsMemory(this string text) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this T[] array, int start, int length) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this T[] array, int start) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this T[] array) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start, int length) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this ArraySegment<T> segment, int start) { throw null; }
+
+        public static Memory<T> AsMemory<T>(this ArraySegment<T> segment) { throw null; }
+
+        public static ReadOnlySpan<char> AsSpan(this string text, int start, int length) { throw null; }
+
+        public static ReadOnlySpan<char> AsSpan(this string text, int start) { throw null; }
+
+        public static ReadOnlySpan<char> AsSpan(this string text) { throw null; }
+
+        public static Span<T> AsSpan<T>(this T[] array, int start, int length) { throw null; }
+
+        public static Span<T> AsSpan<T>(this T[] array, int start) { throw null; }
+
+        public static Span<T> AsSpan<T>(this T[] array) { throw null; }
+
+        public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start, int length) { throw null; }
+
+        public static Span<T> AsSpan<T>(this ArraySegment<T> segment, int start) { throw null; }
+
+        public static Span<T> AsSpan<T>(this ArraySegment<T> segment) { throw null; }
+
+        public static int BinarySearch<T>(this ReadOnlySpan<T> span, IComparable<T> comparable) { throw null; }
+
+        public static int BinarySearch<T>(this Span<T> span, IComparable<T> comparable) { throw null; }
+
+        public static int BinarySearch<T, TComparer>(this ReadOnlySpan<T> span, T value, TComparer comparer)
+            where TComparer : Collections.Generic.IComparer<T> { throw null; }
+
+        public static int BinarySearch<T, TComparable>(this ReadOnlySpan<T> span, TComparable comparable)
+            where TComparable : IComparable<T> { throw null; }
+
+        public static int BinarySearch<T, TComparer>(this Span<T> span, T value, TComparer comparer)
+            where TComparer : Collections.Generic.IComparer<T> { throw null; }
+
+        public static int BinarySearch<T, TComparable>(this Span<T> span, TComparable comparable)
+            where TComparable : IComparable<T> { throw null; }
+
+        public static int CompareTo(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType) { throw null; }
+
+        public static bool Contains(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType) { throw null; }
+
+        public static void CopyTo<T>(this T[] source, Memory<T> destination) { }
+
+        public static void CopyTo<T>(this T[] source, Span<T> destination) { }
+
+        public static bool EndsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType) { throw null; }
+
+        public static bool EndsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool EndsWith<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool Equals(this ReadOnlySpan<char> span, ReadOnlySpan<char> other, StringComparison comparisonType) { throw null; }
+
+        public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType) { throw null; }
+
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOf<T>(this Span<T> span, T value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1, T value2)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this Span<T> span, T value0, T value1)
+            where T : IEquatable<T> { throw null; }
+
+        public static int IndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool IsWhiteSpace(this ReadOnlySpan<char> span) { throw null; }
+
+        public static int LastIndexOf<T>(this ReadOnlySpan<T> span, T value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOf<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOf<T>(this Span<T> span, T value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOf<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1, T value2)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, T value0, T value1)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1, T value2)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this Span<T> span, T value0, T value1)
+            where T : IEquatable<T> { throw null; }
+
+        public static int LastIndexOfAny<T>(this Span<T> span, ReadOnlySpan<T> values)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool Overlaps<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other, out int elementOffset) { throw null; }
+
+        public static bool Overlaps<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) { throw null; }
+
+        public static bool Overlaps<T>(this Span<T> span, ReadOnlySpan<T> other, out int elementOffset) { throw null; }
+
+        public static bool Overlaps<T>(this Span<T> span, ReadOnlySpan<T> other) { throw null; }
+
+        public static void Reverse<T>(this Span<T> span) { }
+
+        public static int SequenceCompareTo<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other)
+            where T : IComparable<T> { throw null; }
+
+        public static int SequenceCompareTo<T>(this Span<T> span, ReadOnlySpan<T> other)
+            where T : IComparable<T> { throw null; }
+
+        public static bool SequenceEqual<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool SequenceEqual<T>(this Span<T> span, ReadOnlySpan<T> other)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool StartsWith(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType) { throw null; }
+
+        public static bool StartsWith<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static bool StartsWith<T>(this Span<T> span, ReadOnlySpan<T> value)
+            where T : IEquatable<T> { throw null; }
+
+        public static int ToLower(this ReadOnlySpan<char> source, Span<char> destination, Globalization.CultureInfo culture) { throw null; }
+
+        public static int ToLowerInvariant(this ReadOnlySpan<char> source, Span<char> destination) { throw null; }
+
+        public static int ToUpper(this ReadOnlySpan<char> source, Span<char> destination, Globalization.CultureInfo culture) { throw null; }
+
+        public static int ToUpperInvariant(this ReadOnlySpan<char> source, Span<char> destination) { throw null; }
+
+        public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, char trimChar) { throw null; }
+
+        public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars) { throw null; }
+
+        public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span) { throw null; }
+
+        public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, char trimChar) { throw null; }
+
+        public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars) { throw null; }
+
+        public static ReadOnlySpan<char> TrimEnd(this ReadOnlySpan<char> span) { throw null; }
+
+        public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, char trimChar) { throw null; }
+
+        public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span, ReadOnlySpan<char> trimChars) { throw null; }
+
+        public static ReadOnlySpan<char> TrimStart(this ReadOnlySpan<char> span) { throw null; }
+    }
+
+    public readonly partial struct Memory<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Memory(T[] array, int start, int length) { }
+
+        public Memory(T[] array) { }
+
+        public static Memory<T> Empty { get { throw null; } }
+
+        public bool IsEmpty { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public Span<T> Span { get { throw null; } }
+
+        public readonly void CopyTo(Memory<T> destination) { }
+
+        public readonly bool Equals(Memory<T> other) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static implicit operator Memory<T>(T[] array) { throw null; }
+
+        public static implicit operator Memory<T>(ArraySegment<T> segment) { throw null; }
+
+        public static implicit operator ReadOnlyMemory<T>(Memory<T> memory) { throw null; }
+
+        public readonly Buffers.MemoryHandle Pin() { throw null; }
+
+        public readonly Memory<T> Slice(int start, int length) { throw null; }
+
+        public readonly Memory<T> Slice(int start) { throw null; }
+
+        public readonly T[] ToArray() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
+    }
+
+    public readonly partial struct ReadOnlyMemory<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlyMemory(T[] array, int start, int length) { }
+
+        public ReadOnlyMemory(T[] array) { }
+
+        public static ReadOnlyMemory<T> Empty { get { throw null; } }
+
+        public bool IsEmpty { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public ReadOnlySpan<T> Span { get { throw null; } }
+
+        public readonly void CopyTo(Memory<T> destination) { }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly bool Equals(ReadOnlyMemory<T> other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static implicit operator ReadOnlyMemory<T>(T[] array) { throw null; }
+
+        public static implicit operator ReadOnlyMemory<T>(ArraySegment<T> segment) { throw null; }
+
+        public readonly Buffers.MemoryHandle Pin() { throw null; }
+
+        public readonly ReadOnlyMemory<T> Slice(int start, int length) { throw null; }
+
+        public readonly ReadOnlyMemory<T> Slice(int start) { throw null; }
+
+        public readonly T[] ToArray() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryCopyTo(Memory<T> destination) { throw null; }
+    }
+
+    public readonly ref partial struct ReadOnlySpan<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlySpan(T[] array, int start, int length) { }
+
+        public ReadOnlySpan(T[] array) { }
+
+        [CLSCompliant(false)]
+        public unsafe ReadOnlySpan(void* pointer, int length) { }
+
+        public static ReadOnlySpan<T> Empty { get { throw null; } }
+
+        public bool IsEmpty { get { throw null; } }
+
+        public ref readonly T this[int index] { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public readonly void CopyTo(Span<T> destination) { }
+
+        [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly Enumerator GetEnumerator() { throw null; }
+
+        [Obsolete("GetHashCode() on ReadOnlySpan will always throw an exception.")]
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly ref readonly T GetPinnableReference() { throw null; }
+
+        public static bool operator ==(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
+
+        public static implicit operator ReadOnlySpan<T>(T[] array) { throw null; }
+
+        public static implicit operator ReadOnlySpan<T>(ArraySegment<T> segment) { throw null; }
+
+        public static bool operator !=(ReadOnlySpan<T> left, ReadOnlySpan<T> right) { throw null; }
+
+        public readonly ReadOnlySpan<T> Slice(int start, int length) { throw null; }
+
+        public readonly ReadOnlySpan<T> Slice(int start) { throw null; }
+
+        public readonly T[] ToArray() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryCopyTo(Span<T> destination) { throw null; }
+
+        public ref partial struct Enumerator
+        {
+            private ReadOnlySpan<T> _span;
+            private object _dummy;
+            private int _dummyPrimitive;
+            public ref readonly T Current { get { throw null; } }
+
+            public bool MoveNext() { throw null; }
+        }
+    }
+
+    public readonly partial struct SequencePosition : IEquatable<SequencePosition>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public SequencePosition(object @object, int integer) { }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly bool Equals(SequencePosition other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly int GetInteger() { throw null; }
+
+        public readonly object GetObject() { throw null; }
+    }
+
+    public readonly ref partial struct Span<T>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public Span(T[] array, int start, int length) { }
+
+        public Span(T[] array) { }
+
+        [CLSCompliant(false)]
+        public unsafe Span(void* pointer, int length) { }
+
+        public static Span<T> Empty { get { throw null; } }
+
+        public bool IsEmpty { get { throw null; } }
+
+        public ref T this[int index] { get { throw null; } }
+
+        public int Length { get { throw null; } }
+
+        public readonly void Clear() { }
+
+        public readonly void CopyTo(Span<T> destination) { }
+
+        [Obsolete("Equals() on Span will always throw an exception. Use == instead.")]
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly void Fill(T value) { }
+
+        public readonly Enumerator GetEnumerator() { throw null; }
+
+        [Obsolete("GetHashCode() on Span will always throw an exception.")]
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly ref T GetPinnableReference() { throw null; }
+
+        public static bool operator ==(Span<T> left, Span<T> right) { throw null; }
+
+        public static implicit operator Span<T>(T[] array) { throw null; }
+
+        public static implicit operator Span<T>(ArraySegment<T> segment) { throw null; }
+
+        public static implicit operator ReadOnlySpan<T>(Span<T> span) { throw null; }
+
+        public static bool operator !=(Span<T> left, Span<T> right) { throw null; }
+
+        public readonly Span<T> Slice(int start, int length) { throw null; }
+
+        public readonly Span<T> Slice(int start) { throw null; }
+
+        public readonly T[] ToArray() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryCopyTo(Span<T> destination) { throw null; }
+
+        public ref partial struct Enumerator
+        {
+            private Span<T> _span;
+            private object _dummy;
+            private int _dummyPrimitive;
+            public ref T Current { get { throw null; } }
+
+            public bool MoveNext() { throw null; }
+        }
+    }
+}
+
+namespace System.Buffers
+{
+    public static partial class BuffersExtensions
+    {
+        public static void CopyTo<T>(this in ReadOnlySequence<T> source, Span<T> destination) { }
+
+        public static SequencePosition? PositionOf<T>(this in ReadOnlySequence<T> source, T value)
+            where T : IEquatable<T> { throw null; }
+
+        public static T[] ToArray<T>(this in ReadOnlySequence<T> sequence) { throw null; }
+
+        public static void Write<T>(this IBufferWriter<T> writer, ReadOnlySpan<T> value) { }
+    }
+
+    public partial interface IBufferWriter<T>
+    {
+        void Advance(int count);
+        Memory<T> GetMemory(int sizeHint = 0);
+        Span<T> GetSpan(int sizeHint = 0);
+    }
+
+    public partial interface IMemoryOwner<T> : IDisposable
+    {
+        Memory<T> Memory { get; }
+    }
+
+    public partial interface IPinnable
+    {
+        MemoryHandle Pin(int elementIndex);
+        void Unpin();
+    }
+
+    public partial struct MemoryHandle : IDisposable
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        [CLSCompliant(false)]
+        public unsafe MemoryHandle(void* pointer, Runtime.InteropServices.GCHandle handle = default, IPinnable pinnable = null) { }
+
+        [CLSCompliant(false)]
+        public unsafe void* Pointer { get { throw null; } }
+
+        public void Dispose() { }
+    }
+
+    public abstract partial class MemoryManager<T> : IMemoryOwner<T>, IDisposable, IPinnable
+    {
+        public virtual Memory<T> Memory { get { throw null; } }
+
+        protected Memory<T> CreateMemory(int start, int length) { throw null; }
+
+        protected Memory<T> CreateMemory(int length) { throw null; }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract Span<T> GetSpan();
+        public abstract MemoryHandle Pin(int elementIndex = 0);
+        void IDisposable.Dispose() { }
+
+        protected internal virtual bool TryGetArray(out ArraySegment<T> segment) { throw null; }
+
+        public abstract void Unpin();
+    }
+
+    public abstract partial class MemoryPool<T> : IDisposable
+    {
+        public abstract int MaxBufferSize { get; }
+
+        public static MemoryPool<T> Shared { get { throw null; } }
+
+        public void Dispose() { }
+
+        protected abstract void Dispose(bool disposing);
+        public abstract IMemoryOwner<T> Rent(int minBufferSize = -1);
+    }
+
+    public enum OperationStatus
+    {
+        Done = 0,
+        DestinationTooSmall = 1,
+        NeedMoreData = 2,
+        InvalidData = 3
+    }
+
+    public abstract partial class ReadOnlySequenceSegment<T>
+    {
+        public ReadOnlyMemory<T> Memory { get { throw null; } protected set { } }
+
+        public ReadOnlySequenceSegment<T> Next { get { throw null; } protected set { } }
+
+        public long RunningIndex { get { throw null; } protected set { } }
+    }
+
+    public readonly partial struct ReadOnlySequence<T>
+    {
+        public static readonly ReadOnlySequence<T> Empty;
+        public ReadOnlySequence(T[] array, int start, int length) { }
+
+        public ReadOnlySequence(T[] array) { }
+
+        public ReadOnlySequence(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment, int endIndex) { }
+
+        public ReadOnlySequence(ReadOnlyMemory<T> memory) { }
+
+        public SequencePosition End { get { throw null; } }
+
+        public ReadOnlyMemory<T> First { get { throw null; } }
+
+        public bool IsEmpty { get { throw null; } }
+
+        public bool IsSingleSegment { get { throw null; } }
+
+        public long Length { get { throw null; } }
+
+        public SequencePosition Start { get { throw null; } }
+
+        public readonly Enumerator GetEnumerator() { throw null; }
+
+        public readonly SequencePosition GetPosition(long offset, SequencePosition origin) { throw null; }
+
+        public readonly SequencePosition GetPosition(long offset) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(int start, int length) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(int start, SequencePosition end) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(long start, long length) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(long start, SequencePosition end) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(long start) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(SequencePosition start, int length) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(SequencePosition start, long length) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(SequencePosition start, SequencePosition end) { throw null; }
+
+        public readonly ReadOnlySequence<T> Slice(SequencePosition start) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryGet(ref SequencePosition position, out ReadOnlyMemory<T> memory, bool advance = true) { throw null; }
+
+        public partial struct Enumerator
+        {
+            private ReadOnlySequence<T> _sequence;
+            private ReadOnlyMemory<T> _currentMemory;
+            private int _dummyPrimitive;
+            public Enumerator(in ReadOnlySequence<T> sequence) { }
+
+            public ReadOnlyMemory<T> Current { get { throw null; } }
+
+            public bool MoveNext() { throw null; }
+        }
+    }
+
+    public readonly partial struct StandardFormat : IEquatable<StandardFormat>
+    {
+        private readonly int _dummyPrimitive;
+        public const byte MaxPrecision = 99;
+        public const byte NoPrecision = 255;
+        public StandardFormat(char symbol, byte precision = 255) { }
+
+        public bool HasPrecision { get { throw null; } }
+
+        public bool IsDefault { get { throw null; } }
+
+        public byte Precision { get { throw null; } }
+
+        public char Symbol { get { throw null; } }
+
+        public readonly bool Equals(StandardFormat other) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(StandardFormat left, StandardFormat right) { throw null; }
+
+        public static implicit operator StandardFormat(char symbol) { throw null; }
+
+        public static bool operator !=(StandardFormat left, StandardFormat right) { throw null; }
+
+        public static StandardFormat Parse(ReadOnlySpan<char> format) { throw null; }
+
+        public static StandardFormat Parse(string format) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+}
+
+namespace System.Buffers.Binary
+{
+    public static partial class BinaryPrimitives
+    {
+        public static short ReadInt16BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static short ReadInt16LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static int ReadInt32BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static int ReadInt32LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static long ReadInt64BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static long ReadInt64LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ushort ReadUInt16BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ushort ReadUInt16LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static uint ReadUInt32BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static uint ReadUInt32LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ulong ReadUInt64BigEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ulong ReadUInt64LittleEndian(ReadOnlySpan<byte> source) { throw null; }
+
+        public static byte ReverseEndianness(byte value) { throw null; }
+
+        public static short ReverseEndianness(short value) { throw null; }
+
+        public static int ReverseEndianness(int value) { throw null; }
+
+        public static long ReverseEndianness(long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static sbyte ReverseEndianness(sbyte value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ushort ReverseEndianness(ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static uint ReverseEndianness(uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static ulong ReverseEndianness(ulong value) { throw null; }
+
+        public static bool TryReadInt16BigEndian(ReadOnlySpan<byte> source, out short value) { throw null; }
+
+        public static bool TryReadInt16LittleEndian(ReadOnlySpan<byte> source, out short value) { throw null; }
+
+        public static bool TryReadInt32BigEndian(ReadOnlySpan<byte> source, out int value) { throw null; }
+
+        public static bool TryReadInt32LittleEndian(ReadOnlySpan<byte> source, out int value) { throw null; }
+
+        public static bool TryReadInt64BigEndian(ReadOnlySpan<byte> source, out long value) { throw null; }
+
+        public static bool TryReadInt64LittleEndian(ReadOnlySpan<byte> source, out long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt16BigEndian(ReadOnlySpan<byte> source, out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt16LittleEndian(ReadOnlySpan<byte> source, out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32BigEndian(ReadOnlySpan<byte> source, out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32LittleEndian(ReadOnlySpan<byte> source, out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64BigEndian(ReadOnlySpan<byte> source, out ulong value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64LittleEndian(ReadOnlySpan<byte> source, out ulong value) { throw null; }
+
+        public static bool TryWriteInt16BigEndian(Span<byte> destination, short value) { throw null; }
+
+        public static bool TryWriteInt16LittleEndian(Span<byte> destination, short value) { throw null; }
+
+        public static bool TryWriteInt32BigEndian(Span<byte> destination, int value) { throw null; }
+
+        public static bool TryWriteInt32LittleEndian(Span<byte> destination, int value) { throw null; }
+
+        public static bool TryWriteInt64BigEndian(Span<byte> destination, long value) { throw null; }
+
+        public static bool TryWriteInt64LittleEndian(Span<byte> destination, long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt16BigEndian(Span<byte> destination, ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt16LittleEndian(Span<byte> destination, ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt32BigEndian(Span<byte> destination, uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt32LittleEndian(Span<byte> destination, uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt64BigEndian(Span<byte> destination, ulong value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryWriteUInt64LittleEndian(Span<byte> destination, ulong value) { throw null; }
+
+        public static void WriteInt16BigEndian(Span<byte> destination, short value) { }
+
+        public static void WriteInt16LittleEndian(Span<byte> destination, short value) { }
+
+        public static void WriteInt32BigEndian(Span<byte> destination, int value) { }
+
+        public static void WriteInt32LittleEndian(Span<byte> destination, int value) { }
+
+        public static void WriteInt64BigEndian(Span<byte> destination, long value) { }
+
+        public static void WriteInt64LittleEndian(Span<byte> destination, long value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt16BigEndian(Span<byte> destination, ushort value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt16LittleEndian(Span<byte> destination, ushort value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt32BigEndian(Span<byte> destination, uint value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt32LittleEndian(Span<byte> destination, uint value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt64BigEndian(Span<byte> destination, ulong value) { }
+
+        [CLSCompliant(false)]
+        public static void WriteUInt64LittleEndian(Span<byte> destination, ulong value) { }
+    }
+}
+
+namespace System.Buffers.Text
+{
+    public static partial class Base64
+    {
+        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true) { throw null; }
+
+        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int bytesWritten) { throw null; }
+
+        public static OperationStatus EncodeToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true) { throw null; }
+
+        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int bytesWritten) { throw null; }
+
+        public static int GetMaxDecodedFromUtf8Length(int length) { throw null; }
+
+        public static int GetMaxEncodedToUtf8Length(int length) { throw null; }
+    }
+
+    public static partial class Utf8Formatter
+    {
+        public static bool TryFormat(bool value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(byte value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(DateTime value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(DateTimeOffset value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(decimal value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(double value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(Guid value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(short value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(int value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(long value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryFormat(sbyte value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(float value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        public static bool TryFormat(TimeSpan value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryFormat(ushort value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryFormat(uint value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryFormat(ulong value, Span<byte> destination, out int bytesWritten, StandardFormat format = default) { throw null; }
+    }
+
+    public static partial class Utf8Parser
+    {
+        public static bool TryParse(ReadOnlySpan<byte> source, out bool value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out byte value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out DateTime value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out decimal value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out double value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out Guid value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out short value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out int value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out long value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryParse(ReadOnlySpan<byte> source, out sbyte value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out float value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        public static bool TryParse(ReadOnlySpan<byte> source, out TimeSpan value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryParse(ReadOnlySpan<byte> source, out ushort value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryParse(ReadOnlySpan<byte> source, out uint value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryParse(ReadOnlySpan<byte> source, out ulong value, out int bytesConsumed, char standardFormat = '\0') { throw null; }
+    }
+}
+
+namespace System.Runtime.InteropServices
+{
+    public static partial class MemoryMarshal
+    {
+        public static ReadOnlySpan<byte> AsBytes<T>(ReadOnlySpan<T> span)
+            where T : struct { throw null; }
+
+        public static Span<byte> AsBytes<T>(Span<T> span)
+            where T : struct { throw null; }
+
+        public static Memory<T> AsMemory<T>(ReadOnlyMemory<T> memory) { throw null; }
+
+        public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> span)
+            where TFrom : struct where TTo : struct { throw null; }
+
+        public static Span<TTo> Cast<TFrom, TTo>(Span<TFrom> span)
+            where TFrom : struct where TTo : struct { throw null; }
+
+        public static Memory<T> CreateFromPinnedArray<T>(T[] array, int start, int length) { throw null; }
+
+        public static ref T GetReference<T>(ReadOnlySpan<T> span) { throw null; }
+
+        public static ref T GetReference<T>(Span<T> span) { throw null; }
+
+        public static T Read<T>(ReadOnlySpan<byte> source)
+            where T : struct { throw null; }
+
+        public static Collections.Generic.IEnumerable<T> ToEnumerable<T>(ReadOnlyMemory<T> memory) { throw null; }
+
+        public static bool TryGetArray<T>(ReadOnlyMemory<T> memory, out ArraySegment<T> segment) { throw null; }
+
+        public static bool TryGetMemoryManager<T, TManager>(ReadOnlyMemory<T> memory, out TManager manager, out int start, out int length)
+            where TManager : Buffers.MemoryManager<T> { throw null; }
+
+        public static bool TryGetMemoryManager<T, TManager>(ReadOnlyMemory<T> memory, out TManager manager)
+            where TManager : Buffers.MemoryManager<T> { throw null; }
+
+        public static bool TryGetString(ReadOnlyMemory<char> memory, out string text, out int start, out int length) { throw null; }
+
+        public static bool TryRead<T>(ReadOnlySpan<byte> source, out T value)
+            where T : struct { throw null; }
+
+        public static bool TryWrite<T>(Span<byte> destination, ref T value)
+            where T : struct { throw null; }
+
+        public static void Write<T>(Span<byte> destination, ref T value)
+            where T : struct { }
+    }
+
+    public static partial class SequenceMarshal
+    {
+        public static bool TryGetArray<T>(Buffers.ReadOnlySequence<T> sequence, out ArraySegment<T> segment) { throw null; }
+
+        public static bool TryGetReadOnlyMemory<T>(Buffers.ReadOnlySequence<T> sequence, out ReadOnlyMemory<T> memory) { throw null; }
+
+        public static bool TryGetReadOnlySequenceSegment<T>(Buffers.ReadOnlySequence<T> sequence, out Buffers.ReadOnlySequenceSegment<T> startSegment, out int startIndex, out Buffers.ReadOnlySequenceSegment<T> endSegment, out int endIndex) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/system.memory.nuspec
+++ b/src/referencePackages/src/system.memory/4.6.0-preview.1.24529.4/system.memory.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Memory</id>
+    <version>4.6.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>System.Memory</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.6.0-preview.1.24529.4" exclude="Build,Analyzers" />
+        <dependency id="System.Numerics.Vectors" version="4.6.0-preview.1.24529.4" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.0-preview.1.24529.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/System.Numerics.Vectors.4.6.0-preview.1.24529.4.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Numerics.Vectors</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Numerics.Vectors.cs
+++ b/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Numerics.Vectors.cs
@@ -1,0 +1,999 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Numerics.Vectors")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Numerics.Vectors")]
+[assembly: System.Reflection.AssemblyFileVersion("4.600.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Numerics.Vectors")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.1.4.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Numerics
+{
+    public partial struct Matrix3x2 : IEquatable<Matrix3x2>
+    {
+        public float M11;
+        public float M12;
+        public float M21;
+        public float M22;
+        public float M31;
+        public float M32;
+        public Matrix3x2(float m11, float m12, float m21, float m22, float m31, float m32) { }
+
+        public static Matrix3x2 Identity { get { throw null; } }
+
+        public bool IsIdentity { get { throw null; } }
+
+        public Vector2 Translation { get { throw null; } set { } }
+
+        public static Matrix3x2 Add(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static Matrix3x2 CreateRotation(float radians, Vector2 centerPoint) { throw null; }
+
+        public static Matrix3x2 CreateRotation(float radians) { throw null; }
+
+        public static Matrix3x2 CreateScale(Vector2 scales, Vector2 centerPoint) { throw null; }
+
+        public static Matrix3x2 CreateScale(Vector2 scales) { throw null; }
+
+        public static Matrix3x2 CreateScale(float scale, Vector2 centerPoint) { throw null; }
+
+        public static Matrix3x2 CreateScale(float xScale, float yScale, Vector2 centerPoint) { throw null; }
+
+        public static Matrix3x2 CreateScale(float xScale, float yScale) { throw null; }
+
+        public static Matrix3x2 CreateScale(float scale) { throw null; }
+
+        public static Matrix3x2 CreateSkew(float radiansX, float radiansY, Vector2 centerPoint) { throw null; }
+
+        public static Matrix3x2 CreateSkew(float radiansX, float radiansY) { throw null; }
+
+        public static Matrix3x2 CreateTranslation(Vector2 position) { throw null; }
+
+        public static Matrix3x2 CreateTranslation(float xPosition, float yPosition) { throw null; }
+
+        public bool Equals(Matrix3x2 other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public float GetDeterminant() { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool Invert(Matrix3x2 matrix, out Matrix3x2 result) { throw null; }
+
+        public static Matrix3x2 Lerp(Matrix3x2 matrix1, Matrix3x2 matrix2, float amount) { throw null; }
+
+        public static Matrix3x2 Multiply(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static Matrix3x2 Multiply(Matrix3x2 value1, float value2) { throw null; }
+
+        public static Matrix3x2 Negate(Matrix3x2 value) { throw null; }
+
+        public static Matrix3x2 operator +(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static bool operator ==(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static bool operator !=(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static Matrix3x2 operator *(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static Matrix3x2 operator *(Matrix3x2 value1, float value2) { throw null; }
+
+        public static Matrix3x2 operator -(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public static Matrix3x2 operator -(Matrix3x2 value) { throw null; }
+
+        public static Matrix3x2 Subtract(Matrix3x2 value1, Matrix3x2 value2) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public partial struct Matrix4x4 : IEquatable<Matrix4x4>
+    {
+        public float M11;
+        public float M12;
+        public float M13;
+        public float M14;
+        public float M21;
+        public float M22;
+        public float M23;
+        public float M24;
+        public float M31;
+        public float M32;
+        public float M33;
+        public float M34;
+        public float M41;
+        public float M42;
+        public float M43;
+        public float M44;
+        public Matrix4x4(Matrix3x2 value) { }
+
+        public Matrix4x4(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31, float m32, float m33, float m34, float m41, float m42, float m43, float m44) { }
+
+        public static Matrix4x4 Identity { get { throw null; } }
+
+        public bool IsIdentity { get { throw null; } }
+
+        public Vector3 Translation { get { throw null; } set { } }
+
+        public static Matrix4x4 Add(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static Matrix4x4 CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 cameraUpVector, Vector3 cameraForwardVector) { throw null; }
+
+        public static Matrix4x4 CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition, Vector3 rotateAxis, Vector3 cameraForwardVector, Vector3 objectForwardVector) { throw null; }
+
+        public static Matrix4x4 CreateFromAxisAngle(Vector3 axis, float angle) { throw null; }
+
+        public static Matrix4x4 CreateFromQuaternion(Quaternion quaternion) { throw null; }
+
+        public static Matrix4x4 CreateFromYawPitchRoll(float yaw, float pitch, float roll) { throw null; }
+
+        public static Matrix4x4 CreateLookAt(Vector3 cameraPosition, Vector3 cameraTarget, Vector3 cameraUpVector) { throw null; }
+
+        public static Matrix4x4 CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane) { throw null; }
+
+        public static Matrix4x4 CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane) { throw null; }
+
+        public static Matrix4x4 CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance) { throw null; }
+
+        public static Matrix4x4 CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance) { throw null; }
+
+        public static Matrix4x4 CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance) { throw null; }
+
+        public static Matrix4x4 CreateReflection(Plane value) { throw null; }
+
+        public static Matrix4x4 CreateRotationX(float radians, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateRotationX(float radians) { throw null; }
+
+        public static Matrix4x4 CreateRotationY(float radians, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateRotationY(float radians) { throw null; }
+
+        public static Matrix4x4 CreateRotationZ(float radians, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateRotationZ(float radians) { throw null; }
+
+        public static Matrix4x4 CreateScale(Vector3 scales, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateScale(Vector3 scales) { throw null; }
+
+        public static Matrix4x4 CreateScale(float scale, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale, Vector3 centerPoint) { throw null; }
+
+        public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale) { throw null; }
+
+        public static Matrix4x4 CreateScale(float scale) { throw null; }
+
+        public static Matrix4x4 CreateShadow(Vector3 lightDirection, Plane plane) { throw null; }
+
+        public static Matrix4x4 CreateTranslation(Vector3 position) { throw null; }
+
+        public static Matrix4x4 CreateTranslation(float xPosition, float yPosition, float zPosition) { throw null; }
+
+        public static Matrix4x4 CreateWorld(Vector3 position, Vector3 forward, Vector3 up) { throw null; }
+
+        public static bool Decompose(Matrix4x4 matrix, out Vector3 scale, out Quaternion rotation, out Vector3 translation) { throw null; }
+
+        public bool Equals(Matrix4x4 other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public float GetDeterminant() { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static bool Invert(Matrix4x4 matrix, out Matrix4x4 result) { throw null; }
+
+        public static Matrix4x4 Lerp(Matrix4x4 matrix1, Matrix4x4 matrix2, float amount) { throw null; }
+
+        public static Matrix4x4 Multiply(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static Matrix4x4 Multiply(Matrix4x4 value1, float value2) { throw null; }
+
+        public static Matrix4x4 Negate(Matrix4x4 value) { throw null; }
+
+        public static Matrix4x4 operator +(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static bool operator ==(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static bool operator !=(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static Matrix4x4 operator *(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static Matrix4x4 operator *(Matrix4x4 value1, float value2) { throw null; }
+
+        public static Matrix4x4 operator -(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public static Matrix4x4 operator -(Matrix4x4 value) { throw null; }
+
+        public static Matrix4x4 Subtract(Matrix4x4 value1, Matrix4x4 value2) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static Matrix4x4 Transform(Matrix4x4 value, Quaternion rotation) { throw null; }
+
+        public static Matrix4x4 Transpose(Matrix4x4 matrix) { throw null; }
+    }
+
+    public partial struct Plane : IEquatable<Plane>
+    {
+        public float D;
+        public Vector3 Normal;
+        public Plane(Vector3 normal, float d) { }
+
+        public Plane(Vector4 value) { }
+
+        public Plane(float x, float y, float z, float d) { }
+
+        public static Plane CreateFromVertices(Vector3 point1, Vector3 point2, Vector3 point3) { throw null; }
+
+        public static float Dot(Plane plane, Vector4 value) { throw null; }
+
+        public static float DotCoordinate(Plane plane, Vector3 value) { throw null; }
+
+        public static float DotNormal(Plane plane, Vector3 value) { throw null; }
+
+        public bool Equals(Plane other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static Plane Normalize(Plane value) { throw null; }
+
+        public static bool operator ==(Plane value1, Plane value2) { throw null; }
+
+        public static bool operator !=(Plane value1, Plane value2) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static Plane Transform(Plane plane, Matrix4x4 matrix) { throw null; }
+
+        public static Plane Transform(Plane plane, Quaternion rotation) { throw null; }
+    }
+
+    public partial struct Quaternion : IEquatable<Quaternion>
+    {
+        public float W;
+        public float X;
+        public float Y;
+        public float Z;
+        public Quaternion(Vector3 vectorPart, float scalarPart) { }
+
+        public Quaternion(float x, float y, float z, float w) { }
+
+        public static Quaternion Identity { get { throw null; } }
+
+        public bool IsIdentity { get { throw null; } }
+
+        public static Quaternion Add(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion Concatenate(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion Conjugate(Quaternion value) { throw null; }
+
+        public static Quaternion CreateFromAxisAngle(Vector3 axis, float angle) { throw null; }
+
+        public static Quaternion CreateFromRotationMatrix(Matrix4x4 matrix) { throw null; }
+
+        public static Quaternion CreateFromYawPitchRoll(float yaw, float pitch, float roll) { throw null; }
+
+        public static Quaternion Divide(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static float Dot(Quaternion quaternion1, Quaternion quaternion2) { throw null; }
+
+        public bool Equals(Quaternion other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static Quaternion Inverse(Quaternion value) { throw null; }
+
+        public float Length() { throw null; }
+
+        public float LengthSquared() { throw null; }
+
+        public static Quaternion Lerp(Quaternion quaternion1, Quaternion quaternion2, float amount) { throw null; }
+
+        public static Quaternion Multiply(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion Multiply(Quaternion value1, float value2) { throw null; }
+
+        public static Quaternion Negate(Quaternion value) { throw null; }
+
+        public static Quaternion Normalize(Quaternion value) { throw null; }
+
+        public static Quaternion operator +(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion operator /(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static bool operator ==(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static bool operator !=(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion operator *(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion operator *(Quaternion value1, float value2) { throw null; }
+
+        public static Quaternion operator -(Quaternion value1, Quaternion value2) { throw null; }
+
+        public static Quaternion operator -(Quaternion value) { throw null; }
+
+        public static Quaternion Slerp(Quaternion quaternion1, Quaternion quaternion2, float amount) { throw null; }
+
+        public static Quaternion Subtract(Quaternion value1, Quaternion value2) { throw null; }
+
+        public override string ToString() { throw null; }
+    }
+
+    public static partial class Vector
+    {
+        public static bool IsHardwareAccelerated { get { throw null; } }
+
+        public static Vector<T> Abs<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<T> Add<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> AndNot<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<byte> AsVectorByte<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<double> AsVectorDouble<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<short> AsVectorInt16<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<int> AsVectorInt32<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<long> AsVectorInt64<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<sbyte> AsVectorSByte<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<float> AsVectorSingle<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<ushort> AsVectorUInt16<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<uint> AsVectorUInt32<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<ulong> AsVectorUInt64<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<T> BitwiseAnd<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> BitwiseOr<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<float> ConditionalSelect(Vector<int> condition, Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<double> ConditionalSelect(Vector<long> condition, Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<T> ConditionalSelect<T>(Vector<T> condition, Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<double> ConvertToDouble(Vector<long> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<double> ConvertToDouble(Vector<ulong> value) { throw null; }
+
+        public static Vector<int> ConvertToInt32(Vector<float> value) { throw null; }
+
+        public static Vector<long> ConvertToInt64(Vector<double> value) { throw null; }
+
+        public static Vector<float> ConvertToSingle(Vector<int> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<float> ConvertToSingle(Vector<uint> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<uint> ConvertToUInt32(Vector<float> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<ulong> ConvertToUInt64(Vector<double> value) { throw null; }
+
+        public static Vector<T> Divide<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static T Dot<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<long> Equals(Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<int> Equals(Vector<int> left, Vector<int> right) { throw null; }
+
+        public static Vector<long> Equals(Vector<long> left, Vector<long> right) { throw null; }
+
+        public static Vector<int> Equals(Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<T> Equals<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool EqualsAll<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool EqualsAny<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<long> GreaterThan(Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<int> GreaterThan(Vector<int> left, Vector<int> right) { throw null; }
+
+        public static Vector<long> GreaterThan(Vector<long> left, Vector<long> right) { throw null; }
+
+        public static Vector<int> GreaterThan(Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<T> GreaterThan<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool GreaterThanAll<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool GreaterThanAny<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<long> GreaterThanOrEqual(Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<int> GreaterThanOrEqual(Vector<int> left, Vector<int> right) { throw null; }
+
+        public static Vector<long> GreaterThanOrEqual(Vector<long> left, Vector<long> right) { throw null; }
+
+        public static Vector<int> GreaterThanOrEqual(Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<T> GreaterThanOrEqual<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool GreaterThanOrEqualAll<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool GreaterThanOrEqualAny<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<long> LessThan(Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<int> LessThan(Vector<int> left, Vector<int> right) { throw null; }
+
+        public static Vector<long> LessThan(Vector<long> left, Vector<long> right) { throw null; }
+
+        public static Vector<int> LessThan(Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<T> LessThan<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool LessThanAll<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool LessThanAny<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<long> LessThanOrEqual(Vector<double> left, Vector<double> right) { throw null; }
+
+        public static Vector<int> LessThanOrEqual(Vector<int> left, Vector<int> right) { throw null; }
+
+        public static Vector<long> LessThanOrEqual(Vector<long> left, Vector<long> right) { throw null; }
+
+        public static Vector<int> LessThanOrEqual(Vector<float> left, Vector<float> right) { throw null; }
+
+        public static Vector<T> LessThanOrEqual<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool LessThanOrEqualAll<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static bool LessThanOrEqualAny<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> Max<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> Min<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> Multiply<T>(T left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<T> Multiply<T>(Vector<T> left, T right)
+            where T : struct { throw null; }
+
+        public static Vector<T> Multiply<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        public static Vector<float> Narrow(Vector<double> low, Vector<double> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<sbyte> Narrow(Vector<short> low, Vector<short> high) { throw null; }
+
+        public static Vector<short> Narrow(Vector<int> low, Vector<int> high) { throw null; }
+
+        public static Vector<int> Narrow(Vector<long> low, Vector<long> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<byte> Narrow(Vector<ushort> low, Vector<ushort> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<ushort> Narrow(Vector<uint> low, Vector<uint> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static Vector<uint> Narrow(Vector<ulong> low, Vector<ulong> high) { throw null; }
+
+        public static Vector<T> Negate<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<T> OnesComplement<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<T> SquareRoot<T>(Vector<T> value)
+            where T : struct { throw null; }
+
+        public static Vector<T> Subtract<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+
+        [CLSCompliant(false)]
+        public static void Widen(Vector<byte> source, out Vector<ushort> low, out Vector<ushort> high) { throw null; }
+
+        public static void Widen(Vector<short> source, out Vector<int> low, out Vector<int> high) { throw null; }
+
+        public static void Widen(Vector<int> source, out Vector<long> low, out Vector<long> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static void Widen(Vector<sbyte> source, out Vector<short> low, out Vector<short> high) { throw null; }
+
+        public static void Widen(Vector<float> source, out Vector<double> low, out Vector<double> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static void Widen(Vector<ushort> source, out Vector<uint> low, out Vector<uint> high) { throw null; }
+
+        [CLSCompliant(false)]
+        public static void Widen(Vector<uint> source, out Vector<ulong> low, out Vector<ulong> high) { throw null; }
+
+        public static Vector<T> Xor<T>(Vector<T> left, Vector<T> right)
+            where T : struct { throw null; }
+    }
+
+    public partial struct Vector2 : IEquatable<Vector2>, IFormattable
+    {
+        public float X;
+        public float Y;
+        public Vector2(float x, float y) { }
+
+        public Vector2(float value) { }
+
+        public static Vector2 One { get { throw null; } }
+
+        public static Vector2 UnitX { get { throw null; } }
+
+        public static Vector2 UnitY { get { throw null; } }
+
+        public static Vector2 Zero { get { throw null; } }
+
+        public static Vector2 Abs(Vector2 value) { throw null; }
+
+        public static Vector2 Add(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 Clamp(Vector2 value1, Vector2 min, Vector2 max) { throw null; }
+
+        public void CopyTo(float[] array, int index) { }
+
+        public void CopyTo(float[] array) { }
+
+        public static float Distance(Vector2 value1, Vector2 value2) { throw null; }
+
+        public static float DistanceSquared(Vector2 value1, Vector2 value2) { throw null; }
+
+        public static Vector2 Divide(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 Divide(Vector2 left, float divisor) { throw null; }
+
+        public static float Dot(Vector2 value1, Vector2 value2) { throw null; }
+
+        public bool Equals(Vector2 other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public float Length() { throw null; }
+
+        public float LengthSquared() { throw null; }
+
+        public static Vector2 Lerp(Vector2 value1, Vector2 value2, float amount) { throw null; }
+
+        public static Vector2 Max(Vector2 value1, Vector2 value2) { throw null; }
+
+        public static Vector2 Min(Vector2 value1, Vector2 value2) { throw null; }
+
+        public static Vector2 Multiply(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 Multiply(Vector2 left, float right) { throw null; }
+
+        public static Vector2 Multiply(float left, Vector2 right) { throw null; }
+
+        public static Vector2 Negate(Vector2 value) { throw null; }
+
+        public static Vector2 Normalize(Vector2 value) { throw null; }
+
+        public static Vector2 operator +(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 operator /(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 operator /(Vector2 value1, float value2) { throw null; }
+
+        public static bool operator ==(Vector2 left, Vector2 right) { throw null; }
+
+        public static bool operator !=(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 operator *(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 operator *(Vector2 left, float right) { throw null; }
+
+        public static Vector2 operator *(float left, Vector2 right) { throw null; }
+
+        public static Vector2 operator -(Vector2 left, Vector2 right) { throw null; }
+
+        public static Vector2 operator -(Vector2 value) { throw null; }
+
+        public static Vector2 Reflect(Vector2 vector, Vector2 normal) { throw null; }
+
+        public static Vector2 SquareRoot(Vector2 value) { throw null; }
+
+        public static Vector2 Subtract(Vector2 left, Vector2 right) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
+
+        public string ToString(string format) { throw null; }
+
+        public static Vector2 Transform(Vector2 position, Matrix3x2 matrix) { throw null; }
+
+        public static Vector2 Transform(Vector2 position, Matrix4x4 matrix) { throw null; }
+
+        public static Vector2 Transform(Vector2 value, Quaternion rotation) { throw null; }
+
+        public static Vector2 TransformNormal(Vector2 normal, Matrix3x2 matrix) { throw null; }
+
+        public static Vector2 TransformNormal(Vector2 normal, Matrix4x4 matrix) { throw null; }
+    }
+
+    public partial struct Vector3 : IEquatable<Vector3>, IFormattable
+    {
+        public float X;
+        public float Y;
+        public float Z;
+        public Vector3(Vector2 value, float z) { }
+
+        public Vector3(float x, float y, float z) { }
+
+        public Vector3(float value) { }
+
+        public static Vector3 One { get { throw null; } }
+
+        public static Vector3 UnitX { get { throw null; } }
+
+        public static Vector3 UnitY { get { throw null; } }
+
+        public static Vector3 UnitZ { get { throw null; } }
+
+        public static Vector3 Zero { get { throw null; } }
+
+        public static Vector3 Abs(Vector3 value) { throw null; }
+
+        public static Vector3 Add(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 Clamp(Vector3 value1, Vector3 min, Vector3 max) { throw null; }
+
+        public void CopyTo(float[] array, int index) { }
+
+        public void CopyTo(float[] array) { }
+
+        public static Vector3 Cross(Vector3 vector1, Vector3 vector2) { throw null; }
+
+        public static float Distance(Vector3 value1, Vector3 value2) { throw null; }
+
+        public static float DistanceSquared(Vector3 value1, Vector3 value2) { throw null; }
+
+        public static Vector3 Divide(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 Divide(Vector3 left, float divisor) { throw null; }
+
+        public static float Dot(Vector3 vector1, Vector3 vector2) { throw null; }
+
+        public bool Equals(Vector3 other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public float Length() { throw null; }
+
+        public float LengthSquared() { throw null; }
+
+        public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount) { throw null; }
+
+        public static Vector3 Max(Vector3 value1, Vector3 value2) { throw null; }
+
+        public static Vector3 Min(Vector3 value1, Vector3 value2) { throw null; }
+
+        public static Vector3 Multiply(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 Multiply(Vector3 left, float right) { throw null; }
+
+        public static Vector3 Multiply(float left, Vector3 right) { throw null; }
+
+        public static Vector3 Negate(Vector3 value) { throw null; }
+
+        public static Vector3 Normalize(Vector3 value) { throw null; }
+
+        public static Vector3 operator +(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 operator /(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 operator /(Vector3 value1, float value2) { throw null; }
+
+        public static bool operator ==(Vector3 left, Vector3 right) { throw null; }
+
+        public static bool operator !=(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 operator *(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 operator *(Vector3 left, float right) { throw null; }
+
+        public static Vector3 operator *(float left, Vector3 right) { throw null; }
+
+        public static Vector3 operator -(Vector3 left, Vector3 right) { throw null; }
+
+        public static Vector3 operator -(Vector3 value) { throw null; }
+
+        public static Vector3 Reflect(Vector3 vector, Vector3 normal) { throw null; }
+
+        public static Vector3 SquareRoot(Vector3 value) { throw null; }
+
+        public static Vector3 Subtract(Vector3 left, Vector3 right) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
+
+        public string ToString(string format) { throw null; }
+
+        public static Vector3 Transform(Vector3 position, Matrix4x4 matrix) { throw null; }
+
+        public static Vector3 Transform(Vector3 value, Quaternion rotation) { throw null; }
+
+        public static Vector3 TransformNormal(Vector3 normal, Matrix4x4 matrix) { throw null; }
+    }
+
+    public partial struct Vector4 : IEquatable<Vector4>, IFormattable
+    {
+        public float W;
+        public float X;
+        public float Y;
+        public float Z;
+        public Vector4(Vector2 value, float z, float w) { }
+
+        public Vector4(Vector3 value, float w) { }
+
+        public Vector4(float x, float y, float z, float w) { }
+
+        public Vector4(float value) { }
+
+        public static Vector4 One { get { throw null; } }
+
+        public static Vector4 UnitW { get { throw null; } }
+
+        public static Vector4 UnitX { get { throw null; } }
+
+        public static Vector4 UnitY { get { throw null; } }
+
+        public static Vector4 UnitZ { get { throw null; } }
+
+        public static Vector4 Zero { get { throw null; } }
+
+        public static Vector4 Abs(Vector4 value) { throw null; }
+
+        public static Vector4 Add(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 Clamp(Vector4 value1, Vector4 min, Vector4 max) { throw null; }
+
+        public void CopyTo(float[] array, int index) { }
+
+        public void CopyTo(float[] array) { }
+
+        public static float Distance(Vector4 value1, Vector4 value2) { throw null; }
+
+        public static float DistanceSquared(Vector4 value1, Vector4 value2) { throw null; }
+
+        public static Vector4 Divide(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 Divide(Vector4 left, float divisor) { throw null; }
+
+        public static float Dot(Vector4 vector1, Vector4 vector2) { throw null; }
+
+        public bool Equals(Vector4 other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public float Length() { throw null; }
+
+        public float LengthSquared() { throw null; }
+
+        public static Vector4 Lerp(Vector4 value1, Vector4 value2, float amount) { throw null; }
+
+        public static Vector4 Max(Vector4 value1, Vector4 value2) { throw null; }
+
+        public static Vector4 Min(Vector4 value1, Vector4 value2) { throw null; }
+
+        public static Vector4 Multiply(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 Multiply(Vector4 left, float right) { throw null; }
+
+        public static Vector4 Multiply(float left, Vector4 right) { throw null; }
+
+        public static Vector4 Negate(Vector4 value) { throw null; }
+
+        public static Vector4 Normalize(Vector4 vector) { throw null; }
+
+        public static Vector4 operator +(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 operator /(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 operator /(Vector4 value1, float value2) { throw null; }
+
+        public static bool operator ==(Vector4 left, Vector4 right) { throw null; }
+
+        public static bool operator !=(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 operator *(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 operator *(Vector4 left, float right) { throw null; }
+
+        public static Vector4 operator *(float left, Vector4 right) { throw null; }
+
+        public static Vector4 operator -(Vector4 left, Vector4 right) { throw null; }
+
+        public static Vector4 operator -(Vector4 value) { throw null; }
+
+        public static Vector4 SquareRoot(Vector4 value) { throw null; }
+
+        public static Vector4 Subtract(Vector4 left, Vector4 right) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
+
+        public string ToString(string format) { throw null; }
+
+        public static Vector4 Transform(Vector2 position, Matrix4x4 matrix) { throw null; }
+
+        public static Vector4 Transform(Vector2 value, Quaternion rotation) { throw null; }
+
+        public static Vector4 Transform(Vector3 position, Matrix4x4 matrix) { throw null; }
+
+        public static Vector4 Transform(Vector3 value, Quaternion rotation) { throw null; }
+
+        public static Vector4 Transform(Vector4 vector, Matrix4x4 matrix) { throw null; }
+
+        public static Vector4 Transform(Vector4 value, Quaternion rotation) { throw null; }
+    }
+
+    public partial struct Vector<T> : IEquatable<Vector<T>>, IFormattable where T : struct
+    {
+        private int _dummyPrimitive;
+        public Vector(T value) { }
+
+        public Vector(T[] values, int index) { }
+
+        public Vector(T[] values) { }
+
+        public static int Count { get { throw null; } }
+
+        public T this[int index] { get { throw null; } }
+
+        public static Vector<T> One { get { throw null; } }
+
+        public static Vector<T> Zero { get { throw null; } }
+
+        public void CopyTo(T[] destination, int startIndex) { }
+
+        public void CopyTo(T[] destination) { }
+
+        public bool Equals(Vector<T> other) { throw null; }
+
+        public override bool Equals(object obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public static Vector<T> operator +(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator &(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator |(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator /(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static bool operator ==(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator ^(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static explicit operator Vector<byte>(Vector<T> value) { throw null; }
+
+        public static explicit operator Vector<double>(Vector<T> value) { throw null; }
+
+        public static explicit operator Vector<short>(Vector<T> value) { throw null; }
+
+        public static explicit operator Vector<int>(Vector<T> value) { throw null; }
+
+        public static explicit operator Vector<long>(Vector<T> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator Vector<sbyte>(Vector<T> value) { throw null; }
+
+        public static explicit operator Vector<float>(Vector<T> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator Vector<ushort>(Vector<T> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator Vector<uint>(Vector<T> value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator Vector<ulong>(Vector<T> value) { throw null; }
+
+        public static bool operator !=(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator *(T factor, Vector<T> value) { throw null; }
+
+        public static Vector<T> operator *(Vector<T> value, T factor) { throw null; }
+
+        public static Vector<T> operator *(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator ~(Vector<T> value) { throw null; }
+
+        public static Vector<T> operator -(Vector<T> left, Vector<T> right) { throw null; }
+
+        public static Vector<T> operator -(Vector<T> value) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public string ToString(string format, IFormatProvider formatProvider) { throw null; }
+
+        public string ToString(string format) { throw null; }
+    }
+}

--- a/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/system.numerics.vectors.nuspec
+++ b/src/referencePackages/src/system.numerics.vectors/4.6.0-preview.1.24529.4/system.numerics.vectors.nuspec
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Numerics.Vectors</id>
+    <version>4.6.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>System.Numerics.Vectors</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/System.Runtime.CompilerServices.Unsafe.6.1.0-preview.1.24529.4.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.CLSCompliant(false)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.Default | System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyDescription("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyFileVersion("6.100.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.1.0-preview.1.24529.4")]
+[assembly: System.Reflection.AssemblyTitle("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Runtime.CompilerServices
+{
+    public static partial class Unsafe
+    {
+        public static ref T Add<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Add<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static bool AreSame<T>(ref T left, ref T right) { throw null; }
+
+        public static T As<T>(object o)
+            where T : class { throw null; }
+
+        public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
+
+        public static unsafe void* AsPointer<T>(ref T value) { throw null; }
+
+        public static ref T AsRef<T>(in T source) { throw null; }
+
+        public static unsafe ref T AsRef<T>(void* source) { throw null; }
+
+        public static IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
+
+        public static unsafe void Copy<T>(ref T destination, void* source) { }
+
+        public static unsafe void Copy<T>(void* destination, ref T source) { }
+
+        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlock(void* destination, void* source, uint byteCount) { }
+
+        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
+
+        public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlock(void* startAddress, byte value, uint byteCount) { }
+
+        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
+
+        public static bool IsAddressGreaterThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsAddressLessThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsNullRef<T>(ref T source) { throw null; }
+
+        public static ref T NullRef<T>() { throw null; }
+
+        public static unsafe T Read<T>(void* source) { throw null; }
+
+        public static T ReadUnaligned<T>(ref byte source) { throw null; }
+
+        public static unsafe T ReadUnaligned<T>(void* source) { throw null; }
+
+        public static int SizeOf<T>() { throw null; }
+
+        public static void SkipInit<T>(out T value) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Subtract<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static ref T Unbox<T>(object box)
+            where T : struct { throw null; }
+
+        public static unsafe void Write<T>(void* destination, T value) { }
+
+        public static void WriteUnaligned<T>(ref byte destination, T value) { }
+
+        public static unsafe void WriteUnaligned<T>(void* destination, T value) { }
+    }
+}

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/system.runtime.compilerservices.unsafe.nuspec
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0-preview.1.24529.4/system.runtime.compilerservices.unsafe.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Runtime.CompilerServices.Unsafe</id>
+    <version>6.1.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.
+
+Commonly Used Types:
+System.Runtime.CompilerServices.Unsafe</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework="net7.0" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/System.Threading.Tasks.Extensions.4.6.0-preview.1.24529.4.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/System.Threading.Tasks.Extensions.4.6.0-preview.1.24529.4.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Threading.Tasks.Extensions</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0-preview.1.24529.4" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Threading.Tasks.Extensions.cs
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/lib/netstandard2.0/System.Threading.Tasks.Extensions.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Threading.Tasks.Extensions")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Threading.Tasks.Extensions")]
+[assembly: System.Reflection.AssemblyFileVersion("4.600.24.52904")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.6.0-preview.1.24529.4+c217b3e67dea4a77c604440fdf5ee9197565fbee")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Threading.Tasks.Extensions")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.2.0.1")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Delegate, Inherited = false, AllowMultiple = false)]
+    public sealed partial class AsyncMethodBuilderAttribute : Attribute
+    {
+        public AsyncMethodBuilderAttribute(Type builderType) { }
+
+        public Type BuilderType { get { throw null; } }
+    }
+
+    public partial struct AsyncValueTaskMethodBuilder
+    {
+        private int _dummyPrimitive;
+        public Threading.Tasks.ValueTask Task { get { throw null; } }
+
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+
+        public static AsyncValueTaskMethodBuilder Create() { throw null; }
+
+        public void SetException(Exception exception) { }
+
+        public void SetResult() { }
+
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine { }
+    }
+
+    public partial struct AsyncValueTaskMethodBuilder<TResult>
+    {
+        private AsyncTaskMethodBuilder<TResult> _methodBuilder;
+        private TResult _result;
+        private int _dummyPrimitive;
+        public Threading.Tasks.ValueTask<TResult> Task { get { throw null; } }
+
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+
+        public static AsyncValueTaskMethodBuilder<TResult> Create() { throw null; }
+
+        public void SetException(Exception exception) { }
+
+        public void SetResult(TResult result) { }
+
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+
+        public void Start<TStateMachine>(ref TStateMachine stateMachine)
+            where TStateMachine : IAsyncStateMachine { }
+    }
+
+    public readonly partial struct ConfiguredValueTaskAwaitable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
+
+        public readonly partial struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public bool IsCompleted { get { throw null; } }
+
+            public readonly void GetResult() { }
+
+            public readonly void OnCompleted(Action continuation) { }
+
+            public readonly void UnsafeOnCompleted(Action continuation) { }
+        }
+    }
+
+    public readonly partial struct ConfiguredValueTaskAwaitable<TResult>
+    {
+        private readonly Threading.Tasks.ValueTask<TResult> _value;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public readonly ConfiguredValueTaskAwaiter GetAwaiter() { throw null; }
+
+        public readonly partial struct ConfiguredValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
+        {
+            private readonly Threading.Tasks.ValueTask<TResult> _value;
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public bool IsCompleted { get { throw null; } }
+
+            public readonly TResult GetResult() { throw null; }
+
+            public readonly void OnCompleted(Action continuation) { }
+
+            public readonly void UnsafeOnCompleted(Action continuation) { }
+        }
+    }
+
+    public readonly partial struct ValueTaskAwaiter : ICriticalNotifyCompletion, INotifyCompletion
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public bool IsCompleted { get { throw null; } }
+
+        public readonly void GetResult() { }
+
+        public readonly void OnCompleted(Action continuation) { }
+
+        public readonly void UnsafeOnCompleted(Action continuation) { }
+    }
+
+    public readonly partial struct ValueTaskAwaiter<TResult> : ICriticalNotifyCompletion, INotifyCompletion
+    {
+        private readonly Threading.Tasks.ValueTask<TResult> _value;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public bool IsCompleted { get { throw null; } }
+
+        public readonly TResult GetResult() { throw null; }
+
+        public readonly void OnCompleted(Action continuation) { }
+
+        public readonly void UnsafeOnCompleted(Action continuation) { }
+    }
+}
+
+namespace System.Threading.Tasks
+{
+    [Runtime.CompilerServices.AsyncMethodBuilder(typeof(Runtime.CompilerServices.AsyncValueTaskMethodBuilder))]
+    public readonly partial struct ValueTask : IEquatable<ValueTask>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ValueTask(Sources.IValueTaskSource source, short token) { }
+
+        public ValueTask(Task task) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+
+        public bool IsCompletedSuccessfully { get { throw null; } }
+
+        public bool IsFaulted { get { throw null; } }
+
+        public readonly Task AsTask() { throw null; }
+
+        public readonly Runtime.CompilerServices.ConfiguredValueTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly bool Equals(ValueTask other) { throw null; }
+
+        public readonly Runtime.CompilerServices.ValueTaskAwaiter GetAwaiter() { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ValueTask left, ValueTask right) { throw null; }
+
+        public static bool operator !=(ValueTask left, ValueTask right) { throw null; }
+
+        public readonly ValueTask Preserve() { throw null; }
+    }
+
+    [Runtime.CompilerServices.AsyncMethodBuilder(typeof(Runtime.CompilerServices.AsyncValueTaskMethodBuilder<>))]
+    public readonly partial struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
+    {
+        private readonly TResult _result;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ValueTask(TResult result) { }
+
+        public ValueTask(Sources.IValueTaskSource<TResult> source, short token) { }
+
+        public ValueTask(Task<TResult> task) { }
+
+        public bool IsCanceled { get { throw null; } }
+
+        public bool IsCompleted { get { throw null; } }
+
+        public bool IsCompletedSuccessfully { get { throw null; } }
+
+        public bool IsFaulted { get { throw null; } }
+
+        public TResult Result { get { throw null; } }
+
+        public readonly Task<TResult> AsTask() { throw null; }
+
+        public readonly Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
+
+        public override readonly bool Equals(object obj) { throw null; }
+
+        public readonly bool Equals(ValueTask<TResult> other) { throw null; }
+
+        public readonly Runtime.CompilerServices.ValueTaskAwaiter<TResult> GetAwaiter() { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public static bool operator ==(ValueTask<TResult> left, ValueTask<TResult> right) { throw null; }
+
+        public static bool operator !=(ValueTask<TResult> left, ValueTask<TResult> right) { throw null; }
+
+        public readonly ValueTask<TResult> Preserve() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+}
+
+namespace System.Threading.Tasks.Sources
+{
+    public partial interface IValueTaskSource
+    {
+        void GetResult(short token);
+        ValueTaskSourceStatus GetStatus(short token);
+        void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags);
+    }
+
+    public partial interface IValueTaskSource<out TResult>
+    {
+        TResult GetResult(short token);
+        ValueTaskSourceStatus GetStatus(short token);
+        void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags);
+    }
+
+    [Flags]
+    public enum ValueTaskSourceOnCompletedFlags
+    {
+        None = 0,
+        UseSchedulingContext = 1,
+        FlowExecutionContext = 2
+    }
+
+    public enum ValueTaskSourceStatus
+    {
+        Pending = 0,
+        Succeeded = 1,
+        Faulted = 2,
+        Canceled = 3
+    }
+}

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/system.threading.tasks.extensions.nuspec
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.6.0-preview.1.24529.4/system.threading.tasks.extensions.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Threading.Tasks.Extensions</id>
+    <version>4.6.0-preview.1.24529.4</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>System.Threading.Tasks.Extensions</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="c217b3e67dea4a77c604440fdf5ee9197565fbee" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.0-preview.1.24529.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Unblocks https://github.com/dotnet/runtime/pull/108806

We have generated new preview versions of some OOB packages that have been recently migrated to the maintenance-packages repo. We need to include them in sbrp so that we can update runtime's `main` dependencies to those preview versions without breaking source build.

The packages that we want to update in runtime are:
- Microsoft.Bcl.HashCode
- System.Buffers
- System.Memory
- System.Numerics.Vectors
- System.Runtime.CompilerServices.Unsafe
- System.Threading.Tasks.Extensions

I used the generate.sh script to generate these files, per the instructions.

For additional details, see the decided plan here: https://github.com/dotnet/maintenance-packages/pull/140#issuecomment-2444383987

cc @ericstj @ViktorHofer @MichaelSimons 