### PR TITLE
Drop prerelease version label.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,6 @@
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #https://github.com/dotnet/source-build/issues/4670.

I couldn't think of a meaningful pre-release label so I opted to remove it.