### PR TITLE
[release/9.0] Exclude reference packages from CG

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,9 @@ a new targeting pack is needed, please [open a new issue](#filing-issues) to dis
 
 ## Vulnerable Packages
 
-CVEs may exist for reference packages included in this repo. If they are mitigated by a newer version, the
-newer version should be added, the vulnerable version should be removed, and references to the vulnerable
-package within other reference packages should be upgraded. A comment should be added to indicate when
-packages were manually upgraded.
-
-``` xml
-    <!-- Manually updated version from 4.3.0 to address CVE-2017-0247 -->
-    <PackageReference Include="System.Net.Security" Version="4.3.1" />
-```
+CVEs may exist for reference packages included in this repo. Because the packages do not contain any
+implementation, they do not pose a security risk. CG is configured in this repo to ignore the reference
+packages. If product repos migrate off these vulnerable packages, they can be [removed](#cleanup).
 
 ## Filing Issues
 

--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -25,6 +25,15 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     sdl:
+      componentgovernance:
+        verbosity: Verbose
+        # All of the SBRPs must be ignored because it is possible some of them are for vulnerable versions.
+        # Because they are reference only packages they are not vulnerable themselves.
+        ignoreDirectories: |
+          artifacts/sb,
+          src/referencePackages
+      policheck:
+        enabled: true
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022

--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -26,7 +26,6 @@ extends:
   parameters:
     sdl:
       componentgovernance:
-        verbosity: Verbose
         # All of the SBRPs must be ignored because it is possible some of them are for vulnerable versions.
         # Because they are reference only packages they are not vulnerable themselves.
         ignoreDirectories: |


### PR DESCRIPTION
Backport of https://github.com/dotnet/source-build-reference-packages/pull/1134 from main.