### PR TITLE
Add back some recently removed packages

### DIFF
--- a/src/referencePackages/src/system.formats.asn1/8.0.0/System.Formats.Asn1.8.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/System.Formats.Asn1.8.0.0.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Formats.Asn1</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net6.0/System.Formats.Asn1.cs
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net6.0/System.Formats.Asn1.cs
@@ -1,0 +1,411 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.\r\n\r\nCommonly Used Types:\r\nSystem.Formats.Asn1.AsnReader\r\nSystem.Formats.Asn1.AsnWriter")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+
+        public bool IsConstructed { get { throw null; } }
+
+        public TagClass TagClass { get { throw null; } }
+
+        public int TagValue { get { throw null; } }
+
+        public readonly Asn1Tag AsConstructed() { throw null; }
+
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+
+        public readonly int CalculateEncodedSize() { throw null; }
+
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+
+        public readonly int Encode(Span<byte> destination) { throw null; }
+
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public AsnContentException(string? message, Exception? inner) { }
+
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+
+        public bool HasData { get { throw null; } }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public AsnReader Clone() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+
+        public Asn1Tag PeekTag() { throw null; }
+
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public void ThrowIfNotEmpty() { }
+
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public void CopyTo(AsnWriter destination) { }
+
+        public byte[] Encode() { throw null; }
+
+        public int Encode(Span<byte> destination) { throw null; }
+
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+
+        public int GetEncodedLength() { throw null; }
+
+        public void PopOctetString(Asn1Tag? tag = null) { }
+
+        public void PopSequence(Asn1Tag? tag = null) { }
+
+        public void PopSetOf(Asn1Tag? tag = null) { }
+
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+
+        public void Reset() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteNull(Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net7.0/System.Formats.Asn1.cs
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net7.0/System.Formats.Asn1.cs
@@ -1,0 +1,411 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.\r\n\r\nCommonly Used Types:\r\nSystem.Formats.Asn1.AsnReader\r\nSystem.Formats.Asn1.AsnWriter")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+
+        public bool IsConstructed { get { throw null; } }
+
+        public TagClass TagClass { get { throw null; } }
+
+        public int TagValue { get { throw null; } }
+
+        public readonly Asn1Tag AsConstructed() { throw null; }
+
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+
+        public readonly int CalculateEncodedSize() { throw null; }
+
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+
+        public readonly int Encode(Span<byte> destination) { throw null; }
+
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public AsnContentException(string? message, Exception? inner) { }
+
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+
+        public bool HasData { get { throw null; } }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public AsnReader Clone() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+
+        public Asn1Tag PeekTag() { throw null; }
+
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public void ThrowIfNotEmpty() { }
+
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public void CopyTo(AsnWriter destination) { }
+
+        public byte[] Encode() { throw null; }
+
+        public int Encode(Span<byte> destination) { throw null; }
+
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+
+        public int GetEncodedLength() { throw null; }
+
+        public void PopOctetString(Asn1Tag? tag = null) { }
+
+        public void PopSequence(Asn1Tag? tag = null) { }
+
+        public void PopSetOf(Asn1Tag? tag = null) { }
+
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+
+        public void Reset() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteNull(Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net8.0/System.Formats.Asn1.cs
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/lib/net8.0/System.Formats.Asn1.cs
@@ -1,0 +1,412 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.\r\n\r\nCommonly Used Types:\r\nSystem.Formats.Asn1.AsnReader\r\nSystem.Formats.Asn1.AsnWriter")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+
+        public bool IsConstructed { get { throw null; } }
+
+        public TagClass TagClass { get { throw null; } }
+
+        public int TagValue { get { throw null; } }
+
+        public readonly Asn1Tag AsConstructed() { throw null; }
+
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+
+        public readonly int CalculateEncodedSize() { throw null; }
+
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+
+        public readonly int Encode(Span<byte> destination) { throw null; }
+
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public AsnContentException(string? message, Exception? inner) { }
+
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+
+        public bool HasData { get { throw null; } }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public AsnReader Clone() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+
+        public Asn1Tag PeekTag() { throw null; }
+
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public void ThrowIfNotEmpty() { }
+
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public void CopyTo(AsnWriter destination) { }
+
+        public byte[] Encode() { throw null; }
+
+        public int Encode(Span<byte> destination) { throw null; }
+
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+
+        public int GetEncodedLength() { throw null; }
+
+        public void PopOctetString(Asn1Tag? tag = null) { }
+
+        public void PopSequence(Asn1Tag? tag = null) { }
+
+        public void PopSetOf(Asn1Tag? tag = null) { }
+
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+
+        public void Reset() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteNull(Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/lib/netstandard2.0/System.Formats.Asn1.cs
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/lib/netstandard2.0/System.Formats.Asn1.cs
@@ -1,0 +1,411 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.\r\n\r\nCommonly Used Types:\r\nSystem.Formats.Asn1.AsnReader\r\nSystem.Formats.Asn1.AsnWriter")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+
+        public bool IsConstructed { get { throw null; } }
+
+        public TagClass TagClass { get { throw null; } }
+
+        public int TagValue { get { throw null; } }
+
+        public readonly Asn1Tag AsConstructed() { throw null; }
+
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+
+        public readonly int CalculateEncodedSize() { throw null; }
+
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+
+        public readonly int Encode(Span<byte> destination) { throw null; }
+
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public AsnContentException(string? message, Exception? inner) { }
+
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+
+        public bool HasData { get { throw null; } }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public AsnReader Clone() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+
+        public Asn1Tag PeekTag() { throw null; }
+
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null)
+            where TEnum : Enum { throw null; }
+
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null)
+            where TFlagsEnum : Enum { throw null; }
+
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+
+        public void ThrowIfNotEmpty() { }
+
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+
+        public AsnEncodingRules RuleSet { get { throw null; } }
+
+        public void CopyTo(AsnWriter destination) { }
+
+        public byte[] Encode() { throw null; }
+
+        public int Encode(Span<byte> destination) { throw null; }
+
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+
+        public int GetEncodedLength() { throw null; }
+
+        public void PopOctetString(Asn1Tag? tag = null) { }
+
+        public void PopSequence(Asn1Tag? tag = null) { }
+
+        public void PopSetOf(Asn1Tag? tag = null) { }
+
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+
+        public void Reset() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null)
+            where TEnum : Enum { }
+
+        public void WriteNull(Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/system.formats.asn1.nuspec
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/system.formats.asn1.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Formats.Asn1</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.
+
+Commonly Used Types:
+System.Formats.Asn1.AsnReader
+System.Formats.Asn1.AsnWriter</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/System.Security.Cryptography.Pkcs.8.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/System.Security.Cryptography.Pkcs.8.0.0.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net6.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net6.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,877 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for PKCS and CMS algorithms.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Pkcs.EnvelopedCms")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values) { }
+
+        public CryptographicAttributeObject(Oid oid) { }
+
+        public Oid Oid { get { throw null; } }
+
+        public AsnEncodedDataCollection Values { get { throw null; } }
+    }
+
+    public sealed partial class CryptographicAttributeObjectCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+
+        public CryptographicAttributeObjectCollection(CryptographicAttributeObject attribute) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CryptographicAttributeObject this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(AsnEncodedData asnEncodedData) { throw null; }
+
+        public int Add(CryptographicAttributeObject attribute) { throw null; }
+
+        public void CopyTo(CryptographicAttributeObject[] array, int index) { }
+
+        public CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CryptographicAttributeObject attribute) { }
+
+        void Collections.ICollection.CopyTo(Array array, int index) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CryptographicAttributeObjectEnumerator : Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+
+        public CryptographicAttributeObject Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+}
+
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+
+        public AlgorithmIdentifier(Oid oid, int keyLength) { }
+
+        public AlgorithmIdentifier(Oid oid) { }
+
+        public int KeyLength { get { throw null; } set { } }
+
+        public Oid Oid { get { throw null; } set { } }
+
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate) { }
+
+        public X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+
+        public RSAEncryptionPadding? RSAEncryptionPadding { get { throw null; } }
+    }
+
+    public sealed partial class CmsRecipientCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+
+        public CmsRecipientCollection(CmsRecipient recipient) { }
+
+        public CmsRecipientCollection(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2Collection certificates) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CmsRecipient this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(CmsRecipient recipient) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(CmsRecipient[] array, int index) { }
+
+        public CmsRecipientEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CmsRecipient recipient) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CmsRecipientEnumerator : Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+
+        public CmsRecipient Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+
+        [Obsolete("CmsSigner(CspParameters) is obsolete and is not supported. Use an alternative constructor instead.", DiagnosticId = "SYSLIB0034", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public CmsSigner(CspParameters parameters) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, AsymmetricAlgorithm? privateKey) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, RSA? privateKey, RSASignaturePadding? signaturePadding) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType) { }
+
+        public CmsSigner(X509Certificates.X509Certificate2? certificate) { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } set { } }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } set { } }
+
+        public X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+
+        public AsymmetricAlgorithm? PrivateKey { get { throw null; } set { } }
+
+        public RSASignaturePadding? SignaturePadding { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+
+        public ContentInfo(Oid contentType, byte[] content) { }
+
+        public byte[] Content { get { throw null; } }
+
+        public Oid ContentType { get { throw null; } }
+
+        public static Oid GetContentType(byte[] encodedMessage) { throw null; }
+
+        public static Oid GetContentType(ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+
+        public EnvelopedCms(ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm) { }
+
+        public EnvelopedCms(ContentInfo contentInfo) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public RecipientInfoCollection RecipientInfos { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public void Decrypt() { }
+
+        public void Decrypt(RecipientInfo recipientInfo, AsymmetricAlgorithm? privateKey) { }
+
+        public void Decrypt(RecipientInfo recipientInfo, X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public void Decrypt(RecipientInfo recipientInfo) { }
+
+        public void Decrypt(X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void Encrypt(CmsRecipient recipient) { }
+
+        public void Encrypt(CmsRecipientCollection recipients) { }
+    }
+
+    public sealed partial class KeyAgreeRecipientInfo : RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+
+        public DateTime Date { get { throw null; } }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+
+        public CryptographicAttributeObject? OtherKeyAttribute { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class KeyTransRecipientInfo : RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12Builder
+    {
+        public bool IsSealed { get { throw null; } }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, byte[]? passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<char> password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, string? password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsUnencrypted(Pkcs12SafeContents safeContents) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void SealWithMac(ReadOnlySpan<char> password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithMac(string? password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithoutIntegrity() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12CertBag : Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(Oid certificateType, ReadOnlyMemory<byte> encodedCertificate) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+
+        public bool IsX509Certificate { get { throw null; } }
+
+        public X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+
+        public Oid GetCertificateType() { throw null; }
+    }
+
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+
+        public Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+
+        public static Pkcs12Info Decode(ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+
+        public bool VerifyMac(ReadOnlySpan<char> password) { throw null; }
+
+        public bool VerifyMac(string? password) { throw null; }
+    }
+
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12KeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public Oid GetBagId() { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Pkcs12CertBag AddCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public Pkcs12KeyBag AddKeyUnencrypted(AsymmetricAlgorithm key) { throw null; }
+
+        public Pkcs12SafeContentsBag AddNestedContents(Pkcs12SafeContents safeContents) { throw null; }
+
+        public void AddSafeBag(Pkcs12SafeBag safeBag) { }
+
+        public Pkcs12SecretBag AddSecret(Oid secretType, ReadOnlyMemory<byte> secretValue) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, byte[]? passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, string? password, PbeParameters pbeParameters) { throw null; }
+
+        public void Decrypt(byte[]? passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<byte> passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<char> password) { }
+
+        public void Decrypt(string? password) { }
+
+        public Collections.Generic.IEnumerable<Pkcs12SafeBag> GetBags() { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContentsBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base(default!, default, default) { }
+
+        public Pkcs12SafeContents? SafeContents { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12SecretBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+
+        public Oid GetSecretType() { throw null; }
+    }
+
+    public sealed partial class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(Oid algorithmId, ReadOnlyMemory<byte>? algorithmParameters, ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+
+        public Oid AlgorithmId { get { throw null; } }
+
+        public ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+
+        public static Pkcs8PrivateKeyInfo Create(AsymmetricAlgorithm privateKey) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo Decode(ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<byte> passwordBytes, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<char> password, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class Pkcs9AttributeObject : AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+
+        public Pkcs9AttributeObject(AsnEncodedData asnEncodedData) { }
+
+        public Pkcs9AttributeObject(Oid oid, byte[] encodedData) { }
+
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+
+        public new Oid? Oid { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9ContentType : Pkcs9AttributeObject
+    {
+        public Oid ContentType { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentDescription : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+
+        public Pkcs9DocumentDescription(string documentDescription) { }
+
+        public string DocumentDescription { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentName : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+
+        public Pkcs9DocumentName(string documentName) { }
+
+        public string DocumentName { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9LocalKeyId : Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+
+        public Pkcs9LocalKeyId(ReadOnlySpan<byte> keyId) { }
+
+        public ReadOnlyMemory<byte> KeyId { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9MessageDigest : Pkcs9AttributeObject
+    {
+        public byte[] MessageDigest { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9SigningTime : Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+
+        public Pkcs9SigningTime(DateTime signingTime) { }
+
+        public DateTime SigningTime { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+
+        public AlgorithmIdentifier Algorithm { get { throw null; } }
+
+        public byte[] KeyValue { get { throw null; } }
+    }
+
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+
+        public abstract byte[] EncryptedKey { get; }
+        public abstract AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract SubjectIdentifier RecipientIdentifier { get; }
+
+        public RecipientInfoType Type { get { throw null; } }
+
+        public abstract int Version { get; }
+    }
+
+    public sealed partial class RecipientInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public RecipientInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(RecipientInfo[] array, int index) { }
+
+        public RecipientInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class RecipientInfoEnumerator : Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+
+        public RecipientInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2
+    }
+
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public Oid? RequestedPolicyId { get { throw null; } }
+
+        public bool RequestSignerCertificate { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static Rfc3161TimestampRequest CreateFromData(ReadOnlySpan<byte> data, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, Oid hashAlgorithmId, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromSignerInfo(SignerInfo signerInfo, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public Rfc3161TimestampToken ProcessResponse(ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampRequest? request, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+
+        public Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+
+        public SignedCms AsSignedCms() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampToken? token, out int bytesConsumed) { throw null; }
+
+        public bool VerifySignatureForData(ReadOnlySpan<byte> data, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, HashAlgorithmName hashAlgorithm, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, Oid hashAlgorithmId, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForSignerInfo(SignerInfo signerInfo, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(Oid policyId, Oid hashAlgorithmId, ReadOnlyMemory<byte> messageHash, ReadOnlyMemory<byte> serialNumber, DateTimeOffset timestamp, long? accuracyInMicroseconds = null, bool isOrdering = false, ReadOnlyMemory<byte>? nonce = null, ReadOnlyMemory<byte>? timestampAuthorityName = null, X509Certificates.X509ExtensionCollection? extensions = null) { }
+
+        public long? AccuracyInMicroseconds { get { throw null; } }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public bool IsOrdering { get { throw null; } }
+
+        public Oid PolicyId { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampTokenInfo? timestampTokenInfo, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+
+        public SignedCms(ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public bool Detached { get { throw null; } }
+
+        public SignerInfoCollection SignerInfos { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(CmsSigner signer, bool silent) { }
+
+        public void ComputeSignature(CmsSigner signer) { }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void RemoveCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void RemoveSignature(int index) { }
+
+        public void RemoveSignature(SignerInfo signerInfo) { }
+    }
+
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+
+        public SignerInfoCollection CounterSignerInfos { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } }
+
+        public Oid SignatureAlgorithm { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifier SignerIdentifier { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        [Obsolete("ComputeCounterSignature without specifying a CmsSigner is obsolete and is not supported. Use the overload that accepts a CmsSigner.", DiagnosticId = "SYSLIB0035", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void ComputeCounterSignature() { }
+
+        public void ComputeCounterSignature(CmsSigner signer) { }
+
+        public byte[] GetSignature() { throw null; }
+
+        public void RemoveCounterSignature(int index) { }
+
+        public void RemoveCounterSignature(SignerInfo counterSignerInfo) { }
+
+        public void RemoveUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+    }
+
+    public sealed partial class SignerInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public SignerInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(SignerInfo[] array, int index) { }
+
+        public SignerInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class SignerInfoEnumerator : Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+
+        public SignerInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+
+        public SubjectIdentifierType Type { get { throw null; } }
+
+        public object? Value { get { throw null; } }
+
+        public bool MatchesCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+
+        public SubjectIdentifierOrKeyType Type { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3
+    }
+
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3
+    }
+}
+
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net7.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net7.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,878 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for PKCS and CMS algorithms.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Pkcs.EnvelopedCms")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values) { }
+
+        public CryptographicAttributeObject(Oid oid) { }
+
+        public Oid Oid { get { throw null; } }
+
+        public AsnEncodedDataCollection Values { get { throw null; } }
+    }
+
+    public sealed partial class CryptographicAttributeObjectCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+
+        public CryptographicAttributeObjectCollection(CryptographicAttributeObject attribute) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CryptographicAttributeObject this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(AsnEncodedData asnEncodedData) { throw null; }
+
+        public int Add(CryptographicAttributeObject attribute) { throw null; }
+
+        public void CopyTo(CryptographicAttributeObject[] array, int index) { }
+
+        public CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CryptographicAttributeObject attribute) { }
+
+        void Collections.ICollection.CopyTo(Array array, int index) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CryptographicAttributeObjectEnumerator : Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+
+        public CryptographicAttributeObject Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+}
+
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+
+        public AlgorithmIdentifier(Oid oid, int keyLength) { }
+
+        public AlgorithmIdentifier(Oid oid) { }
+
+        public int KeyLength { get { throw null; } set { } }
+
+        public Oid Oid { get { throw null; } set { } }
+
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate) { }
+
+        public X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+
+        public RSAEncryptionPadding? RSAEncryptionPadding { get { throw null; } }
+    }
+
+    public sealed partial class CmsRecipientCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+
+        public CmsRecipientCollection(CmsRecipient recipient) { }
+
+        public CmsRecipientCollection(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2Collection certificates) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CmsRecipient this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(CmsRecipient recipient) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(CmsRecipient[] array, int index) { }
+
+        public CmsRecipientEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CmsRecipient recipient) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CmsRecipientEnumerator : Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+
+        public CmsRecipient Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+
+        [Obsolete("CmsSigner(CspParameters) is obsolete and is not supported. Use an alternative constructor instead.", DiagnosticId = "SYSLIB0034", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public CmsSigner(CspParameters parameters) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, AsymmetricAlgorithm? privateKey) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, RSA? privateKey, RSASignaturePadding? signaturePadding) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType) { }
+
+        public CmsSigner(X509Certificates.X509Certificate2? certificate) { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } set { } }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } set { } }
+
+        public X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+
+        public AsymmetricAlgorithm? PrivateKey { get { throw null; } set { } }
+
+        public RSASignaturePadding? SignaturePadding { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+
+        public ContentInfo(Oid contentType, byte[] content) { }
+
+        public byte[] Content { get { throw null; } }
+
+        public Oid ContentType { get { throw null; } }
+
+        public static Oid GetContentType(byte[] encodedMessage) { throw null; }
+
+        public static Oid GetContentType(ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+
+        public EnvelopedCms(ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm) { }
+
+        public EnvelopedCms(ContentInfo contentInfo) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public RecipientInfoCollection RecipientInfos { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public void Decrypt() { }
+
+        public void Decrypt(RecipientInfo recipientInfo, AsymmetricAlgorithm? privateKey) { }
+
+        public void Decrypt(RecipientInfo recipientInfo, X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public void Decrypt(RecipientInfo recipientInfo) { }
+
+        public void Decrypt(X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void Encrypt(CmsRecipient recipient) { }
+
+        public void Encrypt(CmsRecipientCollection recipients) { }
+    }
+
+    public sealed partial class KeyAgreeRecipientInfo : RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+
+        public DateTime Date { get { throw null; } }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+
+        public CryptographicAttributeObject? OtherKeyAttribute { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class KeyTransRecipientInfo : RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12Builder
+    {
+        public bool IsSealed { get { throw null; } }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, byte[]? passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<char> password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, string? password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsUnencrypted(Pkcs12SafeContents safeContents) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void SealWithMac(ReadOnlySpan<char> password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithMac(string? password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithoutIntegrity() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12CertBag : Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(Oid certificateType, ReadOnlyMemory<byte> encodedCertificate) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+
+        public bool IsX509Certificate { get { throw null; } }
+
+        public X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+
+        public Oid GetCertificateType() { throw null; }
+    }
+
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+
+        public Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+
+        public static Pkcs12Info Decode(ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+
+        public bool VerifyMac(ReadOnlySpan<char> password) { throw null; }
+
+        public bool VerifyMac(string? password) { throw null; }
+    }
+
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12KeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public Oid GetBagId() { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Pkcs12CertBag AddCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public Pkcs12KeyBag AddKeyUnencrypted(AsymmetricAlgorithm key) { throw null; }
+
+        public Pkcs12SafeContentsBag AddNestedContents(Pkcs12SafeContents safeContents) { throw null; }
+
+        public void AddSafeBag(Pkcs12SafeBag safeBag) { }
+
+        public Pkcs12SecretBag AddSecret(Oid secretType, ReadOnlyMemory<byte> secretValue) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, byte[]? passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, string? password, PbeParameters pbeParameters) { throw null; }
+
+        public void Decrypt(byte[]? passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<byte> passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<char> password) { }
+
+        public void Decrypt(string? password) { }
+
+        public Collections.Generic.IEnumerable<Pkcs12SafeBag> GetBags() { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContentsBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base(default!, default, default) { }
+
+        public Pkcs12SafeContents? SafeContents { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12SecretBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+
+        public Oid GetSecretType() { throw null; }
+    }
+
+    public sealed partial class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(Oid algorithmId, ReadOnlyMemory<byte>? algorithmParameters, ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+
+        public Oid AlgorithmId { get { throw null; } }
+
+        public ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+
+        public static Pkcs8PrivateKeyInfo Create(AsymmetricAlgorithm privateKey) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo Decode(ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<byte> passwordBytes, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<char> password, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class Pkcs9AttributeObject : AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+
+        public Pkcs9AttributeObject(AsnEncodedData asnEncodedData) { }
+
+        public Pkcs9AttributeObject(Oid oid, byte[] encodedData) { }
+
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+
+        public new Oid? Oid { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9ContentType : Pkcs9AttributeObject
+    {
+        public Oid ContentType { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentDescription : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+
+        public Pkcs9DocumentDescription(string documentDescription) { }
+
+        public string DocumentDescription { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentName : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+
+        public Pkcs9DocumentName(string documentName) { }
+
+        public string DocumentName { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9LocalKeyId : Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+
+        public Pkcs9LocalKeyId(ReadOnlySpan<byte> keyId) { }
+
+        public ReadOnlyMemory<byte> KeyId { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9MessageDigest : Pkcs9AttributeObject
+    {
+        public byte[] MessageDigest { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9SigningTime : Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+
+        public Pkcs9SigningTime(DateTime signingTime) { }
+
+        public DateTime SigningTime { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+
+        public AlgorithmIdentifier Algorithm { get { throw null; } }
+
+        public byte[] KeyValue { get { throw null; } }
+    }
+
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+
+        public abstract byte[] EncryptedKey { get; }
+        public abstract AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract SubjectIdentifier RecipientIdentifier { get; }
+
+        public RecipientInfoType Type { get { throw null; } }
+
+        public abstract int Version { get; }
+    }
+
+    public sealed partial class RecipientInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public RecipientInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(RecipientInfo[] array, int index) { }
+
+        public RecipientInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class RecipientInfoEnumerator : Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+
+        public RecipientInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2
+    }
+
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public Oid? RequestedPolicyId { get { throw null; } }
+
+        public bool RequestSignerCertificate { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static Rfc3161TimestampRequest CreateFromData(ReadOnlySpan<byte> data, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, Oid hashAlgorithmId, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromSignerInfo(SignerInfo signerInfo, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public Rfc3161TimestampToken ProcessResponse(ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampRequest? request, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+
+        public Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+
+        public SignedCms AsSignedCms() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampToken? token, out int bytesConsumed) { throw null; }
+
+        public bool VerifySignatureForData(ReadOnlySpan<byte> data, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, HashAlgorithmName hashAlgorithm, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, Oid hashAlgorithmId, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForSignerInfo(SignerInfo signerInfo, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(Oid policyId, Oid hashAlgorithmId, ReadOnlyMemory<byte> messageHash, ReadOnlyMemory<byte> serialNumber, DateTimeOffset timestamp, long? accuracyInMicroseconds = null, bool isOrdering = false, ReadOnlyMemory<byte>? nonce = null, ReadOnlyMemory<byte>? timestampAuthorityName = null, X509Certificates.X509ExtensionCollection? extensions = null) { }
+
+        public long? AccuracyInMicroseconds { get { throw null; } }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public bool IsOrdering { get { throw null; } }
+
+        public Oid PolicyId { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampTokenInfo? timestampTokenInfo, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+
+        public SignedCms(ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public bool Detached { get { throw null; } }
+
+        public SignerInfoCollection SignerInfos { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(CmsSigner signer, bool silent) { }
+
+        public void ComputeSignature(CmsSigner signer) { }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void RemoveCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void RemoveSignature(int index) { }
+
+        public void RemoveSignature(SignerInfo signerInfo) { }
+    }
+
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+
+        public SignerInfoCollection CounterSignerInfos { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } }
+
+        public Oid SignatureAlgorithm { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifier SignerIdentifier { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        [Obsolete("ComputeCounterSignature without specifying a CmsSigner is obsolete and is not supported. Use the overload that accepts a CmsSigner.", DiagnosticId = "SYSLIB0035", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void ComputeCounterSignature() { }
+
+        public void ComputeCounterSignature(CmsSigner signer) { }
+
+        public byte[] GetSignature() { throw null; }
+
+        public void RemoveCounterSignature(int index) { }
+
+        public void RemoveCounterSignature(SignerInfo counterSignerInfo) { }
+
+        public void RemoveUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+    }
+
+    public sealed partial class SignerInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public SignerInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(SignerInfo[] array, int index) { }
+
+        public SignerInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class SignerInfoEnumerator : Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+
+        public SignerInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+
+        public SubjectIdentifierType Type { get { throw null; } }
+
+        public object? Value { get { throw null; } }
+
+        public bool MatchesCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+
+        public SubjectIdentifierOrKeyType Type { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3
+    }
+
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3
+    }
+}
+
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net8.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/net8.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,878 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for PKCS and CMS algorithms.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Pkcs.EnvelopedCms")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values) { }
+
+        public CryptographicAttributeObject(Oid oid) { }
+
+        public Oid Oid { get { throw null; } }
+
+        public AsnEncodedDataCollection Values { get { throw null; } }
+    }
+
+    public sealed partial class CryptographicAttributeObjectCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+
+        public CryptographicAttributeObjectCollection(CryptographicAttributeObject attribute) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CryptographicAttributeObject this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(AsnEncodedData asnEncodedData) { throw null; }
+
+        public int Add(CryptographicAttributeObject attribute) { throw null; }
+
+        public void CopyTo(CryptographicAttributeObject[] array, int index) { }
+
+        public CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CryptographicAttributeObject attribute) { }
+
+        void Collections.ICollection.CopyTo(Array array, int index) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CryptographicAttributeObjectEnumerator : Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+
+        public CryptographicAttributeObject Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+}
+
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+
+        public AlgorithmIdentifier(Oid oid, int keyLength) { }
+
+        public AlgorithmIdentifier(Oid oid) { }
+
+        public int KeyLength { get { throw null; } set { } }
+
+        public Oid Oid { get { throw null; } set { } }
+
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate) { }
+
+        public X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+
+        public RSAEncryptionPadding? RSAEncryptionPadding { get { throw null; } }
+    }
+
+    public sealed partial class CmsRecipientCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+
+        public CmsRecipientCollection(CmsRecipient recipient) { }
+
+        public CmsRecipientCollection(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2Collection certificates) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CmsRecipient this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(CmsRecipient recipient) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(CmsRecipient[] array, int index) { }
+
+        public CmsRecipientEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CmsRecipient recipient) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CmsRecipientEnumerator : Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+
+        public CmsRecipient Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+
+        [Obsolete("CmsSigner(CspParameters) is obsolete and is not supported. Use an alternative constructor instead.", DiagnosticId = "SYSLIB0034", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public CmsSigner(CspParameters parameters) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, AsymmetricAlgorithm? privateKey) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, RSA? privateKey, RSASignaturePadding? signaturePadding) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType) { }
+
+        public CmsSigner(X509Certificates.X509Certificate2? certificate) { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } set { } }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } set { } }
+
+        public X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+
+        public AsymmetricAlgorithm? PrivateKey { get { throw null; } set { } }
+
+        public RSASignaturePadding? SignaturePadding { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+
+        public ContentInfo(Oid contentType, byte[] content) { }
+
+        public byte[] Content { get { throw null; } }
+
+        public Oid ContentType { get { throw null; } }
+
+        public static Oid GetContentType(byte[] encodedMessage) { throw null; }
+
+        public static Oid GetContentType(ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+
+        public EnvelopedCms(ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm) { }
+
+        public EnvelopedCms(ContentInfo contentInfo) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public RecipientInfoCollection RecipientInfos { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public void Decrypt() { }
+
+        public void Decrypt(RecipientInfo recipientInfo, AsymmetricAlgorithm? privateKey) { }
+
+        public void Decrypt(RecipientInfo recipientInfo, X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public void Decrypt(RecipientInfo recipientInfo) { }
+
+        public void Decrypt(X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void Encrypt(CmsRecipient recipient) { }
+
+        public void Encrypt(CmsRecipientCollection recipients) { }
+    }
+
+    public sealed partial class KeyAgreeRecipientInfo : RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+
+        public DateTime Date { get { throw null; } }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+
+        public CryptographicAttributeObject? OtherKeyAttribute { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class KeyTransRecipientInfo : RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12Builder
+    {
+        public bool IsSealed { get { throw null; } }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, byte[]? passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<char> password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, string? password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsUnencrypted(Pkcs12SafeContents safeContents) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void SealWithMac(ReadOnlySpan<char> password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithMac(string? password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithoutIntegrity() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12CertBag : Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(Oid certificateType, ReadOnlyMemory<byte> encodedCertificate) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+
+        public bool IsX509Certificate { get { throw null; } }
+
+        public X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+
+        public Oid GetCertificateType() { throw null; }
+    }
+
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+
+        public Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+
+        public static Pkcs12Info Decode(ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+
+        public bool VerifyMac(ReadOnlySpan<char> password) { throw null; }
+
+        public bool VerifyMac(string? password) { throw null; }
+    }
+
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12KeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public Oid GetBagId() { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Pkcs12CertBag AddCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public Pkcs12KeyBag AddKeyUnencrypted(AsymmetricAlgorithm key) { throw null; }
+
+        public Pkcs12SafeContentsBag AddNestedContents(Pkcs12SafeContents safeContents) { throw null; }
+
+        public void AddSafeBag(Pkcs12SafeBag safeBag) { }
+
+        public Pkcs12SecretBag AddSecret(Oid secretType, ReadOnlyMemory<byte> secretValue) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, byte[]? passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, string? password, PbeParameters pbeParameters) { throw null; }
+
+        public void Decrypt(byte[]? passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<byte> passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<char> password) { }
+
+        public void Decrypt(string? password) { }
+
+        public Collections.Generic.IEnumerable<Pkcs12SafeBag> GetBags() { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContentsBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base(default!, default, default) { }
+
+        public Pkcs12SafeContents? SafeContents { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12SecretBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+
+        public Oid GetSecretType() { throw null; }
+    }
+
+    public sealed partial class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(Oid algorithmId, ReadOnlyMemory<byte>? algorithmParameters, ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+
+        public Oid AlgorithmId { get { throw null; } }
+
+        public ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+
+        public static Pkcs8PrivateKeyInfo Create(AsymmetricAlgorithm privateKey) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo Decode(ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<byte> passwordBytes, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<char> password, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class Pkcs9AttributeObject : AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+
+        public Pkcs9AttributeObject(AsnEncodedData asnEncodedData) { }
+
+        public Pkcs9AttributeObject(Oid oid, byte[] encodedData) { }
+
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+
+        public new Oid? Oid { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9ContentType : Pkcs9AttributeObject
+    {
+        public Oid ContentType { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentDescription : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+
+        public Pkcs9DocumentDescription(string documentDescription) { }
+
+        public string DocumentDescription { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentName : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+
+        public Pkcs9DocumentName(string documentName) { }
+
+        public string DocumentName { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9LocalKeyId : Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+
+        public Pkcs9LocalKeyId(ReadOnlySpan<byte> keyId) { }
+
+        public ReadOnlyMemory<byte> KeyId { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9MessageDigest : Pkcs9AttributeObject
+    {
+        public byte[] MessageDigest { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9SigningTime : Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+
+        public Pkcs9SigningTime(DateTime signingTime) { }
+
+        public DateTime SigningTime { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+
+        public AlgorithmIdentifier Algorithm { get { throw null; } }
+
+        public byte[] KeyValue { get { throw null; } }
+    }
+
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+
+        public abstract byte[] EncryptedKey { get; }
+        public abstract AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract SubjectIdentifier RecipientIdentifier { get; }
+
+        public RecipientInfoType Type { get { throw null; } }
+
+        public abstract int Version { get; }
+    }
+
+    public sealed partial class RecipientInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public RecipientInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(RecipientInfo[] array, int index) { }
+
+        public RecipientInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class RecipientInfoEnumerator : Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+
+        public RecipientInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2
+    }
+
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public Oid? RequestedPolicyId { get { throw null; } }
+
+        public bool RequestSignerCertificate { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static Rfc3161TimestampRequest CreateFromData(ReadOnlySpan<byte> data, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, Oid hashAlgorithmId, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromSignerInfo(SignerInfo signerInfo, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public Rfc3161TimestampToken ProcessResponse(ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampRequest? request, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+
+        public Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+
+        public SignedCms AsSignedCms() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampToken? token, out int bytesConsumed) { throw null; }
+
+        public bool VerifySignatureForData(ReadOnlySpan<byte> data, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, HashAlgorithmName hashAlgorithm, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, Oid hashAlgorithmId, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForSignerInfo(SignerInfo signerInfo, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(Oid policyId, Oid hashAlgorithmId, ReadOnlyMemory<byte> messageHash, ReadOnlyMemory<byte> serialNumber, DateTimeOffset timestamp, long? accuracyInMicroseconds = null, bool isOrdering = false, ReadOnlyMemory<byte>? nonce = null, ReadOnlyMemory<byte>? timestampAuthorityName = null, X509Certificates.X509ExtensionCollection? extensions = null) { }
+
+        public long? AccuracyInMicroseconds { get { throw null; } }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public bool IsOrdering { get { throw null; } }
+
+        public Oid PolicyId { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampTokenInfo? timestampTokenInfo, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+
+        public SignedCms(ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public bool Detached { get { throw null; } }
+
+        public SignerInfoCollection SignerInfos { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(CmsSigner signer, bool silent) { }
+
+        public void ComputeSignature(CmsSigner signer) { }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void RemoveCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void RemoveSignature(int index) { }
+
+        public void RemoveSignature(SignerInfo signerInfo) { }
+    }
+
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+
+        public SignerInfoCollection CounterSignerInfos { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } }
+
+        public Oid SignatureAlgorithm { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifier SignerIdentifier { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        [Obsolete("ComputeCounterSignature without specifying a CmsSigner is obsolete and is not supported. Use the overload that accepts a CmsSigner.", DiagnosticId = "SYSLIB0035", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void ComputeCounterSignature() { }
+
+        public void ComputeCounterSignature(CmsSigner signer) { }
+
+        public byte[] GetSignature() { throw null; }
+
+        public void RemoveCounterSignature(int index) { }
+
+        public void RemoveCounterSignature(SignerInfo counterSignerInfo) { }
+
+        public void RemoveUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+    }
+
+    public sealed partial class SignerInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public SignerInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(SignerInfo[] array, int index) { }
+
+        public SignerInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class SignerInfoEnumerator : Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+
+        public SignerInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+
+        public SubjectIdentifierType Type { get { throw null; } }
+
+        public object? Value { get { throw null; } }
+
+        public bool MatchesCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+
+        public SubjectIdentifierOrKeyType Type { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3
+    }
+
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3
+    }
+}
+
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/netstandard2.0/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/netstandard2.0/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,582 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for PKCS and CMS algorithms.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Pkcs.EnvelopedCms")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values) { }
+
+        public CryptographicAttributeObject(Oid oid) { }
+
+        public Oid Oid { get { throw null; } }
+
+        public AsnEncodedDataCollection Values { get { throw null; } }
+    }
+
+    public sealed partial class CryptographicAttributeObjectCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+
+        public CryptographicAttributeObjectCollection(CryptographicAttributeObject attribute) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CryptographicAttributeObject this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(AsnEncodedData asnEncodedData) { throw null; }
+
+        public int Add(CryptographicAttributeObject attribute) { throw null; }
+
+        public void CopyTo(CryptographicAttributeObject[] array, int index) { }
+
+        public CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CryptographicAttributeObject attribute) { }
+
+        void Collections.ICollection.CopyTo(Array array, int index) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CryptographicAttributeObjectEnumerator : Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+
+        public CryptographicAttributeObject Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+}
+
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+
+        public AlgorithmIdentifier(Oid oid, int keyLength) { }
+
+        public AlgorithmIdentifier(Oid oid) { }
+
+        public int KeyLength { get { throw null; } set { } }
+
+        public Oid Oid { get { throw null; } set { } }
+
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate) { }
+
+        public X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+    }
+
+    public sealed partial class CmsRecipientCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+
+        public CmsRecipientCollection(CmsRecipient recipient) { }
+
+        public CmsRecipientCollection(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2Collection certificates) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CmsRecipient this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(CmsRecipient recipient) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(CmsRecipient[] array, int index) { }
+
+        public CmsRecipientEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CmsRecipient recipient) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CmsRecipientEnumerator : Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+
+        public CmsRecipient Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+
+        public CmsSigner(CspParameters parameters) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, AsymmetricAlgorithm? privateKey) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, RSA? privateKey, RSASignaturePadding? signaturePadding) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType) { }
+
+        public CmsSigner(X509Certificates.X509Certificate2? certificate) { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } set { } }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } set { } }
+
+        public X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+
+        public AsymmetricAlgorithm? PrivateKey { get { throw null; } set { } }
+
+        public RSASignaturePadding? SignaturePadding { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+
+        public ContentInfo(Oid contentType, byte[] content) { }
+
+        public byte[] Content { get { throw null; } }
+
+        public Oid ContentType { get { throw null; } }
+
+        public static Oid GetContentType(byte[] encodedMessage) { throw null; }
+
+        public static Oid GetContentType(ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+
+        public EnvelopedCms(ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm) { }
+
+        public EnvelopedCms(ContentInfo contentInfo) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public RecipientInfoCollection RecipientInfos { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public void Decrypt() { }
+
+        public void Decrypt(RecipientInfo recipientInfo, AsymmetricAlgorithm? privateKey) { }
+
+        public void Decrypt(RecipientInfo recipientInfo, X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public void Decrypt(RecipientInfo recipientInfo) { }
+
+        public void Decrypt(X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void Encrypt(CmsRecipient recipient) { }
+
+        public void Encrypt(CmsRecipientCollection recipients) { }
+    }
+
+    public sealed partial class KeyAgreeRecipientInfo : RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+
+        public DateTime Date { get { throw null; } }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+
+        public CryptographicAttributeObject? OtherKeyAttribute { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class KeyTransRecipientInfo : RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public partial class Pkcs9AttributeObject : AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+
+        public Pkcs9AttributeObject(AsnEncodedData asnEncodedData) { }
+
+        public Pkcs9AttributeObject(Oid oid, byte[] encodedData) { }
+
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+
+        public new Oid? Oid { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9ContentType : Pkcs9AttributeObject
+    {
+        public Oid ContentType { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentDescription : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+
+        public Pkcs9DocumentDescription(string documentDescription) { }
+
+        public string DocumentDescription { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentName : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+
+        public Pkcs9DocumentName(string documentName) { }
+
+        public string DocumentName { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9MessageDigest : Pkcs9AttributeObject
+    {
+        public byte[] MessageDigest { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9SigningTime : Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+
+        public Pkcs9SigningTime(DateTime signingTime) { }
+
+        public DateTime SigningTime { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+
+        public AlgorithmIdentifier Algorithm { get { throw null; } }
+
+        public byte[] KeyValue { get { throw null; } }
+    }
+
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+
+        public abstract byte[] EncryptedKey { get; }
+        public abstract AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract SubjectIdentifier RecipientIdentifier { get; }
+
+        public RecipientInfoType Type { get { throw null; } }
+
+        public abstract int Version { get; }
+    }
+
+    public sealed partial class RecipientInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public RecipientInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(RecipientInfo[] array, int index) { }
+
+        public RecipientInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class RecipientInfoEnumerator : Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+
+        public RecipientInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2
+    }
+
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+
+        public SignedCms(ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public bool Detached { get { throw null; } }
+
+        public SignerInfoCollection SignerInfos { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(CmsSigner signer, bool silent) { }
+
+        public void ComputeSignature(CmsSigner signer) { }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void RemoveCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void RemoveSignature(int index) { }
+
+        public void RemoveSignature(SignerInfo signerInfo) { }
+    }
+
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+
+        public SignerInfoCollection CounterSignerInfos { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } }
+
+        public Oid SignatureAlgorithm { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifier SignerIdentifier { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeCounterSignature() { }
+
+        public void ComputeCounterSignature(CmsSigner signer) { }
+
+        public byte[] GetSignature() { throw null; }
+
+        public void RemoveCounterSignature(int index) { }
+
+        public void RemoveCounterSignature(SignerInfo counterSignerInfo) { }
+
+        public void RemoveUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+    }
+
+    public sealed partial class SignerInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public SignerInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(SignerInfo[] array, int index) { }
+
+        public SignerInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class SignerInfoEnumerator : Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+
+        public SignerInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+
+        public SubjectIdentifierType Type { get { throw null; } }
+
+        public object? Value { get { throw null; } }
+
+        public bool MatchesCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+
+        public SubjectIdentifierOrKeyType Type { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3
+    }
+
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3
+    }
+}
+
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/netstandard2.1/System.Security.Cryptography.Pkcs.cs
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/lib/netstandard2.1/System.Security.Cryptography.Pkcs.cs
@@ -1,0 +1,874 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName = ".NET Standard 2.1")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Pkcs")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for PKCS and CMS algorithms.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Pkcs.EnvelopedCms")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Pkcs")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography
+{
+    public sealed partial class CryptographicAttributeObject
+    {
+        public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values) { }
+
+        public CryptographicAttributeObject(Oid oid) { }
+
+        public Oid Oid { get { throw null; } }
+
+        public AsnEncodedDataCollection Values { get { throw null; } }
+    }
+
+    public sealed partial class CryptographicAttributeObjectCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CryptographicAttributeObjectCollection() { }
+
+        public CryptographicAttributeObjectCollection(CryptographicAttributeObject attribute) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CryptographicAttributeObject this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(AsnEncodedData asnEncodedData) { throw null; }
+
+        public int Add(CryptographicAttributeObject attribute) { throw null; }
+
+        public void CopyTo(CryptographicAttributeObject[] array, int index) { }
+
+        public CryptographicAttributeObjectEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CryptographicAttributeObject attribute) { }
+
+        void Collections.ICollection.CopyTo(Array array, int index) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CryptographicAttributeObjectEnumerator : Collections.IEnumerator
+    {
+        internal CryptographicAttributeObjectEnumerator() { }
+
+        public CryptographicAttributeObject Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+}
+
+namespace System.Security.Cryptography.Pkcs
+{
+    public sealed partial class AlgorithmIdentifier
+    {
+        public AlgorithmIdentifier() { }
+
+        public AlgorithmIdentifier(Oid oid, int keyLength) { }
+
+        public AlgorithmIdentifier(Oid oid) { }
+
+        public int KeyLength { get { throw null; } set { } }
+
+        public Oid Oid { get { throw null; } set { } }
+
+        public byte[] Parameters { get { throw null; } set { } }
+    }
+
+    public sealed partial class CmsRecipient
+    {
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2 certificate) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate, RSAEncryptionPadding rsaEncryptionPadding) { }
+
+        public CmsRecipient(X509Certificates.X509Certificate2 certificate) { }
+
+        public X509Certificates.X509Certificate2 Certificate { get { throw null; } }
+
+        public SubjectIdentifierType RecipientIdentifierType { get { throw null; } }
+
+        public RSAEncryptionPadding? RSAEncryptionPadding { get { throw null; } }
+    }
+
+    public sealed partial class CmsRecipientCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        public CmsRecipientCollection() { }
+
+        public CmsRecipientCollection(CmsRecipient recipient) { }
+
+        public CmsRecipientCollection(SubjectIdentifierType recipientIdentifierType, X509Certificates.X509Certificate2Collection certificates) { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public CmsRecipient this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public int Add(CmsRecipient recipient) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(CmsRecipient[] array, int index) { }
+
+        public CmsRecipientEnumerator GetEnumerator() { throw null; }
+
+        public void Remove(CmsRecipient recipient) { }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class CmsRecipientEnumerator : Collections.IEnumerator
+    {
+        internal CmsRecipientEnumerator() { }
+
+        public CmsRecipient Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class CmsSigner
+    {
+        public CmsSigner() { }
+
+        public CmsSigner(CspParameters parameters) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, AsymmetricAlgorithm? privateKey) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate, RSA? privateKey, RSASignaturePadding? signaturePadding) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType, X509Certificates.X509Certificate2? certificate) { }
+
+        public CmsSigner(SubjectIdentifierType signerIdentifierType) { }
+
+        public CmsSigner(X509Certificates.X509Certificate2? certificate) { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } set { } }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } set { } }
+
+        public X509Certificates.X509IncludeOption IncludeOption { get { throw null; } set { } }
+
+        public AsymmetricAlgorithm? PrivateKey { get { throw null; } set { } }
+
+        public RSASignaturePadding? SignaturePadding { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifierType SignerIdentifierType { get { throw null; } set { } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+    }
+
+    public sealed partial class ContentInfo
+    {
+        public ContentInfo(byte[] content) { }
+
+        public ContentInfo(Oid contentType, byte[] content) { }
+
+        public byte[] Content { get { throw null; } }
+
+        public Oid ContentType { get { throw null; } }
+
+        public static Oid GetContentType(byte[] encodedMessage) { throw null; }
+
+        public static Oid GetContentType(ReadOnlySpan<byte> encodedMessage) { throw null; }
+    }
+
+    public sealed partial class EnvelopedCms
+    {
+        public EnvelopedCms() { }
+
+        public EnvelopedCms(ContentInfo contentInfo, AlgorithmIdentifier encryptionAlgorithm) { }
+
+        public EnvelopedCms(ContentInfo contentInfo) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public AlgorithmIdentifier ContentEncryptionAlgorithm { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public RecipientInfoCollection RecipientInfos { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnprotectedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public void Decrypt() { }
+
+        public void Decrypt(RecipientInfo recipientInfo, AsymmetricAlgorithm? privateKey) { }
+
+        public void Decrypt(RecipientInfo recipientInfo, X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public void Decrypt(RecipientInfo recipientInfo) { }
+
+        public void Decrypt(X509Certificates.X509Certificate2Collection extraStore) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void Encrypt(CmsRecipient recipient) { }
+
+        public void Encrypt(CmsRecipientCollection recipients) { }
+    }
+
+    public sealed partial class KeyAgreeRecipientInfo : RecipientInfo
+    {
+        internal KeyAgreeRecipientInfo() { }
+
+        public DateTime Date { get { throw null; } }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public SubjectIdentifierOrKey OriginatorIdentifierOrKey { get { throw null; } }
+
+        public CryptographicAttributeObject? OtherKeyAttribute { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class KeyTransRecipientInfo : RecipientInfo
+    {
+        internal KeyTransRecipientInfo() { }
+
+        public override byte[] EncryptedKey { get { throw null; } }
+
+        public override AlgorithmIdentifier KeyEncryptionAlgorithm { get { throw null; } }
+
+        public override SubjectIdentifier RecipientIdentifier { get { throw null; } }
+
+        public override int Version { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12Builder
+    {
+        public bool IsSealed { get { throw null; } }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, byte[]? passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, ReadOnlySpan<char> password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsEncrypted(Pkcs12SafeContents safeContents, string? password, PbeParameters pbeParameters) { }
+
+        public void AddSafeContentsUnencrypted(Pkcs12SafeContents safeContents) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void SealWithMac(ReadOnlySpan<char> password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithMac(string? password, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+
+        public void SealWithoutIntegrity() { }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12CertBag : Pkcs12SafeBag
+    {
+        public Pkcs12CertBag(Oid certificateType, ReadOnlyMemory<byte> encodedCertificate) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncodedCertificate { get { throw null; } }
+
+        public bool IsX509Certificate { get { throw null; } }
+
+        public X509Certificates.X509Certificate2 GetCertificate() { throw null; }
+
+        public Oid GetCertificateType() { throw null; }
+    }
+
+    public enum Pkcs12ConfidentialityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12Info
+    {
+        internal Pkcs12Info() { }
+
+        public Collections.ObjectModel.ReadOnlyCollection<Pkcs12SafeContents> AuthenticatedSafe { get { throw null; } }
+
+        public Pkcs12IntegrityMode IntegrityMode { get { throw null; } }
+
+        public static Pkcs12Info Decode(ReadOnlyMemory<byte> encodedBytes, out int bytesConsumed, bool skipCopy = false) { throw null; }
+
+        public bool VerifyMac(ReadOnlySpan<char> password) { throw null; }
+
+        public bool VerifyMac(string? password) { throw null; }
+    }
+
+    public enum Pkcs12IntegrityMode
+    {
+        Unknown = 0,
+        None = 1,
+        Password = 2,
+        PublicKey = 3
+    }
+
+    public sealed partial class Pkcs12KeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12KeyBag(ReadOnlyMemory<byte> pkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> Pkcs8PrivateKey { get { throw null; } }
+    }
+
+    public abstract partial class Pkcs12SafeBag
+    {
+        protected Pkcs12SafeBag(string bagIdValue, ReadOnlyMemory<byte> encodedBagValue, bool skipCopy = false) { }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> EncodedBagValue { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public Oid GetBagId() { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContents
+    {
+        public Pkcs12ConfidentialityMode ConfidentialityMode { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public Pkcs12CertBag AddCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public Pkcs12KeyBag AddKeyUnencrypted(AsymmetricAlgorithm key) { throw null; }
+
+        public Pkcs12SafeContentsBag AddNestedContents(Pkcs12SafeContents safeContents) { throw null; }
+
+        public void AddSafeBag(Pkcs12SafeBag safeBag) { }
+
+        public Pkcs12SecretBag AddSecret(Oid secretType, ReadOnlyMemory<byte> secretValue) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, byte[]? passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public Pkcs12ShroudedKeyBag AddShroudedKey(AsymmetricAlgorithm key, string? password, PbeParameters pbeParameters) { throw null; }
+
+        public void Decrypt(byte[]? passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<byte> passwordBytes) { }
+
+        public void Decrypt(ReadOnlySpan<char> password) { }
+
+        public void Decrypt(string? password) { }
+
+        public Collections.Generic.IEnumerable<Pkcs12SafeBag> GetBags() { throw null; }
+    }
+
+    public sealed partial class Pkcs12SafeContentsBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SafeContentsBag() : base(default!, default, default) { }
+
+        public Pkcs12SafeContents? SafeContents { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs12SecretBag : Pkcs12SafeBag
+    {
+        internal Pkcs12SecretBag() : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> SecretValue { get { throw null; } }
+
+        public Oid GetSecretType() { throw null; }
+    }
+
+    public sealed partial class Pkcs12ShroudedKeyBag : Pkcs12SafeBag
+    {
+        public Pkcs12ShroudedKeyBag(ReadOnlyMemory<byte> encryptedPkcs8PrivateKey, bool skipCopy = false) : base(default!, default, default) { }
+
+        public ReadOnlyMemory<byte> EncryptedPkcs8PrivateKey { get { throw null; } }
+    }
+
+    public sealed partial class Pkcs8PrivateKeyInfo
+    {
+        public Pkcs8PrivateKeyInfo(Oid algorithmId, ReadOnlyMemory<byte>? algorithmParameters, ReadOnlyMemory<byte> privateKey, bool skipCopies = false) { }
+
+        public Oid AlgorithmId { get { throw null; } }
+
+        public ReadOnlyMemory<byte>? AlgorithmParameters { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection Attributes { get { throw null; } }
+
+        public ReadOnlyMemory<byte> PrivateKeyBytes { get { throw null; } }
+
+        public static Pkcs8PrivateKeyInfo Create(AsymmetricAlgorithm privateKey) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo Decode(ReadOnlyMemory<byte> source, out int bytesRead, bool skipCopy = false) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<byte> passwordBytes, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public static Pkcs8PrivateKeyInfo DecryptAndDecode(ReadOnlySpan<char> password, ReadOnlyMemory<byte> source, out int bytesRead) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+
+        public byte[] Encrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+
+        public bool TryEncrypt(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class Pkcs9AttributeObject : AsnEncodedData
+    {
+        public Pkcs9AttributeObject() { }
+
+        public Pkcs9AttributeObject(AsnEncodedData asnEncodedData) { }
+
+        public Pkcs9AttributeObject(Oid oid, byte[] encodedData) { }
+
+        public Pkcs9AttributeObject(string oid, byte[] encodedData) { }
+
+        public new Oid? Oid { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9ContentType : Pkcs9AttributeObject
+    {
+        public Oid ContentType { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentDescription : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentDescription() { }
+
+        public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
+
+        public Pkcs9DocumentDescription(string documentDescription) { }
+
+        public string DocumentDescription { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9DocumentName : Pkcs9AttributeObject
+    {
+        public Pkcs9DocumentName() { }
+
+        public Pkcs9DocumentName(byte[] encodedDocumentName) { }
+
+        public Pkcs9DocumentName(string documentName) { }
+
+        public string DocumentName { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9LocalKeyId : Pkcs9AttributeObject
+    {
+        public Pkcs9LocalKeyId() { }
+
+        public Pkcs9LocalKeyId(byte[] keyId) { }
+
+        public Pkcs9LocalKeyId(ReadOnlySpan<byte> keyId) { }
+
+        public ReadOnlyMemory<byte> KeyId { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9MessageDigest : Pkcs9AttributeObject
+    {
+        public byte[] MessageDigest { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class Pkcs9SigningTime : Pkcs9AttributeObject
+    {
+        public Pkcs9SigningTime() { }
+
+        public Pkcs9SigningTime(byte[] encodedSigningTime) { }
+
+        public Pkcs9SigningTime(DateTime signingTime) { }
+
+        public DateTime SigningTime { get { throw null; } }
+
+        public override void CopyFrom(AsnEncodedData asnEncodedData) { }
+    }
+
+    public sealed partial class PublicKeyInfo
+    {
+        internal PublicKeyInfo() { }
+
+        public AlgorithmIdentifier Algorithm { get { throw null; } }
+
+        public byte[] KeyValue { get { throw null; } }
+    }
+
+    public abstract partial class RecipientInfo
+    {
+        internal RecipientInfo() { }
+
+        public abstract byte[] EncryptedKey { get; }
+        public abstract AlgorithmIdentifier KeyEncryptionAlgorithm { get; }
+        public abstract SubjectIdentifier RecipientIdentifier { get; }
+
+        public RecipientInfoType Type { get { throw null; } }
+
+        public abstract int Version { get; }
+    }
+
+    public sealed partial class RecipientInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal RecipientInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public RecipientInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(RecipientInfo[] array, int index) { }
+
+        public RecipientInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class RecipientInfoEnumerator : Collections.IEnumerator
+    {
+        internal RecipientInfoEnumerator() { }
+
+        public RecipientInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public enum RecipientInfoType
+    {
+        Unknown = 0,
+        KeyTransport = 1,
+        KeyAgreement = 2
+    }
+
+    public sealed partial class Rfc3161TimestampRequest
+    {
+        internal Rfc3161TimestampRequest() { }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public Oid? RequestedPolicyId { get { throw null; } }
+
+        public bool RequestSignerCertificate { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public static Rfc3161TimestampRequest CreateFromData(ReadOnlySpan<byte> data, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromHash(ReadOnlyMemory<byte> hash, Oid hashAlgorithmId, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public static Rfc3161TimestampRequest CreateFromSignerInfo(SignerInfo signerInfo, HashAlgorithmName hashAlgorithm, Oid? requestedPolicyId = null, ReadOnlyMemory<byte>? nonce = null, bool requestSignerCertificates = false, X509Certificates.X509ExtensionCollection? extensions = null) { throw null; }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public Rfc3161TimestampToken ProcessResponse(ReadOnlyMemory<byte> responseBytes, out int bytesConsumed) { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampRequest? request, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampToken
+    {
+        internal Rfc3161TimestampToken() { }
+
+        public Rfc3161TimestampTokenInfo TokenInfo { get { throw null; } }
+
+        public SignedCms AsSignedCms() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampToken? token, out int bytesConsumed) { throw null; }
+
+        public bool VerifySignatureForData(ReadOnlySpan<byte> data, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, HashAlgorithmName hashAlgorithm, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForHash(ReadOnlySpan<byte> hash, Oid hashAlgorithmId, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+
+        public bool VerifySignatureForSignerInfo(SignerInfo signerInfo, out X509Certificates.X509Certificate2? signerCertificate, X509Certificates.X509Certificate2Collection? extraCandidates = null) { throw null; }
+    }
+
+    public sealed partial class Rfc3161TimestampTokenInfo
+    {
+        public Rfc3161TimestampTokenInfo(Oid policyId, Oid hashAlgorithmId, ReadOnlyMemory<byte> messageHash, ReadOnlyMemory<byte> serialNumber, DateTimeOffset timestamp, long? accuracyInMicroseconds = null, bool isOrdering = false, ReadOnlyMemory<byte>? nonce = null, ReadOnlyMemory<byte>? timestampAuthorityName = null, X509Certificates.X509ExtensionCollection? extensions = null) { }
+
+        public long? AccuracyInMicroseconds { get { throw null; } }
+
+        public bool HasExtensions { get { throw null; } }
+
+        public Oid HashAlgorithmId { get { throw null; } }
+
+        public bool IsOrdering { get { throw null; } }
+
+        public Oid PolicyId { get { throw null; } }
+
+        public DateTimeOffset Timestamp { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public byte[] Encode() { throw null; }
+
+        public X509Certificates.X509ExtensionCollection GetExtensions() { throw null; }
+
+        public ReadOnlyMemory<byte> GetMessageHash() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetNonce() { throw null; }
+
+        public ReadOnlyMemory<byte> GetSerialNumber() { throw null; }
+
+        public ReadOnlyMemory<byte>? GetTimestampAuthorityName() { throw null; }
+
+        public static bool TryDecode(ReadOnlyMemory<byte> encodedBytes, out Rfc3161TimestampTokenInfo? timestampTokenInfo, out int bytesConsumed) { throw null; }
+
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class SignedCms
+    {
+        public SignedCms() { }
+
+        public SignedCms(ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo, bool detached) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType, ContentInfo contentInfo) { }
+
+        public SignedCms(SubjectIdentifierType signerIdentifierType) { }
+
+        public X509Certificates.X509Certificate2Collection Certificates { get { throw null; } }
+
+        public ContentInfo ContentInfo { get { throw null; } }
+
+        public bool Detached { get { throw null; } }
+
+        public SignerInfoCollection SignerInfos { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(CmsSigner signer, bool silent) { }
+
+        public void ComputeSignature(CmsSigner signer) { }
+
+        public void Decode(byte[] encodedMessage) { }
+
+        public void Decode(ReadOnlySpan<byte> encodedMessage) { }
+
+        public byte[] Encode() { throw null; }
+
+        public void RemoveCertificate(X509Certificates.X509Certificate2 certificate) { }
+
+        public void RemoveSignature(int index) { }
+
+        public void RemoveSignature(SignerInfo signerInfo) { }
+    }
+
+    public sealed partial class SignerInfo
+    {
+        internal SignerInfo() { }
+
+        public X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+
+        public SignerInfoCollection CounterSignerInfos { get { throw null; } }
+
+        public Oid DigestAlgorithm { get { throw null; } }
+
+        public Oid SignatureAlgorithm { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection SignedAttributes { get { throw null; } }
+
+        public SubjectIdentifier SignerIdentifier { get { throw null; } }
+
+        public CryptographicAttributeObjectCollection UnsignedAttributes { get { throw null; } }
+
+        public int Version { get { throw null; } }
+
+        public void AddUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+
+        public void CheckHash() { }
+
+        public void CheckSignature(bool verifySignatureOnly) { }
+
+        public void CheckSignature(X509Certificates.X509Certificate2Collection extraStore, bool verifySignatureOnly) { }
+
+        public void ComputeCounterSignature() { }
+
+        public void ComputeCounterSignature(CmsSigner signer) { }
+
+        public byte[] GetSignature() { throw null; }
+
+        public void RemoveCounterSignature(int index) { }
+
+        public void RemoveCounterSignature(SignerInfo counterSignerInfo) { }
+
+        public void RemoveUnsignedAttribute(AsnEncodedData unsignedAttribute) { }
+    }
+
+    public sealed partial class SignerInfoCollection : Collections.ICollection, Collections.IEnumerable
+    {
+        internal SignerInfoCollection() { }
+
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public SignerInfo this[int index] { get { throw null; } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(SignerInfo[] array, int index) { }
+
+        public SignerInfoEnumerator GetEnumerator() { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+
+    public sealed partial class SignerInfoEnumerator : Collections.IEnumerator
+    {
+        internal SignerInfoEnumerator() { }
+
+        public SignerInfo Current { get { throw null; } }
+
+        object Collections.IEnumerator.Current { get { throw null; } }
+
+        public bool MoveNext() { throw null; }
+
+        public void Reset() { }
+    }
+
+    public sealed partial class SubjectIdentifier
+    {
+        internal SubjectIdentifier() { }
+
+        public SubjectIdentifierType Type { get { throw null; } }
+
+        public object? Value { get { throw null; } }
+
+        public bool MatchesCertificate(X509Certificates.X509Certificate2 certificate) { throw null; }
+    }
+
+    public sealed partial class SubjectIdentifierOrKey
+    {
+        internal SubjectIdentifierOrKey() { }
+
+        public SubjectIdentifierOrKeyType Type { get { throw null; } }
+
+        public object Value { get { throw null; } }
+    }
+
+    public enum SubjectIdentifierOrKeyType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        PublicKeyInfo = 3
+    }
+
+    public enum SubjectIdentifierType
+    {
+        Unknown = 0,
+        IssuerAndSerialNumber = 1,
+        SubjectKeyIdentifier = 2,
+        NoSignature = 3
+    }
+}
+
+namespace System.Security.Cryptography.Xml
+{
+    public partial struct X509IssuerSerial
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public string IssuerName { get { throw null; } set { } }
+
+        public string SerialNumber { get { throw null; } set { } }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/system.security.cryptography.pkcs.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/system.security.cryptography.pkcs.nuspec
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Security.Cryptography.Pkcs</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides support for PKCS and CMS algorithms.
+
+Commonly Used Types:
+System.Security.Cryptography.Pkcs.EnvelopedCms</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Formats.Asn1" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Formats.Asn1" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Formats.Asn1" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Formats.Asn1" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Formats.Asn1" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/System.Security.Cryptography.Xml.8.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/System.Security.Cryptography.Xml.8.0.0.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net6.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net6.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,936 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net7.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net7.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,955 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net8.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/net8.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,956 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/netstandard2.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/lib/netstandard2.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,900 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.23.53103")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.0+5535e31a712343a63f5d7d796cd874e563e5ac14")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        public EncryptedXml() { }
+
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public void DecryptDocument() { }
+
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")] // Adding attribute manually as GenAPI filters it out
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        public SignedXml() { }
+
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/system.security.cryptography.xml.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/system.security.cryptography.xml.nuspec
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Security.Cryptography.Xml</id>
+    <version>8.0.0</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.
+
+Commonly Used Types:
+System.Security.Cryptography.Xml.CipherData
+System.Security.Cryptography.Xml.CipherReference
+System.Security.Cryptography.Xml.DataObject
+System.Security.Cryptography.Xml.DataReference
+System.Security.Cryptography.Xml.DSAKeyValue
+System.Security.Cryptography.Xml.EncryptedData
+System.Security.Cryptography.Xml.EncryptedKey
+System.Security.Cryptography.Xml.EncryptedReference
+System.Security.Cryptography.Xml.EncryptedType
+System.Security.Cryptography.Xml.EncryptedXml
+System.Security.Cryptography.Xml.EncryptionMethod
+System.Security.Cryptography.Xml.EncryptionProperty
+System.Security.Cryptography.Xml.EncryptionPropertyCollection
+System.Security.Cryptography.Xml.KeyInfo
+System.Security.Cryptography.Xml.KeyInfoClause
+System.Security.Cryptography.Xml.KeyInfoEncryptedKey
+System.Security.Cryptography.Xml.KeyInfoName
+System.Security.Cryptography.Xml.KeyInfoNode
+System.Security.Cryptography.Xml.KeyInfoRetrievalMethod
+System.Security.Cryptography.Xml.KeyInfoX509Data
+System.Security.Cryptography.Xml.KeyReference
+System.Security.Cryptography.Xml.Reference
+System.Security.Cryptography.Xml.ReferenceList
+System.Security.Cryptography.Xml.RSAKeyValue
+System.Security.Cryptography.Xml.Signature
+System.Security.Cryptography.Xml.SignedInfo
+System.Security.Cryptography.Xml.SignedXml
+System.Security.Cryptography.Xml.Transform
+System.Security.Cryptography.Xml.TransformChain
+System.Security.Cryptography.Xml.XmlDecryptionTransform
+System.Security.Cryptography.Xml.XmlDsigBase64Transform
+System.Security.Cryptography.Xml.XmlDsigC14NTransform
+System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigXPathTransform
+System.Security.Cryptography.Xml.XmlDsigXsltTransform
+System.Security.Cryptography.Xml.XmlLicenseTransform</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="5535e31a712343a63f5d7d796cd874e563e5ac14" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Security.AccessControl" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.text.json/8.0.4/System.Text.Json.8.0.4.csproj
+++ b/src/referencePackages/src/system.text.json/8.0.4/System.Text.Json.8.0.4.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Text.Json</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <Compile Include="$(CommonSrc)IsExternalInit.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.text.json/8.0.4/lib/net6.0/System.Text.Json.cs
+++ b/src/referencePackages/src/system.text.json/8.0.4/lib/net6.0/System.Text.Json.cs
@@ -1,0 +1,2150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Json")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.\r\n\r\nThe System.Text.Json library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.724.31311")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.7+2aade6beb02ea367fd97c4070a4198802fe61c03")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Json")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+namespace System.Text.Json
+{
+    public enum JsonCommentHandling : byte
+    {
+        Disallow = 0,
+        Skip = 1,
+        Allow = 2
+    }
+
+    public sealed partial class JsonDocument : IDisposable
+    {
+        internal JsonDocument() { }
+
+        public JsonElement RootElement { get { throw null; } }
+
+        public void Dispose() { }
+
+        public static JsonDocument Parse(Buffers.ReadOnlySequence<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(IO.Stream utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<char> json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(string json, JsonDocumentOptions options = default) { throw null; }
+
+        public static Threading.Tasks.Task<JsonDocument> ParseAsync(IO.Stream utf8Json, JsonDocumentOptions options = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonDocument? document) { throw null; }
+
+        public void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonDocumentOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public readonly partial struct JsonElement
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonElement this[int index] { get { throw null; } }
+
+        public JsonValueKind ValueKind { get { throw null; } }
+
+        public readonly JsonElement Clone() { throw null; }
+
+        public readonly ArrayEnumerator EnumerateArray() { throw null; }
+
+        public readonly ObjectEnumerator EnumerateObject() { throw null; }
+
+        public readonly int GetArrayLength() { throw null; }
+
+        public readonly bool GetBoolean() { throw null; }
+
+        public readonly byte GetByte() { throw null; }
+
+        public readonly byte[] GetBytesFromBase64() { throw null; }
+
+        public readonly DateTime GetDateTime() { throw null; }
+
+        public readonly DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public readonly decimal GetDecimal() { throw null; }
+
+        public readonly double GetDouble() { throw null; }
+
+        public readonly Guid GetGuid() { throw null; }
+
+        public readonly short GetInt16() { throw null; }
+
+        public readonly int GetInt32() { throw null; }
+
+        public readonly long GetInt64() { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<byte> utf8PropertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<char> propertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(string propertyName) { throw null; }
+
+        public readonly string GetRawText() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly sbyte GetSByte() { throw null; }
+
+        public readonly float GetSingle() { throw null; }
+
+        public readonly string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ulong GetUInt64() { throw null; }
+
+        public static JsonElement ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryGetByte(out byte value) { throw null; }
+
+        public readonly bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public readonly bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public readonly bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public readonly bool TryGetDecimal(out decimal value) { throw null; }
+
+        public readonly bool TryGetDouble(out double value) { throw null; }
+
+        public readonly bool TryGetGuid(out Guid value) { throw null; }
+
+        public readonly bool TryGetInt16(out short value) { throw null; }
+
+        public readonly bool TryGetInt32(out int value) { throw null; }
+
+        public readonly bool TryGetInt64(out long value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<byte> utf8PropertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<char> propertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(string propertyName, out JsonElement value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetSByte(out sbyte value) { throw null; }
+
+        public readonly bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt64(out ulong value) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonElement? element) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueEquals(string? text) { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+
+        public partial struct ArrayEnumerator : Collections.Generic.IEnumerable<JsonElement>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonElement>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonElement Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ArrayEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonElement> Collections.Generic.IEnumerable<JsonElement>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+
+        public partial struct ObjectEnumerator : Collections.Generic.IEnumerable<JsonProperty>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonProperty>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonProperty Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ObjectEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonProperty> Collections.Generic.IEnumerable<JsonProperty>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+    }
+
+    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(string value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public readonly bool Equals(JsonEncodedText other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class JsonException : Exception
+    {
+        public JsonException() { }
+
+        protected JsonException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public JsonException(string? message, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine) { }
+
+        public JsonException(string? message) { }
+
+        public long? BytePositionInLine { get { throw null; } }
+
+        public long? LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string? Path { get { throw null; } }
+
+        public override void GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public abstract partial class JsonNamingPolicy
+    {
+        public static JsonNamingPolicy CamelCase { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseUpper { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseUpper { get { throw null; } }
+
+        public abstract string ConvertName(string name);
+    }
+
+    public readonly partial struct JsonProperty
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public string Name { get { throw null; } }
+
+        public JsonElement Value { get { throw null; } }
+
+        public readonly bool NameEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool NameEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool NameEquals(string? text) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public partial struct JsonReaderState
+    {
+        private int _dummyPrimitive;
+        public JsonReaderState(JsonReaderOptions options = default) { }
+
+        public JsonReaderOptions Options { get { throw null; } }
+    }
+
+    public static partial class JsonSerializer
+    {
+        public static bool IsReflectionEnabledByDefault { get { throw null; } }
+
+        public static object? Deserialize(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(string json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(string json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(string json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(this JsonDocument document, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(this JsonElement element, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(string json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(string json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(this JsonDocument document, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonDocument document, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonElement element, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        public static string Serialize(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static string Serialize(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static string Serialize<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+    }
+
+    public enum JsonSerializerDefaults
+    {
+        General = 0,
+        Web = 1
+    }
+
+    public sealed partial class JsonSerializerOptions
+    {
+        public JsonSerializerOptions() { }
+
+        public JsonSerializerOptions(JsonSerializerDefaults defaults) { }
+
+        public JsonSerializerOptions(JsonSerializerOptions options) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.JsonConverter> Converters { get { throw null; } }
+
+        public static JsonSerializerOptions Default { get { throw null; } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", DiagnosticId = "SYSLIB0020", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool IgnoreNullValues { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public Serialization.JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+
+        public Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.Metadata.IJsonTypeInfoResolver> TypeInfoResolverChain { get { throw null; } }
+
+        public Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public Serialization.JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.AddContext is obsolete. To register a JsonSerializerContext, use either the TypeInfoResolver or TypeInfoResolverChain properties.", DiagnosticId = "SYSLIB0049", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void AddContext<TContext>()
+            where TContext : Serialization.JsonSerializerContext, new() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Getting a converter for a type may require reflection which depends on unreferenced code.")]
+        public Serialization.JsonConverter GetConverter(Type typeToConvert) { throw null; }
+
+        public Serialization.Metadata.JsonTypeInfo GetTypeInfo(Type type) { throw null; }
+
+        public void MakeReadOnly() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires unreferenced code.")]
+        public void MakeReadOnly(bool populateMissingResolver) { }
+
+        public bool TryGetTypeInfo(Type type, out Serialization.Metadata.JsonTypeInfo? typeInfo) { throw null; }
+    }
+
+    public enum JsonTokenType : byte
+    {
+        None = 0,
+        StartObject = 1,
+        EndObject = 2,
+        StartArray = 3,
+        EndArray = 4,
+        PropertyName = 5,
+        Comment = 6,
+        String = 7,
+        Number = 8,
+        True = 9,
+        False = 10,
+        Null = 11
+    }
+
+    public enum JsonValueKind : byte
+    {
+        Undefined = 0,
+        Object = 1,
+        Array = 2,
+        String = 3,
+        Number = 4,
+        True = 5,
+        False = 6,
+        Null = 7
+    }
+
+    public partial struct JsonWriterOptions
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        public bool Indented { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public bool SkipValidation { get { throw null; } set { } }
+    }
+
+    public ref partial struct Utf8JsonReader
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public long BytesConsumed { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonReaderState CurrentState { get { throw null; } }
+
+        public bool HasValueSequence { get { throw null; } }
+
+        public bool IsFinalBlock { get { throw null; } }
+
+        public SequencePosition Position { get { throw null; } }
+
+        public long TokenStartIndex { get { throw null; } }
+
+        public JsonTokenType TokenType { get { throw null; } }
+
+        public bool ValueIsEscaped { get { throw null; } }
+
+        public Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
+
+        public ReadOnlySpan<byte> ValueSpan { get { throw null; } }
+
+        public readonly int CopyString(Span<byte> utf8Destination) { throw null; }
+
+        public readonly int CopyString(Span<char> destination) { throw null; }
+
+        public bool GetBoolean() { throw null; }
+
+        public byte GetByte() { throw null; }
+
+        public byte[] GetBytesFromBase64() { throw null; }
+
+        public string GetComment() { throw null; }
+
+        public DateTime GetDateTime() { throw null; }
+
+        public DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public decimal GetDecimal() { throw null; }
+
+        public double GetDouble() { throw null; }
+
+        public Guid GetGuid() { throw null; }
+
+        public short GetInt16() { throw null; }
+
+        public int GetInt32() { throw null; }
+
+        public long GetInt64() { throw null; }
+
+        [CLSCompliant(false)]
+        public sbyte GetSByte() { throw null; }
+
+        public float GetSingle() { throw null; }
+
+        public string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public ulong GetUInt64() { throw null; }
+
+        public bool Read() { throw null; }
+
+        public void Skip() { }
+
+        public bool TryGetByte(out byte value) { throw null; }
+
+        public bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public bool TryGetDecimal(out decimal value) { throw null; }
+
+        public bool TryGetDouble(out double value) { throw null; }
+
+        public bool TryGetGuid(out Guid value) { throw null; }
+
+        public bool TryGetInt16(out short value) { throw null; }
+
+        public bool TryGetInt32(out int value) { throw null; }
+
+        public bool TryGetInt64(out long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetSByte(out sbyte value) { throw null; }
+
+        public bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt64(out ulong value) { throw null; }
+
+        public bool TrySkip() { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueTextEquals(string? text) { throw null; }
+    }
+
+    public sealed partial class Utf8JsonWriter : IDisposable, IAsyncDisposable
+    {
+        public Utf8JsonWriter(Buffers.IBufferWriter<byte> bufferWriter, JsonWriterOptions options = default) { }
+
+        public Utf8JsonWriter(IO.Stream utf8Json, JsonWriterOptions options = default) { }
+
+        public long BytesCommitted { get { throw null; } }
+
+        public int BytesPending { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonWriterOptions Options { get { throw null; } }
+
+        public void Dispose() { }
+
+        public Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+
+        public void Flush() { }
+
+        public Threading.Tasks.Task FlushAsync(Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public void Reset() { }
+
+        public void Reset(Buffers.IBufferWriter<byte> bufferWriter) { }
+
+        public void Reset(IO.Stream utf8Json) { }
+
+        public void WriteBase64String(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(string propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(JsonEncodedText propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64StringValue(ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBoolean(ReadOnlySpan<byte> utf8PropertyName, bool value) { }
+
+        public void WriteBoolean(ReadOnlySpan<char> propertyName, bool value) { }
+
+        public void WriteBoolean(string propertyName, bool value) { }
+
+        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
+
+        public void WriteBooleanValue(bool value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<char> value) { }
+
+        public void WriteCommentValue(string value) { }
+
+        public void WriteEndArray() { }
+
+        public void WriteEndObject() { }
+
+        public void WriteNull(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteNull(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteNull(string propertyName) { }
+
+        public void WriteNull(JsonEncodedText propertyName) { }
+
+        public void WriteNullValue() { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, ulong value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, ulong value) { }
+
+        public void WriteNumber(string propertyName, decimal value) { }
+
+        public void WriteNumber(string propertyName, double value) { }
+
+        public void WriteNumber(string propertyName, int value) { }
+
+        public void WriteNumber(string propertyName, long value) { }
+
+        public void WriteNumber(string propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, ulong value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, double value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, int value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, long value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
+
+        public void WriteNumberValue(decimal value) { }
+
+        public void WriteNumberValue(double value) { }
+
+        public void WriteNumberValue(int value) { }
+
+        public void WriteNumberValue(long value) { }
+
+        public void WriteNumberValue(float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(ulong value) { }
+
+        public void WritePropertyName(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WritePropertyName(ReadOnlySpan<char> propertyName) { }
+
+        public void WritePropertyName(string propertyName) { }
+
+        public void WritePropertyName(JsonEncodedText propertyName) { }
+
+        public void WriteRawValue(Buffers.ReadOnlySequence<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<char> json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(string json, bool skipInputValidation = false) { }
+
+        public void WriteStartArray() { }
+
+        public void WriteStartArray(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartArray(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartArray(string propertyName) { }
+
+        public void WriteStartArray(JsonEncodedText propertyName) { }
+
+        public void WriteStartObject() { }
+
+        public void WriteStartObject(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartObject(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartObject(string propertyName) { }
+
+        public void WriteStartObject(JsonEncodedText propertyName) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
+
+        public void WriteString(string propertyName, DateTime value) { }
+
+        public void WriteString(string propertyName, DateTimeOffset value) { }
+
+        public void WriteString(string propertyName, Guid value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(string propertyName, string? value) { }
+
+        public void WriteString(string propertyName, JsonEncodedText value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTime value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTimeOffset value) { }
+
+        public void WriteString(JsonEncodedText propertyName, Guid value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(JsonEncodedText propertyName, string? value) { }
+
+        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
+
+        public void WriteStringValue(DateTime value) { }
+
+        public void WriteStringValue(DateTimeOffset value) { }
+
+        public void WriteStringValue(Guid value) { }
+
+        public void WriteStringValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteStringValue(ReadOnlySpan<char> value) { }
+
+        public void WriteStringValue(string? value) { }
+
+        public void WriteStringValue(JsonEncodedText value) { }
+    }
+}
+
+namespace System.Text.Json.Nodes
+{
+    public sealed partial class JsonArray : JsonNode, Collections.Generic.IList<JsonNode?>, Collections.Generic.ICollection<JsonNode?>, Collections.Generic.IEnumerable<JsonNode?>, Collections.IEnumerable
+    {
+        public JsonArray(JsonNodeOptions? options = null) { }
+
+        public JsonArray(params JsonNode?[] items) { }
+
+        public JsonArray(JsonNodeOptions options, params JsonNode?[] items) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<JsonNode>.IsReadOnly { get { throw null; } }
+
+        public void Add(JsonNode? item) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        public void Add<T>(T? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(JsonNode? item) { throw null; }
+
+        public static JsonArray? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<JsonNode?> GetEnumerator() { throw null; }
+
+        public Collections.Generic.IEnumerable<T> GetValues<T>() { throw null; }
+
+        public int IndexOf(JsonNode? item) { throw null; }
+
+        public void Insert(int index, JsonNode? item) { }
+
+        public bool Remove(JsonNode? item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        void Collections.Generic.ICollection<JsonNode>.CopyTo(JsonNode[] array, int index) { }
+
+        Collections.IEnumerator? Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonNode
+    {
+        internal JsonNode() { }
+
+        public JsonNode? this[int index] { get { throw null; } set { } }
+
+        public JsonNode? this[string propertyName] { get { throw null; } set { } }
+
+        public JsonNodeOptions? Options { get { throw null; } }
+
+        public JsonNode? Parent { get { throw null; } }
+
+        public JsonNode Root { get { throw null; } }
+
+        public JsonArray AsArray() { throw null; }
+
+        public JsonObject AsObject() { throw null; }
+
+        public JsonValue AsValue() { throw null; }
+
+        public JsonNode DeepClone() { throw null; }
+
+        public static bool DeepEquals(JsonNode? node1, JsonNode? node2) { throw null; }
+
+        public int GetElementIndex() { throw null; }
+
+        public string GetPath() { throw null; }
+
+        public string GetPropertyName() { throw null; }
+
+        public virtual T GetValue<T>() { throw null; }
+
+        public JsonValueKind GetValueKind() { throw null; }
+
+        public static explicit operator bool(JsonNode value) { throw null; }
+
+        public static explicit operator byte(JsonNode value) { throw null; }
+
+        public static explicit operator char(JsonNode value) { throw null; }
+
+        public static explicit operator DateTime(JsonNode value) { throw null; }
+
+        public static explicit operator DateTimeOffset(JsonNode value) { throw null; }
+
+        public static explicit operator decimal(JsonNode value) { throw null; }
+
+        public static explicit operator double(JsonNode value) { throw null; }
+
+        public static explicit operator Guid(JsonNode value) { throw null; }
+
+        public static explicit operator short(JsonNode value) { throw null; }
+
+        public static explicit operator int(JsonNode value) { throw null; }
+
+        public static explicit operator long(JsonNode value) { throw null; }
+
+        public static explicit operator bool?(JsonNode? value) { throw null; }
+
+        public static explicit operator byte?(JsonNode? value) { throw null; }
+
+        public static explicit operator char?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTime?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTimeOffset?(JsonNode? value) { throw null; }
+
+        public static explicit operator decimal?(JsonNode? value) { throw null; }
+
+        public static explicit operator double?(JsonNode? value) { throw null; }
+
+        public static explicit operator Guid?(JsonNode? value) { throw null; }
+
+        public static explicit operator short?(JsonNode? value) { throw null; }
+
+        public static explicit operator int?(JsonNode? value) { throw null; }
+
+        public static explicit operator long?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte?(JsonNode? value) { throw null; }
+
+        public static explicit operator float?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte(JsonNode value) { throw null; }
+
+        public static explicit operator float(JsonNode value) { throw null; }
+
+        public static explicit operator string?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong(JsonNode value) { throw null; }
+
+        public static implicit operator JsonNode(bool value) { throw null; }
+
+        public static implicit operator JsonNode(byte value) { throw null; }
+
+        public static implicit operator JsonNode(char value) { throw null; }
+
+        public static implicit operator JsonNode(DateTime value) { throw null; }
+
+        public static implicit operator JsonNode(DateTimeOffset value) { throw null; }
+
+        public static implicit operator JsonNode(decimal value) { throw null; }
+
+        public static implicit operator JsonNode(double value) { throw null; }
+
+        public static implicit operator JsonNode(Guid value) { throw null; }
+
+        public static implicit operator JsonNode(short value) { throw null; }
+
+        public static implicit operator JsonNode(int value) { throw null; }
+
+        public static implicit operator JsonNode(long value) { throw null; }
+
+        public static implicit operator JsonNode?(bool? value) { throw null; }
+
+        public static implicit operator JsonNode?(byte? value) { throw null; }
+
+        public static implicit operator JsonNode?(char? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTime? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTimeOffset? value) { throw null; }
+
+        public static implicit operator JsonNode?(decimal? value) { throw null; }
+
+        public static implicit operator JsonNode?(double? value) { throw null; }
+
+        public static implicit operator JsonNode?(Guid? value) { throw null; }
+
+        public static implicit operator JsonNode?(short? value) { throw null; }
+
+        public static implicit operator JsonNode?(int? value) { throw null; }
+
+        public static implicit operator JsonNode?(long? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(sbyte? value) { throw null; }
+
+        public static implicit operator JsonNode?(float? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ushort? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(uint? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ulong? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(sbyte value) { throw null; }
+
+        public static implicit operator JsonNode(float value) { throw null; }
+
+        public static implicit operator JsonNode?(string? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ulong value) { throw null; }
+
+        public static JsonNode? Parse(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ReadOnlySpan<byte> utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(string json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ref Utf8JsonReader reader, JsonNodeOptions? nodeOptions = null) { throw null; }
+
+        public static Threading.Tasks.Task<JsonNode?> ParseAsync(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        public void ReplaceWith<T>(T value) { }
+
+        public string ToJsonString(JsonSerializerOptions? options = null) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public abstract void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null);
+    }
+
+    public partial struct JsonNodeOptions
+    {
+        private int _dummyPrimitive;
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonObject : JsonNode, Collections.Generic.IDictionary<string, JsonNode?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.IEnumerable
+    {
+        public JsonObject(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>> properties, JsonNodeOptions? options = null) { }
+
+        public JsonObject(JsonNodeOptions? options = null) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.IsReadOnly { get { throw null; } }
+
+        Collections.Generic.ICollection<string> Collections.Generic.IDictionary<string, JsonNode>.Keys { get { throw null; } }
+
+        Collections.Generic.ICollection<JsonNode?> Collections.Generic.IDictionary<string, JsonNode>.Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, JsonNode?> property) { }
+
+        public void Add(string propertyName, JsonNode? value) { }
+
+        public void Clear() { }
+
+        public bool ContainsKey(string propertyName) { throw null; }
+
+        public static JsonObject? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, JsonNode?>> GetEnumerator() { throw null; }
+
+        public bool Remove(string propertyName) { throw null; }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Contains(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        void Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.CopyTo(Collections.Generic.KeyValuePair<string, JsonNode>[] array, int index) { }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Remove(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        bool Collections.Generic.IDictionary<string, JsonNode>.TryGetValue(string propertyName, out JsonNode jsonNode) { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode) { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonValue : JsonNode
+    {
+        internal JsonValue() { }
+
+        public static JsonValue Create(bool value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(byte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(char value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(double value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(short value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(int value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(long value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(float value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(uint value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+        public static JsonValue? Create<T>(T? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create<T>(T? value, Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null) { throw null; }
+
+        public abstract bool TryGetValue<T>(out T? value);
+    }
+}
+
+namespace System.Text.Json.Serialization
+{
+    public partial interface IJsonOnDeserialized
+    {
+        void OnDeserialized();
+    }
+
+    public partial interface IJsonOnDeserializing
+    {
+        void OnDeserializing();
+    }
+
+    public partial interface IJsonOnSerialized
+    {
+        void OnSerialized();
+    }
+
+    public partial interface IJsonOnSerializing
+    {
+        void OnSerializing();
+    }
+
+    public abstract partial class JsonAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed partial class JsonConstructorAttribute : JsonAttribute
+    {
+    }
+
+    public abstract partial class JsonConverter
+    {
+        internal JsonConverter() { }
+
+        public abstract Type? Type { get; }
+
+        public abstract bool CanConvert(Type typeToConvert);
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public partial class JsonConverterAttribute : JsonAttribute
+    {
+        protected JsonConverterAttribute() { }
+
+        public JsonConverterAttribute(Type converterType) { }
+
+        [Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type? ConverterType { get { throw null; } }
+
+        public virtual JsonConverter? CreateConverter(Type typeToConvert) { throw null; }
+    }
+
+    public abstract partial class JsonConverterFactory : JsonConverter
+    {
+        protected JsonConverterFactory() { }
+
+        public sealed override Type? Type { get { throw null; } }
+
+        public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
+    }
+
+    public abstract partial class JsonConverter<T> : JsonConverter
+    {
+        protected internal JsonConverter() { }
+
+        public virtual bool HandleNull { get { throw null; } }
+
+        public sealed override Type Type { get { throw null; } }
+
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public abstract T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        public virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { throw null; }
+
+        public abstract void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+        public virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public partial class JsonDerivedTypeAttribute : JsonAttribute
+    {
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonExtensionDataAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIgnoreAttribute : JsonAttribute
+    {
+        public JsonIgnoreCondition Condition { get { throw null; } set { } }
+    }
+
+    public enum JsonIgnoreCondition
+    {
+        Never = 0,
+        Always = 1,
+        WhenWritingDefault = 2,
+        WhenWritingNull = 3
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIncludeAttribute : JsonAttribute
+    {
+    }
+
+    public enum JsonKnownNamingPolicy
+    {
+        Unspecified = 0,
+        CamelCase = 1,
+        SnakeCaseLower = 2,
+        SnakeCaseUpper = 3,
+        KebabCaseLower = 4,
+        KebabCaseUpper = 5
+    }
+
+    public sealed partial class JsonNumberEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        Strict = 0,
+        AllowReadingFromString = 1,
+        WriteAsString = 2,
+        AllowNamedFloatingPointLiterals = 4
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonNumberHandlingAttribute : JsonAttribute
+    {
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling) { }
+
+        public JsonNumberHandling Handling { get { throw null; } }
+    }
+
+    public enum JsonObjectCreationHandling
+    {
+        Replace = 0,
+        Populate = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed partial class JsonObjectCreationHandlingAttribute : JsonAttribute
+    {
+        public JsonObjectCreationHandlingAttribute(JsonObjectCreationHandling handling) { }
+
+        public JsonObjectCreationHandling Handling { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicAttribute : JsonAttribute
+    {
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyNameAttribute : JsonAttribute
+    {
+        public JsonPropertyNameAttribute(string name) { }
+
+        public string Name { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyOrderAttribute : JsonAttribute
+    {
+        public JsonPropertyOrderAttribute(int order) { }
+
+        public int Order { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonRequiredAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed partial class JsonSerializableAttribute : JsonAttribute
+    {
+        public JsonSerializableAttribute(Type type) { }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public string? TypeInfoPropertyName { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonSerializerContext : Metadata.IJsonTypeInfoResolver
+    {
+        protected JsonSerializerContext(JsonSerializerOptions? options) { }
+
+        protected abstract JsonSerializerOptions? GeneratedSerializerOptions { get; }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public abstract Metadata.JsonTypeInfo? GetTypeInfo(Type type);
+        Metadata.JsonTypeInfo Metadata.IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonSourceGenerationMode
+    {
+        Default = 0,
+        Metadata = 1,
+        Serialization = 2
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class JsonSourceGenerationOptionsAttribute : JsonAttribute
+    {
+        public JsonSourceGenerationOptionsAttribute() { }
+
+        public JsonSourceGenerationOptionsAttribute(JsonSerializerDefaults defaults) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Type[]? Converters { get { throw null; } set { } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool UseStringEnumConverter { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+    }
+
+    public partial class JsonStringEnumConverter : JsonConverterFactory
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial class JsonStringEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        FailSerialization = 0,
+        FallBackToBaseType = 1,
+        FallBackToNearestAncestor = 2
+    }
+
+    public enum JsonUnknownTypeHandling
+    {
+        JsonElement = 0,
+        JsonNode = 1
+    }
+
+    public enum JsonUnmappedMemberHandling
+    {
+        Skip = 0,
+        Disallow = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public partial class JsonUnmappedMemberHandlingAttribute : JsonAttribute
+    {
+        public JsonUnmappedMemberHandlingAttribute(JsonUnmappedMemberHandling unmappedMemberHandling) { }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } }
+    }
+
+    public abstract partial class ReferenceHandler
+    {
+        public static ReferenceHandler IgnoreCycles { get { throw null; } }
+
+        public static ReferenceHandler Preserve { get { throw null; } }
+
+        public abstract ReferenceResolver CreateResolver();
+    }
+
+    public sealed partial class ReferenceHandler<T> : ReferenceHandler where T : ReferenceResolver, new()
+    {
+        public override ReferenceResolver CreateResolver() { throw null; }
+    }
+
+    public abstract partial class ReferenceResolver
+    {
+        public abstract void AddReference(string referenceId, object value);
+        public abstract string GetReference(object value, out bool alreadyExists);
+        public abstract object ResolveReference(string referenceId);
+    }
+}
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public partial class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        public Collections.Generic.IList<Action<JsonTypeInfo>> Modifiers { get { throw null; } }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "The ctor is marked RequiresDynamicCode.")]
+        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial interface IJsonTypeInfoResolver
+    {
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+
+    public sealed partial class JsonCollectionInfoValues<TCollection>
+    {
+        public JsonTypeInfo ElementInfo { get { throw null; } init { } }
+
+        public JsonTypeInfo? KeyInfo { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<TCollection>? ObjectCreator { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, TCollection>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public readonly partial struct JsonDerivedType
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonDerivedType(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    public static partial class JsonMetadataServices
+    {
+        public static JsonConverter<bool> BooleanConverter { get { throw null; } }
+
+        public static JsonConverter<byte[]?> ByteArrayConverter { get { throw null; } }
+
+        public static JsonConverter<byte> ByteConverter { get { throw null; } }
+
+        public static JsonConverter<char> CharConverter { get { throw null; } }
+
+        public static JsonConverter<DateOnly> DateOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<DateTime> DateTimeConverter { get { throw null; } }
+
+        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter { get { throw null; } }
+
+        public static JsonConverter<decimal> DecimalConverter { get { throw null; } }
+
+        public static JsonConverter<double> DoubleConverter { get { throw null; } }
+
+        public static JsonConverter<Guid> GuidConverter { get { throw null; } }
+
+        public static JsonConverter<Half> HalfConverter { get { throw null; } }
+
+        public static JsonConverter<short> Int16Converter { get { throw null; } }
+
+        public static JsonConverter<int> Int32Converter { get { throw null; } }
+
+        public static JsonConverter<long> Int64Converter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonArray?> JsonArrayConverter { get { throw null; } }
+
+        public static JsonConverter<JsonDocument?> JsonDocumentConverter { get { throw null; } }
+
+        public static JsonConverter<JsonElement> JsonElementConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonNode?> JsonNodeConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonObject?> JsonObjectConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonValue?> JsonValueConverter { get { throw null; } }
+
+        public static JsonConverter<Memory<byte>> MemoryByteConverter { get { throw null; } }
+
+        public static JsonConverter<object?> ObjectConverter { get { throw null; } }
+
+        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<sbyte> SByteConverter { get { throw null; } }
+
+        public static JsonConverter<float> SingleConverter { get { throw null; } }
+
+        public static JsonConverter<string?> StringConverter { get { throw null; } }
+
+        public static JsonConverter<TimeOnly> TimeOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<TimeSpan> TimeSpanConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ushort> UInt16Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<uint> UInt32Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ulong> UInt64Converter { get { throw null; } }
+
+        public static JsonConverter<Uri?> UriConverter { get { throw null; } }
+
+        public static JsonConverter<Version?> VersionConverter { get { throw null; } }
+
+        public static JsonTypeInfo<TElement[]> CreateArrayInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TElement[]> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentQueue<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentStack<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Dictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIAsyncEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IAsyncEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateICollectionInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ICollection<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IDictionary { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IList { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IList<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<TKey, TValue>>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<TElement>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIReadOnlyDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateISetInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ISet<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.List<TElement> { throw null; }
+
+        public static JsonTypeInfo<Memory<TElement>> CreateMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<Memory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<T> CreateObjectInfo<T>(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) { throw null; }
+
+        public static JsonPropertyInfo CreatePropertyInfo<T>(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Queue<TElement> { throw null; }
+
+        public static JsonTypeInfo<ReadOnlyMemory<TElement>> CreateReadOnlyMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<ReadOnlyMemory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Stack<TElement> { throw null; }
+
+        public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter) { throw null; }
+
+        public static JsonConverter<T> GetEnumConverter<T>(JsonSerializerOptions options)
+            where T : struct, Enum { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonSerializerOptions options)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonTypeInfo<T> underlyingTypeInfo)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T> GetUnsupportedTypeConverter<T>() { throw null; }
+    }
+
+    public sealed partial class JsonObjectInfoValues<T>
+    {
+        public Func<JsonParameterInfoValues[]>? ConstructorParameterMetadataInitializer { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<T>? ObjectCreator { get { throw null; } init { } }
+
+        public Func<object[], T>? ObjectWithParameterizedConstructorCreator { get { throw null; } init { } }
+
+        public Func<JsonSerializerContext, JsonPropertyInfo[]>? PropertyMetadataInitializer { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public sealed partial class JsonParameterInfoValues
+    {
+        public object? DefaultValue { get { throw null; } init { } }
+
+        public bool HasDefaultValue { get { throw null; } init { } }
+
+        public string Name { get { throw null; } init { } }
+
+        public Type ParameterType { get { throw null; } init { } }
+
+        public int Position { get { throw null; } init { } }
+    }
+
+    public partial class JsonPolymorphismOptions
+    {
+        public Collections.Generic.IList<JsonDerivedType> DerivedTypes { get { throw null; } }
+
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonPropertyInfo
+    {
+        internal JsonPropertyInfo() { }
+
+        public System.Reflection.ICustomAttributeProvider? AttributeProvider { get { throw null; } set { } }
+
+        public JsonConverter? CustomConverter { get { throw null; } set { } }
+
+        public Func<object, object?>? Get { get { throw null; } set { } }
+
+        public bool IsExtensionData { get { throw null; } set { } }
+
+        public bool IsRequired { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? ObjectCreationHandling { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public int Order { get { throw null; } set { } }
+
+        public Type PropertyType { get { throw null; } }
+
+        public Action<object, object?>? Set { get { throw null; } set { } }
+
+        public Func<object, object?, bool>? ShouldSerialize { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonPropertyInfoValues<T>
+    {
+        public JsonConverter<T>? Converter { get { throw null; } init { } }
+
+        public Type DeclaringType { get { throw null; } init { } }
+
+        public Func<object, T?>? Getter { get { throw null; } init { } }
+
+        public bool HasJsonInclude { get { throw null; } init { } }
+
+        public JsonIgnoreCondition? IgnoreCondition { get { throw null; } init { } }
+
+        public bool IsExtensionData { get { throw null; } init { } }
+
+        public bool IsProperty { get { throw null; } init { } }
+
+        public bool IsPublic { get { throw null; } init { } }
+
+        public bool IsVirtual { get { throw null; } init { } }
+
+        public string? JsonPropertyName { get { throw null; } init { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } init { } }
+
+        public string PropertyName { get { throw null; } init { } }
+
+        public JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
+
+        public Action<object, T?>? Setter { get { throw null; } init { } }
+    }
+
+    public abstract partial class JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public JsonConverter Converter { get { throw null; } }
+
+        public Func<object>? CreateObject { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public JsonTypeInfoKind Kind { get { throw null; } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public Action<object>? OnDeserialized { get { throw null; } set { } }
+
+        public Action<object>? OnDeserializing { get { throw null; } set { } }
+
+        public Action<object>? OnSerialized { get { throw null; } set { } }
+
+        public Action<object>? OnSerializing { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public IJsonTypeInfoResolver? OriginatingResolver { get { throw null; } set { } }
+
+        public JsonPolymorphismOptions? PolymorphismOptions { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? PreferredPropertyObjectCreationHandling { get { throw null; } set { } }
+
+        public Collections.Generic.IList<JsonPropertyInfo> Properties { get { throw null; } }
+
+        public Type Type { get { throw null; } }
+
+        public JsonUnmappedMemberHandling? UnmappedMemberHandling { get { throw null; } set { } }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options) { throw null; }
+
+        public void MakeReadOnly() { }
+    }
+
+    public enum JsonTypeInfoKind
+    {
+        None = 0,
+        Object = 1,
+        Enumerable = 2,
+        Dictionary = 3
+    }
+
+    public static partial class JsonTypeInfoResolver
+    {
+        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver?[] resolvers) { throw null; }
+
+        public static IJsonTypeInfoResolver WithAddedModifier(this IJsonTypeInfoResolver resolver, Action<JsonTypeInfo> modifier) { throw null; }
+    }
+
+    public sealed partial class JsonTypeInfo<T> : JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public new Func<T>? CreateObject { get { throw null; } set { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.text.json/8.0.4/lib/net7.0/System.Text.Json.cs
+++ b/src/referencePackages/src/system.text.json/8.0.4/lib/net7.0/System.Text.Json.cs
@@ -1,0 +1,2199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Json")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.\r\n\r\nThe System.Text.Json library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.724.31311")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.7+2aade6beb02ea367fd97c4070a4198802fe61c03")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Json")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+namespace System.Text.Json
+{
+    public enum JsonCommentHandling : byte
+    {
+        Disallow = 0,
+        Skip = 1,
+        Allow = 2
+    }
+
+    public sealed partial class JsonDocument : IDisposable
+    {
+        internal JsonDocument() { }
+
+        public JsonElement RootElement { get { throw null; } }
+
+        public void Dispose() { }
+
+        public static JsonDocument Parse(Buffers.ReadOnlySequence<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(IO.Stream utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<char> json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(string json, JsonDocumentOptions options = default) { throw null; }
+
+        public static Threading.Tasks.Task<JsonDocument> ParseAsync(IO.Stream utf8Json, JsonDocumentOptions options = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonDocument? document) { throw null; }
+
+        public void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonDocumentOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public readonly partial struct JsonElement
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonElement this[int index] { get { throw null; } }
+
+        public JsonValueKind ValueKind { get { throw null; } }
+
+        public readonly JsonElement Clone() { throw null; }
+
+        public readonly ArrayEnumerator EnumerateArray() { throw null; }
+
+        public readonly ObjectEnumerator EnumerateObject() { throw null; }
+
+        public readonly int GetArrayLength() { throw null; }
+
+        public readonly bool GetBoolean() { throw null; }
+
+        public readonly byte GetByte() { throw null; }
+
+        public readonly byte[] GetBytesFromBase64() { throw null; }
+
+        public readonly DateTime GetDateTime() { throw null; }
+
+        public readonly DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public readonly decimal GetDecimal() { throw null; }
+
+        public readonly double GetDouble() { throw null; }
+
+        public readonly Guid GetGuid() { throw null; }
+
+        public readonly short GetInt16() { throw null; }
+
+        public readonly int GetInt32() { throw null; }
+
+        public readonly long GetInt64() { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<byte> utf8PropertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<char> propertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(string propertyName) { throw null; }
+
+        public readonly string GetRawText() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly sbyte GetSByte() { throw null; }
+
+        public readonly float GetSingle() { throw null; }
+
+        public readonly string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ulong GetUInt64() { throw null; }
+
+        public static JsonElement ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryGetByte(out byte value) { throw null; }
+
+        public readonly bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public readonly bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public readonly bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public readonly bool TryGetDecimal(out decimal value) { throw null; }
+
+        public readonly bool TryGetDouble(out double value) { throw null; }
+
+        public readonly bool TryGetGuid(out Guid value) { throw null; }
+
+        public readonly bool TryGetInt16(out short value) { throw null; }
+
+        public readonly bool TryGetInt32(out int value) { throw null; }
+
+        public readonly bool TryGetInt64(out long value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<byte> utf8PropertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<char> propertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(string propertyName, out JsonElement value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetSByte(out sbyte value) { throw null; }
+
+        public readonly bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt64(out ulong value) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonElement? element) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueEquals(string? text) { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+
+        public partial struct ArrayEnumerator : Collections.Generic.IEnumerable<JsonElement>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonElement>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonElement Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ArrayEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonElement> Collections.Generic.IEnumerable<JsonElement>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+
+        public partial struct ObjectEnumerator : Collections.Generic.IEnumerable<JsonProperty>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonProperty>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonProperty Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ObjectEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonProperty> Collections.Generic.IEnumerable<JsonProperty>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+    }
+
+    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(string value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public readonly bool Equals(JsonEncodedText other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class JsonException : Exception
+    {
+        public JsonException() { }
+
+        protected JsonException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public JsonException(string? message, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine) { }
+
+        public JsonException(string? message) { }
+
+        public long? BytePositionInLine { get { throw null; } }
+
+        public long? LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string? Path { get { throw null; } }
+
+        public override void GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public abstract partial class JsonNamingPolicy
+    {
+        public static JsonNamingPolicy CamelCase { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseUpper { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseUpper { get { throw null; } }
+
+        public abstract string ConvertName(string name);
+    }
+
+    public readonly partial struct JsonProperty
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public string Name { get { throw null; } }
+
+        public JsonElement Value { get { throw null; } }
+
+        public readonly bool NameEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool NameEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool NameEquals(string? text) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public partial struct JsonReaderState
+    {
+        private int _dummyPrimitive;
+        public JsonReaderState(JsonReaderOptions options = default) { }
+
+        public JsonReaderOptions Options { get { throw null; } }
+    }
+
+    public static partial class JsonSerializer
+    {
+        public static bool IsReflectionEnabledByDefault { get { throw null; } }
+
+        public static object? Deserialize(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(string json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(string json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(string json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this JsonDocument document, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this JsonElement element, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(string json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(string json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this JsonDocument document, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonDocument document, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonElement element, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        public static string Serialize(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static string Serialize(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static string Serialize<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+    }
+
+    public enum JsonSerializerDefaults
+    {
+        General = 0,
+        Web = 1
+    }
+
+    public sealed partial class JsonSerializerOptions
+    {
+        public JsonSerializerOptions() { }
+
+        public JsonSerializerOptions(JsonSerializerDefaults defaults) { }
+
+        public JsonSerializerOptions(JsonSerializerOptions options) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.JsonConverter> Converters { get { throw null; } }
+
+        public static JsonSerializerOptions Default { get { throw null; } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", DiagnosticId = "SYSLIB0020", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool IgnoreNullValues { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public Serialization.JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+
+        public Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.Metadata.IJsonTypeInfoResolver> TypeInfoResolverChain { get { throw null; } }
+
+        public Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public Serialization.JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.AddContext is obsolete. To register a JsonSerializerContext, use either the TypeInfoResolver or TypeInfoResolverChain properties.", DiagnosticId = "SYSLIB0049", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void AddContext<TContext>()
+            where TContext : Serialization.JsonSerializerContext, new() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Getting a converter for a type may require reflection which depends on unreferenced code.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Getting a converter for a type may require reflection which depends on runtime code generation.")]
+        public Serialization.JsonConverter GetConverter(Type typeToConvert) { throw null; }
+
+        public Serialization.Metadata.JsonTypeInfo GetTypeInfo(Type type) { throw null; }
+
+        public void MakeReadOnly() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires unreferenced code.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires runtime code generation.")]
+        public void MakeReadOnly(bool populateMissingResolver) { }
+
+        public bool TryGetTypeInfo(Type type, out Serialization.Metadata.JsonTypeInfo? typeInfo) { throw null; }
+    }
+
+    public enum JsonTokenType : byte
+    {
+        None = 0,
+        StartObject = 1,
+        EndObject = 2,
+        StartArray = 3,
+        EndArray = 4,
+        PropertyName = 5,
+        Comment = 6,
+        String = 7,
+        Number = 8,
+        True = 9,
+        False = 10,
+        Null = 11
+    }
+
+    public enum JsonValueKind : byte
+    {
+        Undefined = 0,
+        Object = 1,
+        Array = 2,
+        String = 3,
+        Number = 4,
+        True = 5,
+        False = 6,
+        Null = 7
+    }
+
+    public partial struct JsonWriterOptions
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        public bool Indented { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public bool SkipValidation { get { throw null; } set { } }
+    }
+
+    public ref partial struct Utf8JsonReader
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public long BytesConsumed { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonReaderState CurrentState { get { throw null; } }
+
+        public bool HasValueSequence { get { throw null; } }
+
+        public bool IsFinalBlock { get { throw null; } }
+
+        public SequencePosition Position { get { throw null; } }
+
+        public long TokenStartIndex { get { throw null; } }
+
+        public JsonTokenType TokenType { get { throw null; } }
+
+        public bool ValueIsEscaped { get { throw null; } }
+
+        public Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
+
+        public ReadOnlySpan<byte> ValueSpan { get { throw null; } }
+
+        public readonly int CopyString(Span<byte> utf8Destination) { throw null; }
+
+        public readonly int CopyString(Span<char> destination) { throw null; }
+
+        public bool GetBoolean() { throw null; }
+
+        public byte GetByte() { throw null; }
+
+        public byte[] GetBytesFromBase64() { throw null; }
+
+        public string GetComment() { throw null; }
+
+        public DateTime GetDateTime() { throw null; }
+
+        public DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public decimal GetDecimal() { throw null; }
+
+        public double GetDouble() { throw null; }
+
+        public Guid GetGuid() { throw null; }
+
+        public short GetInt16() { throw null; }
+
+        public int GetInt32() { throw null; }
+
+        public long GetInt64() { throw null; }
+
+        [CLSCompliant(false)]
+        public sbyte GetSByte() { throw null; }
+
+        public float GetSingle() { throw null; }
+
+        public string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public ulong GetUInt64() { throw null; }
+
+        public bool Read() { throw null; }
+
+        public void Skip() { }
+
+        public bool TryGetByte(out byte value) { throw null; }
+
+        public bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public bool TryGetDecimal(out decimal value) { throw null; }
+
+        public bool TryGetDouble(out double value) { throw null; }
+
+        public bool TryGetGuid(out Guid value) { throw null; }
+
+        public bool TryGetInt16(out short value) { throw null; }
+
+        public bool TryGetInt32(out int value) { throw null; }
+
+        public bool TryGetInt64(out long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetSByte(out sbyte value) { throw null; }
+
+        public bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt64(out ulong value) { throw null; }
+
+        public bool TrySkip() { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueTextEquals(string? text) { throw null; }
+    }
+
+    public sealed partial class Utf8JsonWriter : IDisposable, IAsyncDisposable
+    {
+        public Utf8JsonWriter(Buffers.IBufferWriter<byte> bufferWriter, JsonWriterOptions options = default) { }
+
+        public Utf8JsonWriter(IO.Stream utf8Json, JsonWriterOptions options = default) { }
+
+        public long BytesCommitted { get { throw null; } }
+
+        public int BytesPending { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonWriterOptions Options { get { throw null; } }
+
+        public void Dispose() { }
+
+        public Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+
+        public void Flush() { }
+
+        public Threading.Tasks.Task FlushAsync(Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public void Reset() { }
+
+        public void Reset(Buffers.IBufferWriter<byte> bufferWriter) { }
+
+        public void Reset(IO.Stream utf8Json) { }
+
+        public void WriteBase64String(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(string propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(JsonEncodedText propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64StringValue(ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBoolean(ReadOnlySpan<byte> utf8PropertyName, bool value) { }
+
+        public void WriteBoolean(ReadOnlySpan<char> propertyName, bool value) { }
+
+        public void WriteBoolean(string propertyName, bool value) { }
+
+        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
+
+        public void WriteBooleanValue(bool value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<char> value) { }
+
+        public void WriteCommentValue(string value) { }
+
+        public void WriteEndArray() { }
+
+        public void WriteEndObject() { }
+
+        public void WriteNull(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteNull(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteNull(string propertyName) { }
+
+        public void WriteNull(JsonEncodedText propertyName) { }
+
+        public void WriteNullValue() { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, ulong value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, ulong value) { }
+
+        public void WriteNumber(string propertyName, decimal value) { }
+
+        public void WriteNumber(string propertyName, double value) { }
+
+        public void WriteNumber(string propertyName, int value) { }
+
+        public void WriteNumber(string propertyName, long value) { }
+
+        public void WriteNumber(string propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, ulong value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, double value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, int value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, long value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
+
+        public void WriteNumberValue(decimal value) { }
+
+        public void WriteNumberValue(double value) { }
+
+        public void WriteNumberValue(int value) { }
+
+        public void WriteNumberValue(long value) { }
+
+        public void WriteNumberValue(float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(ulong value) { }
+
+        public void WritePropertyName(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WritePropertyName(ReadOnlySpan<char> propertyName) { }
+
+        public void WritePropertyName(string propertyName) { }
+
+        public void WritePropertyName(JsonEncodedText propertyName) { }
+
+        public void WriteRawValue(Buffers.ReadOnlySequence<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<char> json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(string json, bool skipInputValidation = false) { }
+
+        public void WriteStartArray() { }
+
+        public void WriteStartArray(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartArray(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartArray(string propertyName) { }
+
+        public void WriteStartArray(JsonEncodedText propertyName) { }
+
+        public void WriteStartObject() { }
+
+        public void WriteStartObject(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartObject(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartObject(string propertyName) { }
+
+        public void WriteStartObject(JsonEncodedText propertyName) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
+
+        public void WriteString(string propertyName, DateTime value) { }
+
+        public void WriteString(string propertyName, DateTimeOffset value) { }
+
+        public void WriteString(string propertyName, Guid value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(string propertyName, string? value) { }
+
+        public void WriteString(string propertyName, JsonEncodedText value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTime value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTimeOffset value) { }
+
+        public void WriteString(JsonEncodedText propertyName, Guid value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(JsonEncodedText propertyName, string? value) { }
+
+        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
+
+        public void WriteStringValue(DateTime value) { }
+
+        public void WriteStringValue(DateTimeOffset value) { }
+
+        public void WriteStringValue(Guid value) { }
+
+        public void WriteStringValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteStringValue(ReadOnlySpan<char> value) { }
+
+        public void WriteStringValue(string? value) { }
+
+        public void WriteStringValue(JsonEncodedText value) { }
+    }
+}
+
+namespace System.Text.Json.Nodes
+{
+    public sealed partial class JsonArray : JsonNode, Collections.Generic.IList<JsonNode?>, Collections.Generic.ICollection<JsonNode?>, Collections.Generic.IEnumerable<JsonNode?>, Collections.IEnumerable
+    {
+        public JsonArray(JsonNodeOptions? options = null) { }
+
+        public JsonArray(params JsonNode?[] items) { }
+
+        public JsonArray(JsonNodeOptions options, params JsonNode?[] items) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<JsonNode>.IsReadOnly { get { throw null; } }
+
+        public void Add(JsonNode? item) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public void Add<T>(T? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(JsonNode? item) { throw null; }
+
+        public static JsonArray? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<JsonNode?> GetEnumerator() { throw null; }
+
+        public Collections.Generic.IEnumerable<T> GetValues<T>() { throw null; }
+
+        public int IndexOf(JsonNode? item) { throw null; }
+
+        public void Insert(int index, JsonNode? item) { }
+
+        public bool Remove(JsonNode? item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        void Collections.Generic.ICollection<JsonNode>.CopyTo(JsonNode[] array, int index) { }
+
+        Collections.IEnumerator? Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonNode
+    {
+        internal JsonNode() { }
+
+        public JsonNode? this[int index] { get { throw null; } set { } }
+
+        public JsonNode? this[string propertyName] { get { throw null; } set { } }
+
+        public JsonNodeOptions? Options { get { throw null; } }
+
+        public JsonNode? Parent { get { throw null; } }
+
+        public JsonNode Root { get { throw null; } }
+
+        public JsonArray AsArray() { throw null; }
+
+        public JsonObject AsObject() { throw null; }
+
+        public JsonValue AsValue() { throw null; }
+
+        public JsonNode DeepClone() { throw null; }
+
+        public static bool DeepEquals(JsonNode? node1, JsonNode? node2) { throw null; }
+
+        public int GetElementIndex() { throw null; }
+
+        public string GetPath() { throw null; }
+
+        public string GetPropertyName() { throw null; }
+
+        public virtual T GetValue<T>() { throw null; }
+
+        public JsonValueKind GetValueKind() { throw null; }
+
+        public static explicit operator bool(JsonNode value) { throw null; }
+
+        public static explicit operator byte(JsonNode value) { throw null; }
+
+        public static explicit operator char(JsonNode value) { throw null; }
+
+        public static explicit operator DateTime(JsonNode value) { throw null; }
+
+        public static explicit operator DateTimeOffset(JsonNode value) { throw null; }
+
+        public static explicit operator decimal(JsonNode value) { throw null; }
+
+        public static explicit operator double(JsonNode value) { throw null; }
+
+        public static explicit operator Guid(JsonNode value) { throw null; }
+
+        public static explicit operator short(JsonNode value) { throw null; }
+
+        public static explicit operator int(JsonNode value) { throw null; }
+
+        public static explicit operator long(JsonNode value) { throw null; }
+
+        public static explicit operator bool?(JsonNode? value) { throw null; }
+
+        public static explicit operator byte?(JsonNode? value) { throw null; }
+
+        public static explicit operator char?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTime?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTimeOffset?(JsonNode? value) { throw null; }
+
+        public static explicit operator decimal?(JsonNode? value) { throw null; }
+
+        public static explicit operator double?(JsonNode? value) { throw null; }
+
+        public static explicit operator Guid?(JsonNode? value) { throw null; }
+
+        public static explicit operator short?(JsonNode? value) { throw null; }
+
+        public static explicit operator int?(JsonNode? value) { throw null; }
+
+        public static explicit operator long?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte?(JsonNode? value) { throw null; }
+
+        public static explicit operator float?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte(JsonNode value) { throw null; }
+
+        public static explicit operator float(JsonNode value) { throw null; }
+
+        public static explicit operator string?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong(JsonNode value) { throw null; }
+
+        public static implicit operator JsonNode(bool value) { throw null; }
+
+        public static implicit operator JsonNode(byte value) { throw null; }
+
+        public static implicit operator JsonNode(char value) { throw null; }
+
+        public static implicit operator JsonNode(DateTime value) { throw null; }
+
+        public static implicit operator JsonNode(DateTimeOffset value) { throw null; }
+
+        public static implicit operator JsonNode(decimal value) { throw null; }
+
+        public static implicit operator JsonNode(double value) { throw null; }
+
+        public static implicit operator JsonNode(Guid value) { throw null; }
+
+        public static implicit operator JsonNode(short value) { throw null; }
+
+        public static implicit operator JsonNode(int value) { throw null; }
+
+        public static implicit operator JsonNode(long value) { throw null; }
+
+        public static implicit operator JsonNode?(bool? value) { throw null; }
+
+        public static implicit operator JsonNode?(byte? value) { throw null; }
+
+        public static implicit operator JsonNode?(char? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTime? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTimeOffset? value) { throw null; }
+
+        public static implicit operator JsonNode?(decimal? value) { throw null; }
+
+        public static implicit operator JsonNode?(double? value) { throw null; }
+
+        public static implicit operator JsonNode?(Guid? value) { throw null; }
+
+        public static implicit operator JsonNode?(short? value) { throw null; }
+
+        public static implicit operator JsonNode?(int? value) { throw null; }
+
+        public static implicit operator JsonNode?(long? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(sbyte? value) { throw null; }
+
+        public static implicit operator JsonNode?(float? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ushort? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(uint? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ulong? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(sbyte value) { throw null; }
+
+        public static implicit operator JsonNode(float value) { throw null; }
+
+        public static implicit operator JsonNode?(string? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ulong value) { throw null; }
+
+        public static JsonNode? Parse(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ReadOnlySpan<byte> utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(string json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ref Utf8JsonReader reader, JsonNodeOptions? nodeOptions = null) { throw null; }
+
+        public static Threading.Tasks.Task<JsonNode?> ParseAsync(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public void ReplaceWith<T>(T value) { }
+
+        public string ToJsonString(JsonSerializerOptions? options = null) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public abstract void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null);
+    }
+
+    public partial struct JsonNodeOptions
+    {
+        private int _dummyPrimitive;
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonObject : JsonNode, Collections.Generic.IDictionary<string, JsonNode?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.IEnumerable
+    {
+        public JsonObject(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>> properties, JsonNodeOptions? options = null) { }
+
+        public JsonObject(JsonNodeOptions? options = null) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.IsReadOnly { get { throw null; } }
+
+        Collections.Generic.ICollection<string> Collections.Generic.IDictionary<string, JsonNode>.Keys { get { throw null; } }
+
+        Collections.Generic.ICollection<JsonNode?> Collections.Generic.IDictionary<string, JsonNode>.Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, JsonNode?> property) { }
+
+        public void Add(string propertyName, JsonNode? value) { }
+
+        public void Clear() { }
+
+        public bool ContainsKey(string propertyName) { throw null; }
+
+        public static JsonObject? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, JsonNode?>> GetEnumerator() { throw null; }
+
+        public bool Remove(string propertyName) { throw null; }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Contains(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        void Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.CopyTo(Collections.Generic.KeyValuePair<string, JsonNode>[] array, int index) { }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Remove(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        bool Collections.Generic.IDictionary<string, JsonNode>.TryGetValue(string propertyName, out JsonNode jsonNode) { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode) { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonValue : JsonNode
+    {
+        internal JsonValue() { }
+
+        public static JsonValue Create(bool value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(byte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(char value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(double value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(short value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(int value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(long value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(float value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(uint value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public static JsonValue? Create<T>(T? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create<T>(T? value, Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null) { throw null; }
+
+        public abstract bool TryGetValue<T>(out T? value);
+    }
+}
+
+namespace System.Text.Json.Serialization
+{
+    public partial interface IJsonOnDeserialized
+    {
+        void OnDeserialized();
+    }
+
+    public partial interface IJsonOnDeserializing
+    {
+        void OnDeserializing();
+    }
+
+    public partial interface IJsonOnSerialized
+    {
+        void OnSerialized();
+    }
+
+    public partial interface IJsonOnSerializing
+    {
+        void OnSerializing();
+    }
+
+    public abstract partial class JsonAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed partial class JsonConstructorAttribute : JsonAttribute
+    {
+    }
+
+    public abstract partial class JsonConverter
+    {
+        internal JsonConverter() { }
+
+        public abstract Type? Type { get; }
+
+        public abstract bool CanConvert(Type typeToConvert);
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public partial class JsonConverterAttribute : JsonAttribute
+    {
+        protected JsonConverterAttribute() { }
+
+        public JsonConverterAttribute(Type converterType) { }
+
+        [Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type? ConverterType { get { throw null; } }
+
+        public virtual JsonConverter? CreateConverter(Type typeToConvert) { throw null; }
+    }
+
+    public abstract partial class JsonConverterFactory : JsonConverter
+    {
+        protected JsonConverterFactory() { }
+
+        public sealed override Type? Type { get { throw null; } }
+
+        public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
+    }
+
+    public abstract partial class JsonConverter<T> : JsonConverter
+    {
+        protected internal JsonConverter() { }
+
+        public virtual bool HandleNull { get { throw null; } }
+
+        public sealed override Type Type { get { throw null; } }
+
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public abstract T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        public virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { throw null; }
+
+        public abstract void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+        public virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public partial class JsonDerivedTypeAttribute : JsonAttribute
+    {
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonExtensionDataAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIgnoreAttribute : JsonAttribute
+    {
+        public JsonIgnoreCondition Condition { get { throw null; } set { } }
+    }
+
+    public enum JsonIgnoreCondition
+    {
+        Never = 0,
+        Always = 1,
+        WhenWritingDefault = 2,
+        WhenWritingNull = 3
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIncludeAttribute : JsonAttribute
+    {
+    }
+
+    public enum JsonKnownNamingPolicy
+    {
+        Unspecified = 0,
+        CamelCase = 1,
+        SnakeCaseLower = 2,
+        SnakeCaseUpper = 3,
+        KebabCaseLower = 4,
+        KebabCaseUpper = 5
+    }
+
+    public sealed partial class JsonNumberEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        Strict = 0,
+        AllowReadingFromString = 1,
+        WriteAsString = 2,
+        AllowNamedFloatingPointLiterals = 4
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonNumberHandlingAttribute : JsonAttribute
+    {
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling) { }
+
+        public JsonNumberHandling Handling { get { throw null; } }
+    }
+
+    public enum JsonObjectCreationHandling
+    {
+        Replace = 0,
+        Populate = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed partial class JsonObjectCreationHandlingAttribute : JsonAttribute
+    {
+        public JsonObjectCreationHandlingAttribute(JsonObjectCreationHandling handling) { }
+
+        public JsonObjectCreationHandling Handling { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicAttribute : JsonAttribute
+    {
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyNameAttribute : JsonAttribute
+    {
+        public JsonPropertyNameAttribute(string name) { }
+
+        public string Name { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyOrderAttribute : JsonAttribute
+    {
+        public JsonPropertyOrderAttribute(int order) { }
+
+        public int Order { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonRequiredAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed partial class JsonSerializableAttribute : JsonAttribute
+    {
+        public JsonSerializableAttribute(Type type) { }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public string? TypeInfoPropertyName { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonSerializerContext : Metadata.IJsonTypeInfoResolver
+    {
+        protected JsonSerializerContext(JsonSerializerOptions? options) { }
+
+        protected abstract JsonSerializerOptions? GeneratedSerializerOptions { get; }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public abstract Metadata.JsonTypeInfo? GetTypeInfo(Type type);
+        Metadata.JsonTypeInfo Metadata.IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonSourceGenerationMode
+    {
+        Default = 0,
+        Metadata = 1,
+        Serialization = 2
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class JsonSourceGenerationOptionsAttribute : JsonAttribute
+    {
+        public JsonSourceGenerationOptionsAttribute() { }
+
+        public JsonSourceGenerationOptionsAttribute(JsonSerializerDefaults defaults) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Type[]? Converters { get { throw null; } set { } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool UseStringEnumConverter { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Applications should use the generic JsonStringEnumConverter<TEnum> instead.")]
+    public partial class JsonStringEnumConverter : JsonConverterFactory
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial class JsonStringEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        FailSerialization = 0,
+        FallBackToBaseType = 1,
+        FallBackToNearestAncestor = 2
+    }
+
+    public enum JsonUnknownTypeHandling
+    {
+        JsonElement = 0,
+        JsonNode = 1
+    }
+
+    public enum JsonUnmappedMemberHandling
+    {
+        Skip = 0,
+        Disallow = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public partial class JsonUnmappedMemberHandlingAttribute : JsonAttribute
+    {
+        public JsonUnmappedMemberHandlingAttribute(JsonUnmappedMemberHandling unmappedMemberHandling) { }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } }
+    }
+
+    public abstract partial class ReferenceHandler
+    {
+        public static ReferenceHandler IgnoreCycles { get { throw null; } }
+
+        public static ReferenceHandler Preserve { get { throw null; } }
+
+        public abstract ReferenceResolver CreateResolver();
+    }
+
+    public sealed partial class ReferenceHandler<T> : ReferenceHandler where T : ReferenceResolver, new()
+    {
+        public override ReferenceResolver CreateResolver() { throw null; }
+    }
+
+    public abstract partial class ReferenceResolver
+    {
+        public abstract void AddReference(string referenceId, object value);
+        public abstract string GetReference(object value, out bool alreadyExists);
+        public abstract object ResolveReference(string referenceId);
+    }
+}
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public partial class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        public Collections.Generic.IList<Action<JsonTypeInfo>> Modifiers { get { throw null; } }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "The ctor is marked RequiresDynamicCode.")]
+        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial interface IJsonTypeInfoResolver
+    {
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+
+    public sealed partial class JsonCollectionInfoValues<TCollection>
+    {
+        public JsonTypeInfo ElementInfo { get { throw null; } init { } }
+
+        public JsonTypeInfo? KeyInfo { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<TCollection>? ObjectCreator { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, TCollection>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public readonly partial struct JsonDerivedType
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonDerivedType(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    public static partial class JsonMetadataServices
+    {
+        public static JsonConverter<bool> BooleanConverter { get { throw null; } }
+
+        public static JsonConverter<byte[]?> ByteArrayConverter { get { throw null; } }
+
+        public static JsonConverter<byte> ByteConverter { get { throw null; } }
+
+        public static JsonConverter<char> CharConverter { get { throw null; } }
+
+        public static JsonConverter<DateOnly> DateOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<DateTime> DateTimeConverter { get { throw null; } }
+
+        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter { get { throw null; } }
+
+        public static JsonConverter<decimal> DecimalConverter { get { throw null; } }
+
+        public static JsonConverter<double> DoubleConverter { get { throw null; } }
+
+        public static JsonConverter<Guid> GuidConverter { get { throw null; } }
+
+        public static JsonConverter<Half> HalfConverter { get { throw null; } }
+
+        public static JsonConverter<Int128> Int128Converter { get { throw null; } }
+
+        public static JsonConverter<short> Int16Converter { get { throw null; } }
+
+        public static JsonConverter<int> Int32Converter { get { throw null; } }
+
+        public static JsonConverter<long> Int64Converter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonArray?> JsonArrayConverter { get { throw null; } }
+
+        public static JsonConverter<JsonDocument?> JsonDocumentConverter { get { throw null; } }
+
+        public static JsonConverter<JsonElement> JsonElementConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonNode?> JsonNodeConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonObject?> JsonObjectConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonValue?> JsonValueConverter { get { throw null; } }
+
+        public static JsonConverter<Memory<byte>> MemoryByteConverter { get { throw null; } }
+
+        public static JsonConverter<object?> ObjectConverter { get { throw null; } }
+
+        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<sbyte> SByteConverter { get { throw null; } }
+
+        public static JsonConverter<float> SingleConverter { get { throw null; } }
+
+        public static JsonConverter<string?> StringConverter { get { throw null; } }
+
+        public static JsonConverter<TimeOnly> TimeOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<TimeSpan> TimeSpanConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<UInt128> UInt128Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ushort> UInt16Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<uint> UInt32Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ulong> UInt64Converter { get { throw null; } }
+
+        public static JsonConverter<Uri?> UriConverter { get { throw null; } }
+
+        public static JsonConverter<Version?> VersionConverter { get { throw null; } }
+
+        public static JsonTypeInfo<TElement[]> CreateArrayInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TElement[]> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentQueue<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentStack<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Dictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIAsyncEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IAsyncEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateICollectionInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ICollection<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IDictionary { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IList { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IList<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<TKey, TValue>>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<TElement>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIReadOnlyDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateISetInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ISet<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.List<TElement> { throw null; }
+
+        public static JsonTypeInfo<Memory<TElement>> CreateMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<Memory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<T> CreateObjectInfo<T>(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) { throw null; }
+
+        public static JsonPropertyInfo CreatePropertyInfo<T>(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Queue<TElement> { throw null; }
+
+        public static JsonTypeInfo<ReadOnlyMemory<TElement>> CreateReadOnlyMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<ReadOnlyMemory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Stack<TElement> { throw null; }
+
+        public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter) { throw null; }
+
+        public static JsonConverter<T> GetEnumConverter<T>(JsonSerializerOptions options)
+            where T : struct, Enum { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonSerializerOptions options)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonTypeInfo<T> underlyingTypeInfo)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T> GetUnsupportedTypeConverter<T>() { throw null; }
+    }
+
+    public sealed partial class JsonObjectInfoValues<T>
+    {
+        public Func<JsonParameterInfoValues[]>? ConstructorParameterMetadataInitializer { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<T>? ObjectCreator { get { throw null; } init { } }
+
+        public Func<object[], T>? ObjectWithParameterizedConstructorCreator { get { throw null; } init { } }
+
+        public Func<JsonSerializerContext, JsonPropertyInfo[]>? PropertyMetadataInitializer { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public sealed partial class JsonParameterInfoValues
+    {
+        public object? DefaultValue { get { throw null; } init { } }
+
+        public bool HasDefaultValue { get { throw null; } init { } }
+
+        public string Name { get { throw null; } init { } }
+
+        public Type ParameterType { get { throw null; } init { } }
+
+        public int Position { get { throw null; } init { } }
+    }
+
+    public partial class JsonPolymorphismOptions
+    {
+        public Collections.Generic.IList<JsonDerivedType> DerivedTypes { get { throw null; } }
+
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonPropertyInfo
+    {
+        internal JsonPropertyInfo() { }
+
+        public System.Reflection.ICustomAttributeProvider? AttributeProvider { get { throw null; } set { } }
+
+        public JsonConverter? CustomConverter { get { throw null; } set { } }
+
+        public Func<object, object?>? Get { get { throw null; } set { } }
+
+        public bool IsExtensionData { get { throw null; } set { } }
+
+        public bool IsRequired { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? ObjectCreationHandling { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public int Order { get { throw null; } set { } }
+
+        public Type PropertyType { get { throw null; } }
+
+        public Action<object, object?>? Set { get { throw null; } set { } }
+
+        public Func<object, object?, bool>? ShouldSerialize { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonPropertyInfoValues<T>
+    {
+        public JsonConverter<T>? Converter { get { throw null; } init { } }
+
+        public Type DeclaringType { get { throw null; } init { } }
+
+        public Func<object, T?>? Getter { get { throw null; } init { } }
+
+        public bool HasJsonInclude { get { throw null; } init { } }
+
+        public JsonIgnoreCondition? IgnoreCondition { get { throw null; } init { } }
+
+        public bool IsExtensionData { get { throw null; } init { } }
+
+        public bool IsProperty { get { throw null; } init { } }
+
+        public bool IsPublic { get { throw null; } init { } }
+
+        public bool IsVirtual { get { throw null; } init { } }
+
+        public string? JsonPropertyName { get { throw null; } init { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } init { } }
+
+        public string PropertyName { get { throw null; } init { } }
+
+        public JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
+
+        public Action<object, T?>? Setter { get { throw null; } init { } }
+    }
+
+    public abstract partial class JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public JsonConverter Converter { get { throw null; } }
+
+        public Func<object>? CreateObject { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public JsonTypeInfoKind Kind { get { throw null; } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public Action<object>? OnDeserialized { get { throw null; } set { } }
+
+        public Action<object>? OnDeserializing { get { throw null; } set { } }
+
+        public Action<object>? OnSerialized { get { throw null; } set { } }
+
+        public Action<object>? OnSerializing { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public IJsonTypeInfoResolver? OriginatingResolver { get { throw null; } set { } }
+
+        public JsonPolymorphismOptions? PolymorphismOptions { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? PreferredPropertyObjectCreationHandling { get { throw null; } set { } }
+
+        public Collections.Generic.IList<JsonPropertyInfo> Properties { get { throw null; } }
+
+        public Type Type { get { throw null; } }
+
+        public JsonUnmappedMemberHandling? UnmappedMemberHandling { get { throw null; } set { } }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options) { throw null; }
+
+        public void MakeReadOnly() { }
+    }
+
+    public enum JsonTypeInfoKind
+    {
+        None = 0,
+        Object = 1,
+        Enumerable = 2,
+        Dictionary = 3
+    }
+
+    public static partial class JsonTypeInfoResolver
+    {
+        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver?[] resolvers) { throw null; }
+
+        public static IJsonTypeInfoResolver WithAddedModifier(this IJsonTypeInfoResolver resolver, Action<JsonTypeInfo> modifier) { throw null; }
+    }
+
+    public sealed partial class JsonTypeInfo<T> : JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public new Func<T>? CreateObject { get { throw null; } set { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.text.json/8.0.4/lib/net8.0/System.Text.Json.cs
+++ b/src/referencePackages/src/system.text.json/8.0.4/lib/net8.0/System.Text.Json.cs
@@ -1,0 +1,2201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Json")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.\r\n\r\nThe System.Text.Json library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.724.31311")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.7+2aade6beb02ea367fd97c4070a4198802fe61c03")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Json")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+namespace System.Text.Json
+{
+    public enum JsonCommentHandling : byte
+    {
+        Disallow = 0,
+        Skip = 1,
+        Allow = 2
+    }
+
+    public sealed partial class JsonDocument : IDisposable
+    {
+        internal JsonDocument() { }
+
+        public JsonElement RootElement { get { throw null; } }
+
+        public void Dispose() { }
+
+        public static JsonDocument Parse(Buffers.ReadOnlySequence<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(IO.Stream utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<char> json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(string json, JsonDocumentOptions options = default) { throw null; }
+
+        public static Threading.Tasks.Task<JsonDocument> ParseAsync(IO.Stream utf8Json, JsonDocumentOptions options = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonDocument? document) { throw null; }
+
+        public void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonDocumentOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public readonly partial struct JsonElement
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonElement this[int index] { get { throw null; } }
+
+        public JsonValueKind ValueKind { get { throw null; } }
+
+        public readonly JsonElement Clone() { throw null; }
+
+        public readonly ArrayEnumerator EnumerateArray() { throw null; }
+
+        public readonly ObjectEnumerator EnumerateObject() { throw null; }
+
+        public readonly int GetArrayLength() { throw null; }
+
+        public readonly bool GetBoolean() { throw null; }
+
+        public readonly byte GetByte() { throw null; }
+
+        public readonly byte[] GetBytesFromBase64() { throw null; }
+
+        public readonly DateTime GetDateTime() { throw null; }
+
+        public readonly DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public readonly decimal GetDecimal() { throw null; }
+
+        public readonly double GetDouble() { throw null; }
+
+        public readonly Guid GetGuid() { throw null; }
+
+        public readonly short GetInt16() { throw null; }
+
+        public readonly int GetInt32() { throw null; }
+
+        public readonly long GetInt64() { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<byte> utf8PropertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<char> propertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(string propertyName) { throw null; }
+
+        public readonly string GetRawText() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly sbyte GetSByte() { throw null; }
+
+        public readonly float GetSingle() { throw null; }
+
+        public readonly string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ulong GetUInt64() { throw null; }
+
+        public static JsonElement ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryGetByte(out byte value) { throw null; }
+
+        public readonly bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public readonly bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public readonly bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public readonly bool TryGetDecimal(out decimal value) { throw null; }
+
+        public readonly bool TryGetDouble(out double value) { throw null; }
+
+        public readonly bool TryGetGuid(out Guid value) { throw null; }
+
+        public readonly bool TryGetInt16(out short value) { throw null; }
+
+        public readonly bool TryGetInt32(out int value) { throw null; }
+
+        public readonly bool TryGetInt64(out long value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<byte> utf8PropertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<char> propertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(string propertyName, out JsonElement value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetSByte(out sbyte value) { throw null; }
+
+        public readonly bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt64(out ulong value) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonElement? element) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueEquals(string? text) { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+
+        public partial struct ArrayEnumerator : Collections.Generic.IEnumerable<JsonElement>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonElement>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonElement Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ArrayEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonElement> Collections.Generic.IEnumerable<JsonElement>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+
+        public partial struct ObjectEnumerator : Collections.Generic.IEnumerable<JsonProperty>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonProperty>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonProperty Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ObjectEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonProperty> Collections.Generic.IEnumerable<JsonProperty>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+    }
+
+    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(string value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public readonly bool Equals(JsonEncodedText other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class JsonException : Exception
+    {
+        public JsonException() { }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected JsonException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public JsonException(string? message, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine) { }
+
+        public JsonException(string? message) { }
+
+        public long? BytePositionInLine { get { throw null; } }
+
+        public long? LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string? Path { get { throw null; } }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public override void GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public abstract partial class JsonNamingPolicy
+    {
+        public static JsonNamingPolicy CamelCase { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseUpper { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseUpper { get { throw null; } }
+
+        public abstract string ConvertName(string name);
+    }
+
+    public readonly partial struct JsonProperty
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public string Name { get { throw null; } }
+
+        public JsonElement Value { get { throw null; } }
+
+        public readonly bool NameEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool NameEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool NameEquals(string? text) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public partial struct JsonReaderState
+    {
+        private int _dummyPrimitive;
+        public JsonReaderState(JsonReaderOptions options = default) { }
+
+        public JsonReaderOptions Options { get { throw null; } }
+    }
+
+    public static partial class JsonSerializer
+    {
+        public static bool IsReflectionEnabledByDefault { get { throw null; } }
+
+        public static object? Deserialize(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(string json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(string json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(string json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this JsonDocument document, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this JsonElement element, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(string json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(string json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this JsonDocument document, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonDocument document, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonElement element, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        public static string Serialize(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static string Serialize(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static string Serialize<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+    }
+
+    public enum JsonSerializerDefaults
+    {
+        General = 0,
+        Web = 1
+    }
+
+    public sealed partial class JsonSerializerOptions
+    {
+        public JsonSerializerOptions() { }
+
+        public JsonSerializerOptions(JsonSerializerDefaults defaults) { }
+
+        public JsonSerializerOptions(JsonSerializerOptions options) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.JsonConverter> Converters { get { throw null; } }
+
+        public static JsonSerializerOptions Default { get { throw null; } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.", DiagnosticId = "SYSLIB0020", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool IgnoreNullValues { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public Serialization.JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+
+        public Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.Metadata.IJsonTypeInfoResolver> TypeInfoResolverChain { get { throw null; } }
+
+        public Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public Serialization.JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+
+        [Obsolete("JsonSerializerOptions.AddContext is obsolete. To register a JsonSerializerContext, use either the TypeInfoResolver or TypeInfoResolverChain properties.", DiagnosticId = "SYSLIB0049", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void AddContext<TContext>()
+            where TContext : Serialization.JsonSerializerContext, new() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Getting a converter for a type may require reflection which depends on unreferenced code.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Getting a converter for a type may require reflection which depends on runtime code generation.")]
+        public Serialization.JsonConverter GetConverter(Type typeToConvert) { throw null; }
+
+        public Serialization.Metadata.JsonTypeInfo GetTypeInfo(Type type) { throw null; }
+
+        public void MakeReadOnly() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires unreferenced code.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Populating unconfigured TypeInfoResolver properties with the reflection resolver requires runtime code generation.")]
+        public void MakeReadOnly(bool populateMissingResolver) { }
+
+        public bool TryGetTypeInfo(Type type, out Serialization.Metadata.JsonTypeInfo? typeInfo) { throw null; }
+    }
+
+    public enum JsonTokenType : byte
+    {
+        None = 0,
+        StartObject = 1,
+        EndObject = 2,
+        StartArray = 3,
+        EndArray = 4,
+        PropertyName = 5,
+        Comment = 6,
+        String = 7,
+        Number = 8,
+        True = 9,
+        False = 10,
+        Null = 11
+    }
+
+    public enum JsonValueKind : byte
+    {
+        Undefined = 0,
+        Object = 1,
+        Array = 2,
+        String = 3,
+        Number = 4,
+        True = 5,
+        False = 6,
+        Null = 7
+    }
+
+    public partial struct JsonWriterOptions
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        public bool Indented { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public bool SkipValidation { get { throw null; } set { } }
+    }
+
+    public ref partial struct Utf8JsonReader
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public long BytesConsumed { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonReaderState CurrentState { get { throw null; } }
+
+        public bool HasValueSequence { get { throw null; } }
+
+        public bool IsFinalBlock { get { throw null; } }
+
+        public SequencePosition Position { get { throw null; } }
+
+        public long TokenStartIndex { get { throw null; } }
+
+        public JsonTokenType TokenType { get { throw null; } }
+
+        public bool ValueIsEscaped { get { throw null; } }
+
+        public Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
+
+        public ReadOnlySpan<byte> ValueSpan { get { throw null; } }
+
+        public readonly int CopyString(Span<byte> utf8Destination) { throw null; }
+
+        public readonly int CopyString(Span<char> destination) { throw null; }
+
+        public bool GetBoolean() { throw null; }
+
+        public byte GetByte() { throw null; }
+
+        public byte[] GetBytesFromBase64() { throw null; }
+
+        public string GetComment() { throw null; }
+
+        public DateTime GetDateTime() { throw null; }
+
+        public DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public decimal GetDecimal() { throw null; }
+
+        public double GetDouble() { throw null; }
+
+        public Guid GetGuid() { throw null; }
+
+        public short GetInt16() { throw null; }
+
+        public int GetInt32() { throw null; }
+
+        public long GetInt64() { throw null; }
+
+        [CLSCompliant(false)]
+        public sbyte GetSByte() { throw null; }
+
+        public float GetSingle() { throw null; }
+
+        public string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public ulong GetUInt64() { throw null; }
+
+        public bool Read() { throw null; }
+
+        public void Skip() { }
+
+        public bool TryGetByte(out byte value) { throw null; }
+
+        public bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public bool TryGetDecimal(out decimal value) { throw null; }
+
+        public bool TryGetDouble(out double value) { throw null; }
+
+        public bool TryGetGuid(out Guid value) { throw null; }
+
+        public bool TryGetInt16(out short value) { throw null; }
+
+        public bool TryGetInt32(out int value) { throw null; }
+
+        public bool TryGetInt64(out long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetSByte(out sbyte value) { throw null; }
+
+        public bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt64(out ulong value) { throw null; }
+
+        public bool TrySkip() { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueTextEquals(string? text) { throw null; }
+    }
+
+    public sealed partial class Utf8JsonWriter : IDisposable, IAsyncDisposable
+    {
+        public Utf8JsonWriter(Buffers.IBufferWriter<byte> bufferWriter, JsonWriterOptions options = default) { }
+
+        public Utf8JsonWriter(IO.Stream utf8Json, JsonWriterOptions options = default) { }
+
+        public long BytesCommitted { get { throw null; } }
+
+        public int BytesPending { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonWriterOptions Options { get { throw null; } }
+
+        public void Dispose() { }
+
+        public Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+
+        public void Flush() { }
+
+        public Threading.Tasks.Task FlushAsync(Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public void Reset() { }
+
+        public void Reset(Buffers.IBufferWriter<byte> bufferWriter) { }
+
+        public void Reset(IO.Stream utf8Json) { }
+
+        public void WriteBase64String(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(string propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(JsonEncodedText propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64StringValue(ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBoolean(ReadOnlySpan<byte> utf8PropertyName, bool value) { }
+
+        public void WriteBoolean(ReadOnlySpan<char> propertyName, bool value) { }
+
+        public void WriteBoolean(string propertyName, bool value) { }
+
+        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
+
+        public void WriteBooleanValue(bool value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<char> value) { }
+
+        public void WriteCommentValue(string value) { }
+
+        public void WriteEndArray() { }
+
+        public void WriteEndObject() { }
+
+        public void WriteNull(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteNull(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteNull(string propertyName) { }
+
+        public void WriteNull(JsonEncodedText propertyName) { }
+
+        public void WriteNullValue() { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, ulong value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, ulong value) { }
+
+        public void WriteNumber(string propertyName, decimal value) { }
+
+        public void WriteNumber(string propertyName, double value) { }
+
+        public void WriteNumber(string propertyName, int value) { }
+
+        public void WriteNumber(string propertyName, long value) { }
+
+        public void WriteNumber(string propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, ulong value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, double value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, int value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, long value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
+
+        public void WriteNumberValue(decimal value) { }
+
+        public void WriteNumberValue(double value) { }
+
+        public void WriteNumberValue(int value) { }
+
+        public void WriteNumberValue(long value) { }
+
+        public void WriteNumberValue(float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(ulong value) { }
+
+        public void WritePropertyName(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WritePropertyName(ReadOnlySpan<char> propertyName) { }
+
+        public void WritePropertyName(string propertyName) { }
+
+        public void WritePropertyName(JsonEncodedText propertyName) { }
+
+        public void WriteRawValue(Buffers.ReadOnlySequence<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<char> json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(string json, bool skipInputValidation = false) { }
+
+        public void WriteStartArray() { }
+
+        public void WriteStartArray(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartArray(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartArray(string propertyName) { }
+
+        public void WriteStartArray(JsonEncodedText propertyName) { }
+
+        public void WriteStartObject() { }
+
+        public void WriteStartObject(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartObject(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartObject(string propertyName) { }
+
+        public void WriteStartObject(JsonEncodedText propertyName) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
+
+        public void WriteString(string propertyName, DateTime value) { }
+
+        public void WriteString(string propertyName, DateTimeOffset value) { }
+
+        public void WriteString(string propertyName, Guid value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(string propertyName, string? value) { }
+
+        public void WriteString(string propertyName, JsonEncodedText value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTime value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTimeOffset value) { }
+
+        public void WriteString(JsonEncodedText propertyName, Guid value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(JsonEncodedText propertyName, string? value) { }
+
+        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
+
+        public void WriteStringValue(DateTime value) { }
+
+        public void WriteStringValue(DateTimeOffset value) { }
+
+        public void WriteStringValue(Guid value) { }
+
+        public void WriteStringValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteStringValue(ReadOnlySpan<char> value) { }
+
+        public void WriteStringValue(string? value) { }
+
+        public void WriteStringValue(JsonEncodedText value) { }
+    }
+}
+
+namespace System.Text.Json.Nodes
+{
+    public sealed partial class JsonArray : JsonNode, Collections.Generic.IList<JsonNode?>, Collections.Generic.ICollection<JsonNode?>, Collections.Generic.IEnumerable<JsonNode?>, Collections.IEnumerable
+    {
+        public JsonArray(JsonNodeOptions? options = null) { }
+
+        public JsonArray(params JsonNode?[] items) { }
+
+        public JsonArray(JsonNodeOptions options, params JsonNode?[] items) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<JsonNode>.IsReadOnly { get { throw null; } }
+
+        public void Add(JsonNode? item) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public void Add<T>(T? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(JsonNode? item) { throw null; }
+
+        public static JsonArray? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<JsonNode?> GetEnumerator() { throw null; }
+
+        public Collections.Generic.IEnumerable<T> GetValues<T>() { throw null; }
+
+        public int IndexOf(JsonNode? item) { throw null; }
+
+        public void Insert(int index, JsonNode? item) { }
+
+        public bool Remove(JsonNode? item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        void Collections.Generic.ICollection<JsonNode>.CopyTo(JsonNode[] array, int index) { }
+
+        Collections.IEnumerator? Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonNode
+    {
+        internal JsonNode() { }
+
+        public JsonNode? this[int index] { get { throw null; } set { } }
+
+        public JsonNode? this[string propertyName] { get { throw null; } set { } }
+
+        public JsonNodeOptions? Options { get { throw null; } }
+
+        public JsonNode? Parent { get { throw null; } }
+
+        public JsonNode Root { get { throw null; } }
+
+        public JsonArray AsArray() { throw null; }
+
+        public JsonObject AsObject() { throw null; }
+
+        public JsonValue AsValue() { throw null; }
+
+        public JsonNode DeepClone() { throw null; }
+
+        public static bool DeepEquals(JsonNode? node1, JsonNode? node2) { throw null; }
+
+        public int GetElementIndex() { throw null; }
+
+        public string GetPath() { throw null; }
+
+        public string GetPropertyName() { throw null; }
+
+        public virtual T GetValue<T>() { throw null; }
+
+        public JsonValueKind GetValueKind() { throw null; }
+
+        public static explicit operator bool(JsonNode value) { throw null; }
+
+        public static explicit operator byte(JsonNode value) { throw null; }
+
+        public static explicit operator char(JsonNode value) { throw null; }
+
+        public static explicit operator DateTime(JsonNode value) { throw null; }
+
+        public static explicit operator DateTimeOffset(JsonNode value) { throw null; }
+
+        public static explicit operator decimal(JsonNode value) { throw null; }
+
+        public static explicit operator double(JsonNode value) { throw null; }
+
+        public static explicit operator Guid(JsonNode value) { throw null; }
+
+        public static explicit operator short(JsonNode value) { throw null; }
+
+        public static explicit operator int(JsonNode value) { throw null; }
+
+        public static explicit operator long(JsonNode value) { throw null; }
+
+        public static explicit operator bool?(JsonNode? value) { throw null; }
+
+        public static explicit operator byte?(JsonNode? value) { throw null; }
+
+        public static explicit operator char?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTime?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTimeOffset?(JsonNode? value) { throw null; }
+
+        public static explicit operator decimal?(JsonNode? value) { throw null; }
+
+        public static explicit operator double?(JsonNode? value) { throw null; }
+
+        public static explicit operator Guid?(JsonNode? value) { throw null; }
+
+        public static explicit operator short?(JsonNode? value) { throw null; }
+
+        public static explicit operator int?(JsonNode? value) { throw null; }
+
+        public static explicit operator long?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte?(JsonNode? value) { throw null; }
+
+        public static explicit operator float?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte(JsonNode value) { throw null; }
+
+        public static explicit operator float(JsonNode value) { throw null; }
+
+        public static explicit operator string?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong(JsonNode value) { throw null; }
+
+        public static implicit operator JsonNode(bool value) { throw null; }
+
+        public static implicit operator JsonNode(byte value) { throw null; }
+
+        public static implicit operator JsonNode(char value) { throw null; }
+
+        public static implicit operator JsonNode(DateTime value) { throw null; }
+
+        public static implicit operator JsonNode(DateTimeOffset value) { throw null; }
+
+        public static implicit operator JsonNode(decimal value) { throw null; }
+
+        public static implicit operator JsonNode(double value) { throw null; }
+
+        public static implicit operator JsonNode(Guid value) { throw null; }
+
+        public static implicit operator JsonNode(short value) { throw null; }
+
+        public static implicit operator JsonNode(int value) { throw null; }
+
+        public static implicit operator JsonNode(long value) { throw null; }
+
+        public static implicit operator JsonNode?(bool? value) { throw null; }
+
+        public static implicit operator JsonNode?(byte? value) { throw null; }
+
+        public static implicit operator JsonNode?(char? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTime? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTimeOffset? value) { throw null; }
+
+        public static implicit operator JsonNode?(decimal? value) { throw null; }
+
+        public static implicit operator JsonNode?(double? value) { throw null; }
+
+        public static implicit operator JsonNode?(Guid? value) { throw null; }
+
+        public static implicit operator JsonNode?(short? value) { throw null; }
+
+        public static implicit operator JsonNode?(int? value) { throw null; }
+
+        public static implicit operator JsonNode?(long? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(sbyte? value) { throw null; }
+
+        public static implicit operator JsonNode?(float? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ushort? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(uint? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ulong? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(sbyte value) { throw null; }
+
+        public static implicit operator JsonNode(float value) { throw null; }
+
+        public static implicit operator JsonNode?(string? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ulong value) { throw null; }
+
+        public static JsonNode? Parse(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ReadOnlySpan<byte> utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(string json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ref Utf8JsonReader reader, JsonNodeOptions? nodeOptions = null) { throw null; }
+
+        public static Threading.Tasks.Task<JsonNode?> ParseAsync(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public void ReplaceWith<T>(T value) { }
+
+        public string ToJsonString(JsonSerializerOptions? options = null) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public abstract void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null);
+    }
+
+    public partial struct JsonNodeOptions
+    {
+        private int _dummyPrimitive;
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonObject : JsonNode, Collections.Generic.IDictionary<string, JsonNode?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.IEnumerable
+    {
+        public JsonObject(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>> properties, JsonNodeOptions? options = null) { }
+
+        public JsonObject(JsonNodeOptions? options = null) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.IsReadOnly { get { throw null; } }
+
+        Collections.Generic.ICollection<string> Collections.Generic.IDictionary<string, JsonNode>.Keys { get { throw null; } }
+
+        Collections.Generic.ICollection<JsonNode?> Collections.Generic.IDictionary<string, JsonNode>.Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, JsonNode?> property) { }
+
+        public void Add(string propertyName, JsonNode? value) { }
+
+        public void Clear() { }
+
+        public bool ContainsKey(string propertyName) { throw null; }
+
+        public static JsonObject? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, JsonNode?>> GetEnumerator() { throw null; }
+
+        public bool Remove(string propertyName) { throw null; }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Contains(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        void Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.CopyTo(Collections.Generic.KeyValuePair<string, JsonNode>[] array, int index) { }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Remove(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        bool Collections.Generic.IDictionary<string, JsonNode>.TryGetValue(string propertyName, out JsonNode jsonNode) { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode) { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonValue : JsonNode
+    {
+        internal JsonValue() { }
+
+        public static JsonValue Create(bool value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(byte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(char value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(double value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(short value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(int value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(long value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(float value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(uint value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Creating JsonValue instances with non-primitive types is not compatible with trimming. It can result in non-primitive types being serialized, which may have their members trimmed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("Creating JsonValue instances with non-primitive types requires generating code at runtime.")]
+        public static JsonValue? Create<T>(T? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create<T>(T? value, Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null) { throw null; }
+
+        public abstract bool TryGetValue<T>(out T? value);
+    }
+}
+
+namespace System.Text.Json.Serialization
+{
+    public partial interface IJsonOnDeserialized
+    {
+        void OnDeserialized();
+    }
+
+    public partial interface IJsonOnDeserializing
+    {
+        void OnDeserializing();
+    }
+
+    public partial interface IJsonOnSerialized
+    {
+        void OnSerialized();
+    }
+
+    public partial interface IJsonOnSerializing
+    {
+        void OnSerializing();
+    }
+
+    public abstract partial class JsonAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed partial class JsonConstructorAttribute : JsonAttribute
+    {
+    }
+
+    public abstract partial class JsonConverter
+    {
+        internal JsonConverter() { }
+
+        public abstract Type? Type { get; }
+
+        public abstract bool CanConvert(Type typeToConvert);
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public partial class JsonConverterAttribute : JsonAttribute
+    {
+        protected JsonConverterAttribute() { }
+
+        public JsonConverterAttribute(Type converterType) { }
+
+        [Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type? ConverterType { get { throw null; } }
+
+        public virtual JsonConverter? CreateConverter(Type typeToConvert) { throw null; }
+    }
+
+    public abstract partial class JsonConverterFactory : JsonConverter
+    {
+        protected JsonConverterFactory() { }
+
+        public sealed override Type? Type { get { throw null; } }
+
+        public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
+    }
+
+    public abstract partial class JsonConverter<T> : JsonConverter
+    {
+        protected internal JsonConverter() { }
+
+        public virtual bool HandleNull { get { throw null; } }
+
+        public sealed override Type Type { get { throw null; } }
+
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public abstract T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        public virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { throw null; }
+
+        public abstract void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+        public virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public partial class JsonDerivedTypeAttribute : JsonAttribute
+    {
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonExtensionDataAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIgnoreAttribute : JsonAttribute
+    {
+        public JsonIgnoreCondition Condition { get { throw null; } set { } }
+    }
+
+    public enum JsonIgnoreCondition
+    {
+        Never = 0,
+        Always = 1,
+        WhenWritingDefault = 2,
+        WhenWritingNull = 3
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIncludeAttribute : JsonAttribute
+    {
+    }
+
+    public enum JsonKnownNamingPolicy
+    {
+        Unspecified = 0,
+        CamelCase = 1,
+        SnakeCaseLower = 2,
+        SnakeCaseUpper = 3,
+        KebabCaseLower = 4,
+        KebabCaseUpper = 5
+    }
+
+    public sealed partial class JsonNumberEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        Strict = 0,
+        AllowReadingFromString = 1,
+        WriteAsString = 2,
+        AllowNamedFloatingPointLiterals = 4
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonNumberHandlingAttribute : JsonAttribute
+    {
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling) { }
+
+        public JsonNumberHandling Handling { get { throw null; } }
+    }
+
+    public enum JsonObjectCreationHandling
+    {
+        Replace = 0,
+        Populate = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed partial class JsonObjectCreationHandlingAttribute : JsonAttribute
+    {
+        public JsonObjectCreationHandlingAttribute(JsonObjectCreationHandling handling) { }
+
+        public JsonObjectCreationHandling Handling { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicAttribute : JsonAttribute
+    {
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyNameAttribute : JsonAttribute
+    {
+        public JsonPropertyNameAttribute(string name) { }
+
+        public string Name { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyOrderAttribute : JsonAttribute
+    {
+        public JsonPropertyOrderAttribute(int order) { }
+
+        public int Order { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonRequiredAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed partial class JsonSerializableAttribute : JsonAttribute
+    {
+        public JsonSerializableAttribute(Type type) { }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public string? TypeInfoPropertyName { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonSerializerContext : Metadata.IJsonTypeInfoResolver
+    {
+        protected JsonSerializerContext(JsonSerializerOptions? options) { }
+
+        protected abstract JsonSerializerOptions? GeneratedSerializerOptions { get; }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public abstract Metadata.JsonTypeInfo? GetTypeInfo(Type type);
+        Metadata.JsonTypeInfo Metadata.IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonSourceGenerationMode
+    {
+        Default = 0,
+        Metadata = 1,
+        Serialization = 2
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class JsonSourceGenerationOptionsAttribute : JsonAttribute
+    {
+        public JsonSourceGenerationOptionsAttribute() { }
+
+        public JsonSourceGenerationOptionsAttribute(JsonSerializerDefaults defaults) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Type[]? Converters { get { throw null; } set { } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool UseStringEnumConverter { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Applications should use the generic JsonStringEnumConverter<TEnum> instead.")]
+    public partial class JsonStringEnumConverter : JsonConverterFactory
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial class JsonStringEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        FailSerialization = 0,
+        FallBackToBaseType = 1,
+        FallBackToNearestAncestor = 2
+    }
+
+    public enum JsonUnknownTypeHandling
+    {
+        JsonElement = 0,
+        JsonNode = 1
+    }
+
+    public enum JsonUnmappedMemberHandling
+    {
+        Skip = 0,
+        Disallow = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public partial class JsonUnmappedMemberHandlingAttribute : JsonAttribute
+    {
+        public JsonUnmappedMemberHandlingAttribute(JsonUnmappedMemberHandling unmappedMemberHandling) { }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } }
+    }
+
+    public abstract partial class ReferenceHandler
+    {
+        public static ReferenceHandler IgnoreCycles { get { throw null; } }
+
+        public static ReferenceHandler Preserve { get { throw null; } }
+
+        public abstract ReferenceResolver CreateResolver();
+    }
+
+    public sealed partial class ReferenceHandler<T> : ReferenceHandler where T : ReferenceResolver, new()
+    {
+        public override ReferenceResolver CreateResolver() { throw null; }
+    }
+
+    public abstract partial class ReferenceResolver
+    {
+        public abstract void AddReference(string referenceId, object value);
+        public abstract string GetReference(object value, out bool alreadyExists);
+        public abstract object ResolveReference(string referenceId);
+    }
+}
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public partial class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        public Collections.Generic.IList<Action<JsonTypeInfo>> Modifiers { get { throw null; } }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode", Justification = "The ctor is marked RequiresDynamicCode.")]
+        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial interface IJsonTypeInfoResolver
+    {
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+
+    public sealed partial class JsonCollectionInfoValues<TCollection>
+    {
+        public JsonTypeInfo ElementInfo { get { throw null; } init { } }
+
+        public JsonTypeInfo? KeyInfo { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<TCollection>? ObjectCreator { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, TCollection>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public readonly partial struct JsonDerivedType
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonDerivedType(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    public static partial class JsonMetadataServices
+    {
+        public static JsonConverter<bool> BooleanConverter { get { throw null; } }
+
+        public static JsonConverter<byte[]?> ByteArrayConverter { get { throw null; } }
+
+        public static JsonConverter<byte> ByteConverter { get { throw null; } }
+
+        public static JsonConverter<char> CharConverter { get { throw null; } }
+
+        public static JsonConverter<DateOnly> DateOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<DateTime> DateTimeConverter { get { throw null; } }
+
+        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter { get { throw null; } }
+
+        public static JsonConverter<decimal> DecimalConverter { get { throw null; } }
+
+        public static JsonConverter<double> DoubleConverter { get { throw null; } }
+
+        public static JsonConverter<Guid> GuidConverter { get { throw null; } }
+
+        public static JsonConverter<Half> HalfConverter { get { throw null; } }
+
+        public static JsonConverter<Int128> Int128Converter { get { throw null; } }
+
+        public static JsonConverter<short> Int16Converter { get { throw null; } }
+
+        public static JsonConverter<int> Int32Converter { get { throw null; } }
+
+        public static JsonConverter<long> Int64Converter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonArray?> JsonArrayConverter { get { throw null; } }
+
+        public static JsonConverter<JsonDocument?> JsonDocumentConverter { get { throw null; } }
+
+        public static JsonConverter<JsonElement> JsonElementConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonNode?> JsonNodeConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonObject?> JsonObjectConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonValue?> JsonValueConverter { get { throw null; } }
+
+        public static JsonConverter<Memory<byte>> MemoryByteConverter { get { throw null; } }
+
+        public static JsonConverter<object?> ObjectConverter { get { throw null; } }
+
+        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<sbyte> SByteConverter { get { throw null; } }
+
+        public static JsonConverter<float> SingleConverter { get { throw null; } }
+
+        public static JsonConverter<string?> StringConverter { get { throw null; } }
+
+        public static JsonConverter<TimeOnly> TimeOnlyConverter { get { throw null; } }
+
+        public static JsonConverter<TimeSpan> TimeSpanConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<UInt128> UInt128Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ushort> UInt16Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<uint> UInt32Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ulong> UInt64Converter { get { throw null; } }
+
+        public static JsonConverter<Uri?> UriConverter { get { throw null; } }
+
+        public static JsonConverter<Version?> VersionConverter { get { throw null; } }
+
+        public static JsonTypeInfo<TElement[]> CreateArrayInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TElement[]> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentQueue<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentStack<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Dictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIAsyncEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IAsyncEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateICollectionInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ICollection<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IDictionary { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IList { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IList<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<TKey, TValue>>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<TElement>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIReadOnlyDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateISetInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ISet<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.List<TElement> { throw null; }
+
+        public static JsonTypeInfo<Memory<TElement>> CreateMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<Memory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<T> CreateObjectInfo<T>(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) { throw null; }
+
+        public static JsonPropertyInfo CreatePropertyInfo<T>(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Queue<TElement> { throw null; }
+
+        public static JsonTypeInfo<ReadOnlyMemory<TElement>> CreateReadOnlyMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<ReadOnlyMemory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Stack<TElement> { throw null; }
+
+        public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter) { throw null; }
+
+        public static JsonConverter<T> GetEnumConverter<T>(JsonSerializerOptions options)
+            where T : struct, Enum { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonSerializerOptions options)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonTypeInfo<T> underlyingTypeInfo)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T> GetUnsupportedTypeConverter<T>() { throw null; }
+    }
+
+    public sealed partial class JsonObjectInfoValues<T>
+    {
+        public Func<JsonParameterInfoValues[]>? ConstructorParameterMetadataInitializer { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<T>? ObjectCreator { get { throw null; } init { } }
+
+        public Func<object[], T>? ObjectWithParameterizedConstructorCreator { get { throw null; } init { } }
+
+        public Func<JsonSerializerContext, JsonPropertyInfo[]>? PropertyMetadataInitializer { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public sealed partial class JsonParameterInfoValues
+    {
+        public object? DefaultValue { get { throw null; } init { } }
+
+        public bool HasDefaultValue { get { throw null; } init { } }
+
+        public string Name { get { throw null; } init { } }
+
+        public Type ParameterType { get { throw null; } init { } }
+
+        public int Position { get { throw null; } init { } }
+    }
+
+    public partial class JsonPolymorphismOptions
+    {
+        public Collections.Generic.IList<JsonDerivedType> DerivedTypes { get { throw null; } }
+
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonPropertyInfo
+    {
+        internal JsonPropertyInfo() { }
+
+        public System.Reflection.ICustomAttributeProvider? AttributeProvider { get { throw null; } set { } }
+
+        public JsonConverter? CustomConverter { get { throw null; } set { } }
+
+        public Func<object, object?>? Get { get { throw null; } set { } }
+
+        public bool IsExtensionData { get { throw null; } set { } }
+
+        public bool IsRequired { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? ObjectCreationHandling { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public int Order { get { throw null; } set { } }
+
+        public Type PropertyType { get { throw null; } }
+
+        public Action<object, object?>? Set { get { throw null; } set { } }
+
+        public Func<object, object?, bool>? ShouldSerialize { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonPropertyInfoValues<T>
+    {
+        public JsonConverter<T>? Converter { get { throw null; } init { } }
+
+        public Type DeclaringType { get { throw null; } init { } }
+
+        public Func<object, T?>? Getter { get { throw null; } init { } }
+
+        public bool HasJsonInclude { get { throw null; } init { } }
+
+        public JsonIgnoreCondition? IgnoreCondition { get { throw null; } init { } }
+
+        public bool IsExtensionData { get { throw null; } init { } }
+
+        public bool IsProperty { get { throw null; } init { } }
+
+        public bool IsPublic { get { throw null; } init { } }
+
+        public bool IsVirtual { get { throw null; } init { } }
+
+        public string? JsonPropertyName { get { throw null; } init { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } init { } }
+
+        public string PropertyName { get { throw null; } init { } }
+
+        public JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
+
+        public Action<object, T?>? Setter { get { throw null; } init { } }
+    }
+
+    public abstract partial class JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public JsonConverter Converter { get { throw null; } }
+
+        public Func<object>? CreateObject { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public JsonTypeInfoKind Kind { get { throw null; } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public Action<object>? OnDeserialized { get { throw null; } set { } }
+
+        public Action<object>? OnDeserializing { get { throw null; } set { } }
+
+        public Action<object>? OnSerialized { get { throw null; } set { } }
+
+        public Action<object>? OnSerializing { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public IJsonTypeInfoResolver? OriginatingResolver { get { throw null; } set { } }
+
+        public JsonPolymorphismOptions? PolymorphismOptions { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? PreferredPropertyObjectCreationHandling { get { throw null; } set { } }
+
+        public Collections.Generic.IList<JsonPropertyInfo> Properties { get { throw null; } }
+
+        public Type Type { get { throw null; } }
+
+        public JsonUnmappedMemberHandling? UnmappedMemberHandling { get { throw null; } set { } }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options) { throw null; }
+
+        public void MakeReadOnly() { }
+    }
+
+    public enum JsonTypeInfoKind
+    {
+        None = 0,
+        Object = 1,
+        Enumerable = 2,
+        Dictionary = 3
+    }
+
+    public static partial class JsonTypeInfoResolver
+    {
+        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver?[] resolvers) { throw null; }
+
+        public static IJsonTypeInfoResolver WithAddedModifier(this IJsonTypeInfoResolver resolver, Action<JsonTypeInfo> modifier) { throw null; }
+    }
+
+    public sealed partial class JsonTypeInfo<T> : JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public new Func<T>? CreateObject { get { throw null; } set { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.text.json/8.0.4/lib/netstandard2.0/System.Text.Json.cs
+++ b/src/referencePackages/src/system.text.json/8.0.4/lib/netstandard2.0/System.Text.Json.cs
@@ -1,0 +1,2095 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Text.Json")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.\r\n\r\nThe System.Text.Json library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.724.31311")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.7+2aade6beb02ea367fd97c4070a4198802fe61c03")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Text.Json")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Text.Json
+{
+    public enum JsonCommentHandling : byte
+    {
+        Disallow = 0,
+        Skip = 1,
+        Allow = 2
+    }
+
+    public sealed partial class JsonDocument : IDisposable
+    {
+        internal JsonDocument() { }
+
+        public JsonElement RootElement { get { throw null; } }
+
+        public void Dispose() { }
+
+        public static JsonDocument Parse(Buffers.ReadOnlySequence<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(IO.Stream utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<byte> utf8Json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(ReadOnlyMemory<char> json, JsonDocumentOptions options = default) { throw null; }
+
+        public static JsonDocument Parse(string json, JsonDocumentOptions options = default) { throw null; }
+
+        public static Threading.Tasks.Task<JsonDocument> ParseAsync(IO.Stream utf8Json, JsonDocumentOptions options = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonDocument? document) { throw null; }
+
+        public void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonDocumentOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public readonly partial struct JsonElement
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonElement this[int index] { get { throw null; } }
+
+        public JsonValueKind ValueKind { get { throw null; } }
+
+        public readonly JsonElement Clone() { throw null; }
+
+        public readonly ArrayEnumerator EnumerateArray() { throw null; }
+
+        public readonly ObjectEnumerator EnumerateObject() { throw null; }
+
+        public readonly int GetArrayLength() { throw null; }
+
+        public readonly bool GetBoolean() { throw null; }
+
+        public readonly byte GetByte() { throw null; }
+
+        public readonly byte[] GetBytesFromBase64() { throw null; }
+
+        public readonly DateTime GetDateTime() { throw null; }
+
+        public readonly DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public readonly decimal GetDecimal() { throw null; }
+
+        public readonly double GetDouble() { throw null; }
+
+        public readonly Guid GetGuid() { throw null; }
+
+        public readonly short GetInt16() { throw null; }
+
+        public readonly int GetInt32() { throw null; }
+
+        public readonly long GetInt64() { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<byte> utf8PropertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(ReadOnlySpan<char> propertyName) { throw null; }
+
+        public readonly JsonElement GetProperty(string propertyName) { throw null; }
+
+        public readonly string GetRawText() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly sbyte GetSByte() { throw null; }
+
+        public readonly float GetSingle() { throw null; }
+
+        public readonly string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly ulong GetUInt64() { throw null; }
+
+        public static JsonElement ParseValue(ref Utf8JsonReader reader) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly bool TryGetByte(out byte value) { throw null; }
+
+        public readonly bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public readonly bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public readonly bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public readonly bool TryGetDecimal(out decimal value) { throw null; }
+
+        public readonly bool TryGetDouble(out double value) { throw null; }
+
+        public readonly bool TryGetGuid(out Guid value) { throw null; }
+
+        public readonly bool TryGetInt16(out short value) { throw null; }
+
+        public readonly bool TryGetInt32(out int value) { throw null; }
+
+        public readonly bool TryGetInt64(out long value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<byte> utf8PropertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(ReadOnlySpan<char> propertyName, out JsonElement value) { throw null; }
+
+        public readonly bool TryGetProperty(string propertyName, out JsonElement value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetSByte(out sbyte value) { throw null; }
+
+        public readonly bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public readonly bool TryGetUInt64(out ulong value) { throw null; }
+
+        public static bool TryParseValue(ref Utf8JsonReader reader, out JsonElement? element) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueEquals(string? text) { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+
+        public partial struct ArrayEnumerator : Collections.Generic.IEnumerable<JsonElement>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonElement>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonElement Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ArrayEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonElement> Collections.Generic.IEnumerable<JsonElement>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+
+        public partial struct ObjectEnumerator : Collections.Generic.IEnumerable<JsonProperty>, Collections.IEnumerable, Collections.Generic.IEnumerator<JsonProperty>, Collections.IEnumerator, IDisposable
+        {
+            private int _dummyPrimitive;
+            public JsonProperty Current { get { throw null; } }
+
+            object Collections.IEnumerator.Current { get { throw null; } }
+
+            public void Dispose() { }
+
+            public ObjectEnumerator GetEnumerator() { throw null; }
+
+            public bool MoveNext() { throw null; }
+
+            public void Reset() { }
+
+            Collections.Generic.IEnumerator<JsonProperty> Collections.Generic.IEnumerable<JsonProperty>.GetEnumerator() { throw null; }
+
+            Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+    }
+
+    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public static JsonEncodedText Encode(string value, Encodings.Web.JavaScriptEncoder? encoder = null) { throw null; }
+
+        public override readonly bool Equals(object? obj) { throw null; }
+
+        public readonly bool Equals(JsonEncodedText other) { throw null; }
+
+        public override readonly int GetHashCode() { throw null; }
+
+        public override readonly string ToString() { throw null; }
+    }
+
+    public partial class JsonException : Exception
+    {
+        public JsonException() { }
+
+        protected JsonException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public JsonException(string? message, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine, Exception? innerException) { }
+
+        public JsonException(string? message, string? path, long? lineNumber, long? bytePositionInLine) { }
+
+        public JsonException(string? message) { }
+
+        public long? BytePositionInLine { get { throw null; } }
+
+        public long? LineNumber { get { throw null; } }
+
+        public override string Message { get { throw null; } }
+
+        public string? Path { get { throw null; } }
+
+        public override void GetObjectData(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+    }
+
+    public abstract partial class JsonNamingPolicy
+    {
+        public static JsonNamingPolicy CamelCase { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy KebabCaseUpper { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseLower { get { throw null; } }
+
+        public static JsonNamingPolicy SnakeCaseUpper { get { throw null; } }
+
+        public abstract string ConvertName(string name);
+    }
+
+    public readonly partial struct JsonProperty
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public string Name { get { throw null; } }
+
+        public JsonElement Value { get { throw null; } }
+
+        public readonly bool NameEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool NameEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool NameEquals(string? text) { throw null; }
+
+        public override readonly string ToString() { throw null; }
+
+        public readonly void WriteTo(Utf8JsonWriter writer) { }
+    }
+
+    public partial struct JsonReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public JsonCommentHandling CommentHandling { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+    }
+
+    public partial struct JsonReaderState
+    {
+        private int _dummyPrimitive;
+        public JsonReaderState(JsonReaderOptions options = default) { }
+
+        public JsonReaderOptions Options { get { throw null; } }
+    }
+
+    public static partial class JsonSerializer
+    {
+        public static bool IsReflectionEnabledByDefault { get { throw null; } }
+
+        public static object? Deserialize(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ReadOnlySpan<char> json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(string json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(string json, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(string json, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonDocument document, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this JsonElement element, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(this Nodes.JsonNode? node, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static object? Deserialize(ref Utf8JsonReader reader, Type returnType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ReadOnlySpan<char> json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(string json, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(string json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonDocument document, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonDocument document, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this JsonElement element, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(this Nodes.JsonNode? node, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions? options = null) { throw null; }
+
+        public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<object?> DeserializeAsync(IO.Stream utf8Json, Type returnType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.ValueTask<TValue?> DeserializeAsync<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Collections.Generic.IAsyncEnumerable<TValue?> DeserializeAsyncEnumerable<TValue>(IO.Stream utf8Json, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        public static string Serialize(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static string Serialize(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize(Utf8JsonWriter writer, object? value, Type inputType, Serialization.JsonSerializerContext context) { }
+
+        public static string Serialize<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static string Serialize<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions? options = null) { }
+
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync(IO.Stream utf8Json, object? value, Type inputType, Serialization.JsonSerializerContext context, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, JsonSerializerOptions? options = null, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static Threading.Tasks.Task SerializeAsync<TValue>(IO.Stream utf8Json, TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonDocument SerializeToDocument<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static JsonElement SerializeToElement<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static Nodes.JsonNode? SerializeToNode<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Serialization.Metadata.JsonTypeInfo jsonTypeInfo) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes(object? value, Type inputType, Serialization.JsonSerializerContext context) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions? options = null) { throw null; }
+
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, Serialization.Metadata.JsonTypeInfo<TValue> jsonTypeInfo) { throw null; }
+    }
+
+    public enum JsonSerializerDefaults
+    {
+        General = 0,
+        Web = 1
+    }
+
+    public sealed partial class JsonSerializerOptions
+    {
+        public JsonSerializerOptions() { }
+
+        public JsonSerializerOptions(JsonSerializerDefaults defaults) { }
+
+        public JsonSerializerOptions(JsonSerializerOptions options) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.JsonConverter> Converters { get { throw null; } }
+
+        public static JsonSerializerOptions Default { get { throw null; } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        public bool IgnoreNullValues { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public Serialization.JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
+
+        public Serialization.Metadata.IJsonTypeInfoResolver? TypeInfoResolver { get { throw null; } set { } }
+
+        public Collections.Generic.IList<Serialization.Metadata.IJsonTypeInfoResolver> TypeInfoResolverChain { get { throw null; } }
+
+        public Serialization.JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public Serialization.JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+
+        public void AddContext<TContext>()
+            where TContext : Serialization.JsonSerializerContext, new() { }
+
+        public Serialization.JsonConverter GetConverter(Type typeToConvert) { throw null; }
+
+        public Serialization.Metadata.JsonTypeInfo GetTypeInfo(Type type) { throw null; }
+
+        public void MakeReadOnly() { }
+
+        public void MakeReadOnly(bool populateMissingResolver) { }
+
+        public bool TryGetTypeInfo(Type type, out Serialization.Metadata.JsonTypeInfo? typeInfo) { throw null; }
+    }
+
+    public enum JsonTokenType : byte
+    {
+        None = 0,
+        StartObject = 1,
+        EndObject = 2,
+        StartArray = 3,
+        EndArray = 4,
+        PropertyName = 5,
+        Comment = 6,
+        String = 7,
+        Number = 8,
+        True = 9,
+        False = 10,
+        Null = 11
+    }
+
+    public enum JsonValueKind : byte
+    {
+        Undefined = 0,
+        Object = 1,
+        Array = 2,
+        String = 3,
+        Number = 4,
+        True = 5,
+        False = 6,
+        Null = 7
+    }
+
+    public partial struct JsonWriterOptions
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
+
+        public bool Indented { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public bool SkipValidation { get { throw null; } set { } }
+    }
+
+    public ref partial struct Utf8JsonReader
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(Buffers.ReadOnlySequence<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) { }
+
+        public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) { }
+
+        public long BytesConsumed { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonReaderState CurrentState { get { throw null; } }
+
+        public bool HasValueSequence { get { throw null; } }
+
+        public bool IsFinalBlock { get { throw null; } }
+
+        public SequencePosition Position { get { throw null; } }
+
+        public long TokenStartIndex { get { throw null; } }
+
+        public JsonTokenType TokenType { get { throw null; } }
+
+        public bool ValueIsEscaped { get { throw null; } }
+
+        public Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
+
+        public ReadOnlySpan<byte> ValueSpan { get { throw null; } }
+
+        public readonly int CopyString(Span<byte> utf8Destination) { throw null; }
+
+        public readonly int CopyString(Span<char> destination) { throw null; }
+
+        public bool GetBoolean() { throw null; }
+
+        public byte GetByte() { throw null; }
+
+        public byte[] GetBytesFromBase64() { throw null; }
+
+        public string GetComment() { throw null; }
+
+        public DateTime GetDateTime() { throw null; }
+
+        public DateTimeOffset GetDateTimeOffset() { throw null; }
+
+        public decimal GetDecimal() { throw null; }
+
+        public double GetDouble() { throw null; }
+
+        public Guid GetGuid() { throw null; }
+
+        public short GetInt16() { throw null; }
+
+        public int GetInt32() { throw null; }
+
+        public long GetInt64() { throw null; }
+
+        [CLSCompliant(false)]
+        public sbyte GetSByte() { throw null; }
+
+        public float GetSingle() { throw null; }
+
+        public string? GetString() { throw null; }
+
+        [CLSCompliant(false)]
+        public ushort GetUInt16() { throw null; }
+
+        [CLSCompliant(false)]
+        public uint GetUInt32() { throw null; }
+
+        [CLSCompliant(false)]
+        public ulong GetUInt64() { throw null; }
+
+        public bool Read() { throw null; }
+
+        public void Skip() { }
+
+        public bool TryGetByte(out byte value) { throw null; }
+
+        public bool TryGetBytesFromBase64(out byte[]? value) { throw null; }
+
+        public bool TryGetDateTime(out DateTime value) { throw null; }
+
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
+
+        public bool TryGetDecimal(out decimal value) { throw null; }
+
+        public bool TryGetDouble(out double value) { throw null; }
+
+        public bool TryGetGuid(out Guid value) { throw null; }
+
+        public bool TryGetInt16(out short value) { throw null; }
+
+        public bool TryGetInt32(out int value) { throw null; }
+
+        public bool TryGetInt64(out long value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetSByte(out sbyte value) { throw null; }
+
+        public bool TryGetSingle(out float value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt16(out ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt32(out uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public bool TryGetUInt64(out ulong value) { throw null; }
+
+        public bool TrySkip() { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<byte> utf8Text) { throw null; }
+
+        public readonly bool ValueTextEquals(ReadOnlySpan<char> text) { throw null; }
+
+        public readonly bool ValueTextEquals(string? text) { throw null; }
+    }
+
+    public sealed partial class Utf8JsonWriter : IDisposable, IAsyncDisposable
+    {
+        public Utf8JsonWriter(Buffers.IBufferWriter<byte> bufferWriter, JsonWriterOptions options = default) { }
+
+        public Utf8JsonWriter(IO.Stream utf8Json, JsonWriterOptions options = default) { }
+
+        public long BytesCommitted { get { throw null; } }
+
+        public int BytesPending { get { throw null; } }
+
+        public int CurrentDepth { get { throw null; } }
+
+        public JsonWriterOptions Options { get { throw null; } }
+
+        public void Dispose() { }
+
+        public Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+
+        public void Flush() { }
+
+        public Threading.Tasks.Task FlushAsync(Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public void Reset() { }
+
+        public void Reset(Buffers.IBufferWriter<byte> bufferWriter) { }
+
+        public void Reset(IO.Stream utf8Json) { }
+
+        public void WriteBase64String(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(string propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64String(JsonEncodedText propertyName, ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBase64StringValue(ReadOnlySpan<byte> bytes) { }
+
+        public void WriteBoolean(ReadOnlySpan<byte> utf8PropertyName, bool value) { }
+
+        public void WriteBoolean(ReadOnlySpan<char> propertyName, bool value) { }
+
+        public void WriteBoolean(string propertyName, bool value) { }
+
+        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
+
+        public void WriteBooleanValue(bool value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteCommentValue(ReadOnlySpan<char> value) { }
+
+        public void WriteCommentValue(string value) { }
+
+        public void WriteEndArray() { }
+
+        public void WriteEndObject() { }
+
+        public void WriteNull(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteNull(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteNull(string propertyName) { }
+
+        public void WriteNull(JsonEncodedText propertyName) { }
+
+        public void WriteNullValue() { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<byte> utf8PropertyName, ulong value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, decimal value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, double value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, int value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, long value) { }
+
+        public void WriteNumber(ReadOnlySpan<char> propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(ReadOnlySpan<char> propertyName, ulong value) { }
+
+        public void WriteNumber(string propertyName, decimal value) { }
+
+        public void WriteNumber(string propertyName, double value) { }
+
+        public void WriteNumber(string propertyName, int value) { }
+
+        public void WriteNumber(string propertyName, long value) { }
+
+        public void WriteNumber(string propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(string propertyName, ulong value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, double value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, int value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, long value) { }
+
+        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
+
+        public void WriteNumberValue(decimal value) { }
+
+        public void WriteNumberValue(double value) { }
+
+        public void WriteNumberValue(int value) { }
+
+        public void WriteNumberValue(long value) { }
+
+        public void WriteNumberValue(float value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(uint value) { }
+
+        [CLSCompliant(false)]
+        public void WriteNumberValue(ulong value) { }
+
+        public void WritePropertyName(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WritePropertyName(ReadOnlySpan<char> propertyName) { }
+
+        public void WritePropertyName(string propertyName) { }
+
+        public void WritePropertyName(JsonEncodedText propertyName) { }
+
+        public void WriteRawValue(Buffers.ReadOnlySequence<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<byte> utf8Json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(ReadOnlySpan<char> json, bool skipInputValidation = false) { }
+
+        public void WriteRawValue(string json, bool skipInputValidation = false) { }
+
+        public void WriteStartArray() { }
+
+        public void WriteStartArray(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartArray(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartArray(string propertyName) { }
+
+        public void WriteStartArray(JsonEncodedText propertyName) { }
+
+        public void WriteStartObject() { }
+
+        public void WriteStartObject(ReadOnlySpan<byte> utf8PropertyName) { }
+
+        public void WriteStartObject(ReadOnlySpan<char> propertyName) { }
+
+        public void WriteStartObject(string propertyName) { }
+
+        public void WriteStartObject(JsonEncodedText propertyName) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTime value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, DateTimeOffset value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, Guid value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, string? value) { }
+
+        public void WriteString(ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
+
+        public void WriteString(string propertyName, DateTime value) { }
+
+        public void WriteString(string propertyName, DateTimeOffset value) { }
+
+        public void WriteString(string propertyName, Guid value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(string propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(string propertyName, string? value) { }
+
+        public void WriteString(string propertyName, JsonEncodedText value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTime value) { }
+
+        public void WriteString(JsonEncodedText propertyName, DateTimeOffset value) { }
+
+        public void WriteString(JsonEncodedText propertyName, Guid value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<char> value) { }
+
+        public void WriteString(JsonEncodedText propertyName, string? value) { }
+
+        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
+
+        public void WriteStringValue(DateTime value) { }
+
+        public void WriteStringValue(DateTimeOffset value) { }
+
+        public void WriteStringValue(Guid value) { }
+
+        public void WriteStringValue(ReadOnlySpan<byte> utf8Value) { }
+
+        public void WriteStringValue(ReadOnlySpan<char> value) { }
+
+        public void WriteStringValue(string? value) { }
+
+        public void WriteStringValue(JsonEncodedText value) { }
+    }
+}
+
+namespace System.Text.Json.Nodes
+{
+    public sealed partial class JsonArray : JsonNode, Collections.Generic.IList<JsonNode?>, Collections.Generic.ICollection<JsonNode?>, Collections.Generic.IEnumerable<JsonNode?>, Collections.IEnumerable
+    {
+        public JsonArray(JsonNodeOptions? options = null) { }
+
+        public JsonArray(params JsonNode?[] items) { }
+
+        public JsonArray(JsonNodeOptions options, params JsonNode?[] items) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<JsonNode>.IsReadOnly { get { throw null; } }
+
+        public void Add(JsonNode? item) { }
+
+        public void Add<T>(T? value) { }
+
+        public void Clear() { }
+
+        public bool Contains(JsonNode? item) { throw null; }
+
+        public static JsonArray? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<JsonNode?> GetEnumerator() { throw null; }
+
+        public Collections.Generic.IEnumerable<T> GetValues<T>() { throw null; }
+
+        public int IndexOf(JsonNode? item) { throw null; }
+
+        public void Insert(int index, JsonNode? item) { }
+
+        public bool Remove(JsonNode? item) { throw null; }
+
+        public void RemoveAt(int index) { }
+
+        void Collections.Generic.ICollection<JsonNode>.CopyTo(JsonNode[] array, int index) { }
+
+        Collections.IEnumerator? Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonNode
+    {
+        internal JsonNode() { }
+
+        public JsonNode? this[int index] { get { throw null; } set { } }
+
+        public JsonNode? this[string propertyName] { get { throw null; } set { } }
+
+        public JsonNodeOptions? Options { get { throw null; } }
+
+        public JsonNode? Parent { get { throw null; } }
+
+        public JsonNode Root { get { throw null; } }
+
+        public JsonArray AsArray() { throw null; }
+
+        public JsonObject AsObject() { throw null; }
+
+        public JsonValue AsValue() { throw null; }
+
+        public JsonNode DeepClone() { throw null; }
+
+        public static bool DeepEquals(JsonNode? node1, JsonNode? node2) { throw null; }
+
+        public int GetElementIndex() { throw null; }
+
+        public string GetPath() { throw null; }
+
+        public string GetPropertyName() { throw null; }
+
+        public virtual T GetValue<T>() { throw null; }
+
+        public JsonValueKind GetValueKind() { throw null; }
+
+        public static explicit operator bool(JsonNode value) { throw null; }
+
+        public static explicit operator byte(JsonNode value) { throw null; }
+
+        public static explicit operator char(JsonNode value) { throw null; }
+
+        public static explicit operator DateTime(JsonNode value) { throw null; }
+
+        public static explicit operator DateTimeOffset(JsonNode value) { throw null; }
+
+        public static explicit operator decimal(JsonNode value) { throw null; }
+
+        public static explicit operator double(JsonNode value) { throw null; }
+
+        public static explicit operator Guid(JsonNode value) { throw null; }
+
+        public static explicit operator short(JsonNode value) { throw null; }
+
+        public static explicit operator int(JsonNode value) { throw null; }
+
+        public static explicit operator long(JsonNode value) { throw null; }
+
+        public static explicit operator bool?(JsonNode? value) { throw null; }
+
+        public static explicit operator byte?(JsonNode? value) { throw null; }
+
+        public static explicit operator char?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTime?(JsonNode? value) { throw null; }
+
+        public static explicit operator DateTimeOffset?(JsonNode? value) { throw null; }
+
+        public static explicit operator decimal?(JsonNode? value) { throw null; }
+
+        public static explicit operator double?(JsonNode? value) { throw null; }
+
+        public static explicit operator Guid?(JsonNode? value) { throw null; }
+
+        public static explicit operator short?(JsonNode? value) { throw null; }
+
+        public static explicit operator int?(JsonNode? value) { throw null; }
+
+        public static explicit operator long?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte?(JsonNode? value) { throw null; }
+
+        public static explicit operator float?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator sbyte(JsonNode value) { throw null; }
+
+        public static explicit operator float(JsonNode value) { throw null; }
+
+        public static explicit operator string?(JsonNode? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ushort(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator uint(JsonNode value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static explicit operator ulong(JsonNode value) { throw null; }
+
+        public static implicit operator JsonNode(bool value) { throw null; }
+
+        public static implicit operator JsonNode(byte value) { throw null; }
+
+        public static implicit operator JsonNode(char value) { throw null; }
+
+        public static implicit operator JsonNode(DateTime value) { throw null; }
+
+        public static implicit operator JsonNode(DateTimeOffset value) { throw null; }
+
+        public static implicit operator JsonNode(decimal value) { throw null; }
+
+        public static implicit operator JsonNode(double value) { throw null; }
+
+        public static implicit operator JsonNode(Guid value) { throw null; }
+
+        public static implicit operator JsonNode(short value) { throw null; }
+
+        public static implicit operator JsonNode(int value) { throw null; }
+
+        public static implicit operator JsonNode(long value) { throw null; }
+
+        public static implicit operator JsonNode?(bool? value) { throw null; }
+
+        public static implicit operator JsonNode?(byte? value) { throw null; }
+
+        public static implicit operator JsonNode?(char? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTime? value) { throw null; }
+
+        public static implicit operator JsonNode?(DateTimeOffset? value) { throw null; }
+
+        public static implicit operator JsonNode?(decimal? value) { throw null; }
+
+        public static implicit operator JsonNode?(double? value) { throw null; }
+
+        public static implicit operator JsonNode?(Guid? value) { throw null; }
+
+        public static implicit operator JsonNode?(short? value) { throw null; }
+
+        public static implicit operator JsonNode?(int? value) { throw null; }
+
+        public static implicit operator JsonNode?(long? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(sbyte? value) { throw null; }
+
+        public static implicit operator JsonNode?(float? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ushort? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(uint? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode?(ulong? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(sbyte value) { throw null; }
+
+        public static implicit operator JsonNode(float value) { throw null; }
+
+        public static implicit operator JsonNode?(string? value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ushort value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(uint value) { throw null; }
+
+        [CLSCompliant(false)]
+        public static implicit operator JsonNode(ulong value) { throw null; }
+
+        public static JsonNode? Parse(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ReadOnlySpan<byte> utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(string json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default) { throw null; }
+
+        public static JsonNode? Parse(ref Utf8JsonReader reader, JsonNodeOptions? nodeOptions = null) { throw null; }
+
+        public static Threading.Tasks.Task<JsonNode?> ParseAsync(IO.Stream utf8Json, JsonNodeOptions? nodeOptions = null, JsonDocumentOptions documentOptions = default, Threading.CancellationToken cancellationToken = default) { throw null; }
+
+        public void ReplaceWith<T>(T value) { }
+
+        public string ToJsonString(JsonSerializerOptions? options = null) { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public abstract void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null);
+    }
+
+    public partial struct JsonNodeOptions
+    {
+        private int _dummyPrimitive;
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonObject : JsonNode, Collections.Generic.IDictionary<string, JsonNode?>, Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>>, Collections.IEnumerable
+    {
+        public JsonObject(Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<string, JsonNode?>> properties, JsonNodeOptions? options = null) { }
+
+        public JsonObject(JsonNodeOptions? options = null) { }
+
+        public int Count { get { throw null; } }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.IsReadOnly { get { throw null; } }
+
+        Collections.Generic.ICollection<string> Collections.Generic.IDictionary<string, JsonNode>.Keys { get { throw null; } }
+
+        Collections.Generic.ICollection<JsonNode?> Collections.Generic.IDictionary<string, JsonNode>.Values { get { throw null; } }
+
+        public void Add(Collections.Generic.KeyValuePair<string, JsonNode?> property) { }
+
+        public void Add(string propertyName, JsonNode? value) { }
+
+        public void Clear() { }
+
+        public bool ContainsKey(string propertyName) { throw null; }
+
+        public static JsonObject? Create(JsonElement element, JsonNodeOptions? options = null) { throw null; }
+
+        public Collections.Generic.IEnumerator<Collections.Generic.KeyValuePair<string, JsonNode?>> GetEnumerator() { throw null; }
+
+        public bool Remove(string propertyName) { throw null; }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Contains(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        void Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.CopyTo(Collections.Generic.KeyValuePair<string, JsonNode>[] array, int index) { }
+
+        bool Collections.Generic.ICollection<Collections.Generic.KeyValuePair<string, JsonNode>>.Remove(Collections.Generic.KeyValuePair<string, JsonNode> item) { throw null; }
+
+        bool Collections.Generic.IDictionary<string, JsonNode>.TryGetValue(string propertyName, out JsonNode jsonNode) { throw null; }
+
+        Collections.IEnumerator Collections.IEnumerable.GetEnumerator() { throw null; }
+
+        public bool TryGetPropertyValue(string propertyName, out JsonNode? jsonNode) { throw null; }
+
+        public override void WriteTo(Utf8JsonWriter writer, JsonSerializerOptions? options = null) { }
+    }
+
+    public abstract partial class JsonValue : JsonNode
+    {
+        internal JsonValue() { }
+
+        public static JsonValue Create(bool value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(byte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(char value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTime value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(DateTimeOffset value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(decimal value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(double value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(Guid value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(short value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(int value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(long value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(bool? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(byte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(char? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTime? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(DateTimeOffset? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(decimal? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(double? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(Guid? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(short? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(int? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(long? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(sbyte? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(float? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ushort? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(uint? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue? Create(ulong? value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(sbyte value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue Create(float value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(string? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create(JsonElement value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ushort value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(uint value, JsonNodeOptions? options = null) { throw null; }
+
+        [CLSCompliant(false)]
+        public static JsonValue Create(ulong value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create<T>(T? value, JsonNodeOptions? options = null) { throw null; }
+
+        public static JsonValue? Create<T>(T? value, Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo, JsonNodeOptions? options = null) { throw null; }
+
+        public abstract bool TryGetValue<T>(out T? value);
+    }
+}
+
+namespace System.Text.Json.Serialization
+{
+    public partial interface IJsonOnDeserialized
+    {
+        void OnDeserialized();
+    }
+
+    public partial interface IJsonOnDeserializing
+    {
+        void OnDeserializing();
+    }
+
+    public partial interface IJsonOnSerialized
+    {
+        void OnSerialized();
+    }
+
+    public partial interface IJsonOnSerializing
+    {
+        void OnSerializing();
+    }
+
+    public abstract partial class JsonAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false)]
+    public sealed partial class JsonConstructorAttribute : JsonAttribute
+    {
+    }
+
+    public abstract partial class JsonConverter
+    {
+        internal JsonConverter() { }
+
+        public abstract Type? Type { get; }
+
+        public abstract bool CanConvert(Type typeToConvert);
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public partial class JsonConverterAttribute : JsonAttribute
+    {
+        protected JsonConverterAttribute() { }
+
+        public JsonConverterAttribute(Type converterType) { }
+
+        public Type? ConverterType { get { throw null; } }
+
+        public virtual JsonConverter? CreateConverter(Type typeToConvert) { throw null; }
+    }
+
+    public abstract partial class JsonConverterFactory : JsonConverter
+    {
+        protected JsonConverterFactory() { }
+
+        public sealed override Type? Type { get { throw null; } }
+
+        public abstract JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options);
+    }
+
+    public abstract partial class JsonConverter<T> : JsonConverter
+    {
+        protected internal JsonConverter() { }
+
+        public virtual bool HandleNull { get { throw null; } }
+
+        public sealed override Type Type { get { throw null; } }
+
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public abstract T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
+        public virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { throw null; }
+
+        public abstract void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+        public virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+    public partial class JsonDerivedTypeAttribute : JsonAttribute
+    {
+        public JsonDerivedTypeAttribute(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedTypeAttribute(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonExtensionDataAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIgnoreAttribute : JsonAttribute
+    {
+        public JsonIgnoreCondition Condition { get { throw null; } set { } }
+    }
+
+    public enum JsonIgnoreCondition
+    {
+        Never = 0,
+        Always = 1,
+        WhenWritingDefault = 2,
+        WhenWritingNull = 3
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonIncludeAttribute : JsonAttribute
+    {
+    }
+
+    public enum JsonKnownNamingPolicy
+    {
+        Unspecified = 0,
+        CamelCase = 1,
+        SnakeCaseLower = 2,
+        SnakeCaseUpper = 3,
+        KebabCaseLower = 4,
+        KebabCaseUpper = 5
+    }
+
+    public sealed partial class JsonNumberEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        Strict = 0,
+        AllowReadingFromString = 1,
+        WriteAsString = 2,
+        AllowNamedFloatingPointLiterals = 4
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonNumberHandlingAttribute : JsonAttribute
+    {
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling) { }
+
+        public JsonNumberHandling Handling { get { throw null; } }
+    }
+
+    public enum JsonObjectCreationHandling
+    {
+        Replace = 0,
+        Populate = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed partial class JsonObjectCreationHandlingAttribute : JsonAttribute
+    {
+        public JsonObjectCreationHandlingAttribute(JsonObjectCreationHandling handling) { }
+
+        public JsonObjectCreationHandling Handling { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicAttribute : JsonAttribute
+    {
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string? TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyNameAttribute : JsonAttribute
+    {
+        public JsonPropertyNameAttribute(string name) { }
+
+        public string Name { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonPropertyOrderAttribute : JsonAttribute
+    {
+        public JsonPropertyOrderAttribute(int order) { }
+
+        public int Order { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonRequiredAttribute : JsonAttribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public sealed partial class JsonSerializableAttribute : JsonAttribute
+    {
+        public JsonSerializableAttribute(Type type) { }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public string? TypeInfoPropertyName { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonSerializerContext : Metadata.IJsonTypeInfoResolver
+    {
+        protected JsonSerializerContext(JsonSerializerOptions? options) { }
+
+        protected abstract JsonSerializerOptions? GeneratedSerializerOptions { get; }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public abstract Metadata.JsonTypeInfo? GetTypeInfo(Type type);
+        Metadata.JsonTypeInfo Metadata.IJsonTypeInfoResolver.GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    [Flags]
+    public enum JsonSourceGenerationMode
+    {
+        Default = 0,
+        Metadata = 1,
+        Serialization = 2
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed partial class JsonSourceGenerationOptionsAttribute : JsonAttribute
+    {
+        public JsonSourceGenerationOptionsAttribute() { }
+
+        public JsonSourceGenerationOptionsAttribute(JsonSerializerDefaults defaults) { }
+
+        public bool AllowTrailingCommas { get { throw null; } set { } }
+
+        public Type[]? Converters { get { throw null; } set { } }
+
+        public int DefaultBufferSize { get { throw null; } set { } }
+
+        public JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy DictionaryKeyPolicy { get { throw null; } set { } }
+
+        public JsonSourceGenerationMode GenerationMode { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyFields { get { throw null; } set { } }
+
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+
+        public bool IncludeFields { get { throw null; } set { } }
+
+        public int MaxDepth { get { throw null; } set { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling PreferredObjectCreationHandling { get { throw null; } set { } }
+
+        public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
+
+        public JsonKnownNamingPolicy PropertyNamingPolicy { get { throw null; } set { } }
+
+        public JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+
+        public JsonUnknownTypeHandling UnknownTypeHandling { get { throw null; } set { } }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } set { } }
+
+        public bool UseStringEnumConverter { get { throw null; } set { } }
+
+        public bool WriteIndented { get { throw null; } set { } }
+    }
+
+    public partial class JsonStringEnumConverter : JsonConverterFactory
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial class JsonStringEnumConverter<TEnum> : JsonConverterFactory where TEnum : struct, Enum
+    {
+        public JsonStringEnumConverter() { }
+
+        public JsonStringEnumConverter(JsonNamingPolicy? namingPolicy = null, bool allowIntegerValues = true) { }
+
+        public sealed override bool CanConvert(Type typeToConvert) { throw null; }
+
+        public sealed override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options) { throw null; }
+    }
+
+    public enum JsonUnknownDerivedTypeHandling
+    {
+        FailSerialization = 0,
+        FallBackToBaseType = 1,
+        FallBackToNearestAncestor = 2
+    }
+
+    public enum JsonUnknownTypeHandling
+    {
+        JsonElement = 0,
+        JsonNode = 1
+    }
+
+    public enum JsonUnmappedMemberHandling
+    {
+        Skip = 0,
+        Disallow = 1
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public partial class JsonUnmappedMemberHandlingAttribute : JsonAttribute
+    {
+        public JsonUnmappedMemberHandlingAttribute(JsonUnmappedMemberHandling unmappedMemberHandling) { }
+
+        public JsonUnmappedMemberHandling UnmappedMemberHandling { get { throw null; } }
+    }
+
+    public abstract partial class ReferenceHandler
+    {
+        public static ReferenceHandler IgnoreCycles { get { throw null; } }
+
+        public static ReferenceHandler Preserve { get { throw null; } }
+
+        public abstract ReferenceResolver CreateResolver();
+    }
+
+    public sealed partial class ReferenceHandler<T> : ReferenceHandler where T : ReferenceResolver, new()
+    {
+        public override ReferenceResolver CreateResolver() { throw null; }
+    }
+
+    public abstract partial class ReferenceResolver
+    {
+        public abstract void AddReference(string referenceId, object value);
+        public abstract string GetReference(object value, out bool alreadyExists);
+        public abstract object ResolveReference(string referenceId);
+    }
+}
+
+namespace System.Text.Json.Serialization.Metadata
+{
+    public partial class DefaultJsonTypeInfoResolver : IJsonTypeInfoResolver
+    {
+        public Collections.Generic.IList<Action<JsonTypeInfo>> Modifiers { get { throw null; } }
+
+        public virtual JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+    }
+
+    public partial interface IJsonTypeInfoResolver
+    {
+        JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options);
+    }
+
+    public sealed partial class JsonCollectionInfoValues<TCollection>
+    {
+        public JsonTypeInfo ElementInfo { get { throw null; } init { } }
+
+        public JsonTypeInfo? KeyInfo { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<TCollection>? ObjectCreator { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, TCollection>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public readonly partial struct JsonDerivedType
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JsonDerivedType(Type derivedType, int typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType, string typeDiscriminator) { }
+
+        public JsonDerivedType(Type derivedType) { }
+
+        public Type DerivedType { get { throw null; } }
+
+        public object? TypeDiscriminator { get { throw null; } }
+    }
+
+    public static partial class JsonMetadataServices
+    {
+        public static JsonConverter<bool> BooleanConverter { get { throw null; } }
+
+        public static JsonConverter<byte[]?> ByteArrayConverter { get { throw null; } }
+
+        public static JsonConverter<byte> ByteConverter { get { throw null; } }
+
+        public static JsonConverter<char> CharConverter { get { throw null; } }
+
+        public static JsonConverter<DateTime> DateTimeConverter { get { throw null; } }
+
+        public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter { get { throw null; } }
+
+        public static JsonConverter<decimal> DecimalConverter { get { throw null; } }
+
+        public static JsonConverter<double> DoubleConverter { get { throw null; } }
+
+        public static JsonConverter<Guid> GuidConverter { get { throw null; } }
+
+        public static JsonConverter<short> Int16Converter { get { throw null; } }
+
+        public static JsonConverter<int> Int32Converter { get { throw null; } }
+
+        public static JsonConverter<long> Int64Converter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonArray?> JsonArrayConverter { get { throw null; } }
+
+        public static JsonConverter<JsonDocument?> JsonDocumentConverter { get { throw null; } }
+
+        public static JsonConverter<JsonElement> JsonElementConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonNode?> JsonNodeConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonObject?> JsonObjectConverter { get { throw null; } }
+
+        public static JsonConverter<Nodes.JsonValue?> JsonValueConverter { get { throw null; } }
+
+        public static JsonConverter<Memory<byte>> MemoryByteConverter { get { throw null; } }
+
+        public static JsonConverter<object?> ObjectConverter { get { throw null; } }
+
+        public static JsonConverter<ReadOnlyMemory<byte>> ReadOnlyMemoryByteConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<sbyte> SByteConverter { get { throw null; } }
+
+        public static JsonConverter<float> SingleConverter { get { throw null; } }
+
+        public static JsonConverter<string?> StringConverter { get { throw null; } }
+
+        public static JsonConverter<TimeSpan> TimeSpanConverter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ushort> UInt16Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<uint> UInt32Converter { get { throw null; } }
+
+        [CLSCompliant(false)]
+        public static JsonConverter<ulong> UInt64Converter { get { throw null; } }
+
+        public static JsonConverter<Uri?> UriConverter { get { throw null; } }
+
+        public static JsonConverter<Version?> VersionConverter { get { throw null; } }
+
+        public static JsonTypeInfo<TElement[]> CreateArrayInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TElement[]> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentQueue<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateConcurrentStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Concurrent.ConcurrentStack<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Dictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIAsyncEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IAsyncEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateICollectionInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ICollection<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IDictionary { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.IList { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IList<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<Collections.Generic.KeyValuePair<TKey, TValue>>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Func<Collections.Generic.IEnumerable<TElement>, TCollection> createRangeFunc)
+            where TCollection : Collections.Generic.IEnumerable<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateIReadOnlyDictionaryInfo<TCollection, TKey, TValue>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.IReadOnlyDictionary<TKey, TValue> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateISetInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.ISet<TElement> { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateListInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.List<TElement> { throw null; }
+
+        public static JsonTypeInfo<Memory<TElement>> CreateMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<Memory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<T> CreateObjectInfo<T>(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) { throw null; }
+
+        public static JsonPropertyInfo CreatePropertyInfo<T>(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Queue<TElement> { throw null; }
+
+        public static JsonTypeInfo<ReadOnlyMemory<TElement>> CreateReadOnlyMemoryInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<ReadOnlyMemory<TElement>> collectionInfo) { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo, Action<TCollection, object?> addFunc)
+            where TCollection : Collections.IEnumerable { throw null; }
+
+        public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection, TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TCollection> collectionInfo)
+            where TCollection : Collections.Generic.Stack<TElement> { throw null; }
+
+        public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter) { throw null; }
+
+        public static JsonConverter<T> GetEnumConverter<T>(JsonSerializerOptions options)
+            where T : struct, Enum { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonSerializerOptions options)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T?> GetNullableConverter<T>(JsonTypeInfo<T> underlyingTypeInfo)
+            where T : struct { throw null; }
+
+        public static JsonConverter<T> GetUnsupportedTypeConverter<T>() { throw null; }
+    }
+
+    public sealed partial class JsonObjectInfoValues<T>
+    {
+        public Func<JsonParameterInfoValues[]>? ConstructorParameterMetadataInitializer { get { throw null; } init { } }
+
+        public JsonNumberHandling NumberHandling { get { throw null; } init { } }
+
+        public Func<T>? ObjectCreator { get { throw null; } init { } }
+
+        public Func<object[], T>? ObjectWithParameterizedConstructorCreator { get { throw null; } init { } }
+
+        public Func<JsonSerializerContext, JsonPropertyInfo[]>? PropertyMetadataInitializer { get { throw null; } init { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } init { } }
+    }
+
+    public sealed partial class JsonParameterInfoValues
+    {
+        public object? DefaultValue { get { throw null; } init { } }
+
+        public bool HasDefaultValue { get { throw null; } init { } }
+
+        public string Name { get { throw null; } init { } }
+
+        public Type ParameterType { get { throw null; } init { } }
+
+        public int Position { get { throw null; } init { } }
+    }
+
+    public partial class JsonPolymorphismOptions
+    {
+        public Collections.Generic.IList<JsonDerivedType> DerivedTypes { get { throw null; } }
+
+        public bool IgnoreUnrecognizedTypeDiscriminators { get { throw null; } set { } }
+
+        public string TypeDiscriminatorPropertyName { get { throw null; } set { } }
+
+        public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get { throw null; } set { } }
+    }
+
+    public abstract partial class JsonPropertyInfo
+    {
+        internal JsonPropertyInfo() { }
+
+        public System.Reflection.ICustomAttributeProvider? AttributeProvider { get { throw null; } set { } }
+
+        public JsonConverter? CustomConverter { get { throw null; } set { } }
+
+        public Func<object, object?>? Get { get { throw null; } set { } }
+
+        public bool IsExtensionData { get { throw null; } set { } }
+
+        public bool IsRequired { get { throw null; } set { } }
+
+        public string Name { get { throw null; } set { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? ObjectCreationHandling { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public int Order { get { throw null; } set { } }
+
+        public Type PropertyType { get { throw null; } }
+
+        public Action<object, object?>? Set { get { throw null; } set { } }
+
+        public Func<object, object?, bool>? ShouldSerialize { get { throw null; } set { } }
+    }
+
+    public sealed partial class JsonPropertyInfoValues<T>
+    {
+        public JsonConverter<T>? Converter { get { throw null; } init { } }
+
+        public Type DeclaringType { get { throw null; } init { } }
+
+        public Func<object, T?>? Getter { get { throw null; } init { } }
+
+        public bool HasJsonInclude { get { throw null; } init { } }
+
+        public JsonIgnoreCondition? IgnoreCondition { get { throw null; } init { } }
+
+        public bool IsExtensionData { get { throw null; } init { } }
+
+        public bool IsProperty { get { throw null; } init { } }
+
+        public bool IsPublic { get { throw null; } init { } }
+
+        public bool IsVirtual { get { throw null; } init { } }
+
+        public string? JsonPropertyName { get { throw null; } init { } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } init { } }
+
+        public string PropertyName { get { throw null; } init { } }
+
+        public JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
+
+        public Action<object, T?>? Setter { get { throw null; } init { } }
+    }
+
+    public abstract partial class JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public JsonConverter Converter { get { throw null; } }
+
+        public Func<object>? CreateObject { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public JsonTypeInfoKind Kind { get { throw null; } }
+
+        public JsonNumberHandling? NumberHandling { get { throw null; } set { } }
+
+        public Action<object>? OnDeserialized { get { throw null; } set { } }
+
+        public Action<object>? OnDeserializing { get { throw null; } set { } }
+
+        public Action<object>? OnSerialized { get { throw null; } set { } }
+
+        public Action<object>? OnSerializing { get { throw null; } set { } }
+
+        public JsonSerializerOptions Options { get { throw null; } }
+
+        public IJsonTypeInfoResolver? OriginatingResolver { get { throw null; } set { } }
+
+        public JsonPolymorphismOptions? PolymorphismOptions { get { throw null; } set { } }
+
+        public JsonObjectCreationHandling? PreferredPropertyObjectCreationHandling { get { throw null; } set { } }
+
+        public Collections.Generic.IList<JsonPropertyInfo> Properties { get { throw null; } }
+
+        public Type Type { get { throw null; } }
+
+        public JsonUnmappedMemberHandling? UnmappedMemberHandling { get { throw null; } set { } }
+
+        public JsonPropertyInfo CreateJsonPropertyInfo(Type propertyType, string name) { throw null; }
+
+        public static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) { throw null; }
+
+        public static JsonTypeInfo<T> CreateJsonTypeInfo<T>(JsonSerializerOptions options) { throw null; }
+
+        public void MakeReadOnly() { }
+    }
+
+    public enum JsonTypeInfoKind
+    {
+        None = 0,
+        Object = 1,
+        Enumerable = 2,
+        Dictionary = 3
+    }
+
+    public static partial class JsonTypeInfoResolver
+    {
+        public static IJsonTypeInfoResolver Combine(params IJsonTypeInfoResolver?[] resolvers) { throw null; }
+
+        public static IJsonTypeInfoResolver WithAddedModifier(this IJsonTypeInfoResolver resolver, Action<JsonTypeInfo> modifier) { throw null; }
+    }
+
+    public sealed partial class JsonTypeInfo<T> : JsonTypeInfo
+    {
+        internal JsonTypeInfo() { }
+
+        public new Func<T>? CreateObject { get { throw null; } set { } }
+
+        public Action<Utf8JsonWriter, T>? SerializeHandler { get { throw null; } }
+    }
+}

--- a/src/referencePackages/src/system.text.json/8.0.4/system.text.json.nuspec
+++ b/src/referencePackages/src/system.text.json/8.0.4/system.text.json.nuspec
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Text.Json</id>
+    <version>8.0.4</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides high-performance and low-allocating types that serialize objects to JavaScript Object Notation (JSON) text and deserialize JSON text to objects, with UTF-8 support built-in. Also provides types to read and write JSON text encoded as UTF-8, and to create an in-memory document object model (DOM), that is read-only, for random access of the JSON elements within a structured view of the data.
+
+The System.Text.Json library is built-in as part of the shared framework in .NET Runtime. The package can be installed when you need to use it in other target frameworks.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="2aade6beb02ea367fd97c4070a4198802fe61c03" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Text.Encodings.Web" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Text.Encodings.Web" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Text.Encodings.Web" version="8.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Encodings.Web" version="8.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Buffers" version="4.5.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Adding back the following packages:

referencePackages/src/system.formats.asn1/8.0.0
referencePackages/src/system.security.cryptography.pkcs/8.0.0
referencePackages/src/system.security.cryptography.xml/8.0.0
referencePackages/src/system.text.json/8.0.4

These packages were removed in https://github.com/dotnet/source-build-reference-packages/pull/1108 but https://github.com/dotnet/source-build-reference-packages/pull/1110 and https://github.com/dotnet/source-build-reference-packages/pull/1109 which were merged after added dependencies on them.  It was not caught in validation because the packages existed in the n-1 self-reference.  This would be solved by https://github.com/dotnet/source-build/issues/1690.