### PR TITLE
[release/8.0] Fix wrong componentGovernance ignoreDirectories

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -29,7 +29,7 @@ extends:
         # All of the SBRPs must be ignored because it is possible some of them are for vulnerable versions.
         # Because they are reference only packages they are not vulnerable themselves.
         ignoreDirectories: |
-          artifacts/sb,
+          artifacts/source-build/self,
           src/referencePackages
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
This was an issue with https://github.com/dotnet/source-build-reference-packages/pull/1136.  The UB project changed the path so the straight backport was incorrect.