### PR TITLE
Revert "Drop prerelease version label. (#1070)"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,8 @@
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
This reverts commit 598ee70e60b92b2dfd853358a84d080e954b76a4.

Reverting this change to unblock the builds until I can get clear direction on how to handle this change on the back end (e.g darc channels).

Fixes https://github.com/dotnet/source-build/issues/4718