### PR TITLE
Enable Nuget Audit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,9 @@
     <CustomizationsPrefix>Customizations</CustomizationsPrefix>
     <CustomizationsPropsFile>$(CustomizationsPrefix).props</CustomizationsPropsFile>
     <CustomizationsSourceFile>$(CustomizationsPrefix).cs</CustomizationsSourceFile>
+
+    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
+    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -24,4 +24,8 @@
     <add key="darc-pub-DotNet-msbuild-Trusted" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-a400405b/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>

--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageSourceGeneratorTaskAssembly>$(ArtifactsBinDir)PackageSourceGeneratorTask\$(Configuration)\$(NetCurrent)\PackageSourceGeneratorTask.dll</PackageSourceGeneratorTaskAssembly>
     <!-- The packages output directory. -->
     <PackagesTargetDirectory Condition="'$(PackageType)' != 'text'">$(RepoRoot)src\referencePackages\src\</PackagesTargetDirectory>

--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -33,6 +33,7 @@
     <SourceControlInformationFeatureSupported>false</SourceControlInformationFeatureSupported>
     <Configuration>Release</Configuration>
     <EnableSourceLink>false</EnableSourceLink>
+    <NuGetAudit>false</NuGetAudit>
 
     <NoStdLib>true</NoStdLib>
     <NoConfig>true</NoConfig>

--- a/src/targetPacks/Directory.Build.props
+++ b/src/targetPacks/Directory.Build.props
@@ -10,6 +10,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <NuGetAudit>false</NuGetAudit>
 
     <RestoreIlTooling>true</RestoreIlTooling>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/4673.

Enabled the NuGet Audit functionality for the SBRP repo but disabled it for the reference and targeting packages given they contain no implementation.  It is enabled for the generate tooling as well as the text only packages.