### PR TITLE
Drop prerelease version label

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,6 @@
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <SkipPackagePublishingVersionChecks>true</SkipPackagePublishingVersionChecks>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,8 +3,8 @@
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <SkipPackagePublishingVersionChecks>true</SkipPackagePublishingVersionChecks>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #https://github.com/dotnet/source-build/issues/4670.

Second attempt of https://github.com/dotnet/source-build-reference-packages/pull/1070

[Test Build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2589920&view=results) (internal Microsoft link)