### PR TITLE
Add version 4.8.1 of System.Reflection.DispatchProxy and 6.1.1 of System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -23,7 +23,7 @@
     <!-- Required for MSBuild 17.3.4 -->
     <add key="darc-pub-DotNet-msbuild-Trusted" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-a400405b/nuget/v3/index.json" />
     <!-- Required for System.Runtime.CompilerServices.Unsafe 6.1.1 -->
-    <add key="darc-pub-dotnet-maintenance-packages-f9ed1720" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-f9ed1720/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-maintenance-packages-3b65679f" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-3b65679f/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
   <auditSources>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
+     <add key="darc-pub-dotnet-maintenance-packages-f9ed1720" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-f9ed1720/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,6 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
-     <add key="darc-pub-dotnet-maintenance-packages-f9ed1720" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-f9ed1720/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -23,6 +22,8 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <!-- Required for MSBuild 17.3.4 -->
     <add key="darc-pub-DotNet-msbuild-Trusted" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-a400405b/nuget/v3/index.json" />
+    <!-- Required for System.Runtime.CompilerServices.Unsafe 6.1.1 -->
+    <add key="darc-pub-dotnet-maintenance-packages-f9ed1720" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-f9ed1720/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
   <auditSources>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -43,6 +43,7 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.6.0.11.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.DependencyModel.6.0.2.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.1.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Reflection.DispatchProxy.4.8.1.csproj" />
 
   </ItemGroup>
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -42,6 +42,7 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Encodings.Web.6.0.1.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Text.Json.6.0.11.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.DependencyModel.6.0.2.csproj" />
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Runtime.CompilerServices.Unsafe.6.1.1.csproj" />
 
   </ItemGroup>
 

--- a/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/System.Reflection.DispatchProxy.4.8.1.csproj
+++ b/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/System.Reflection.DispatchProxy.4.8.1.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <AssemblyName>System.Reflection.DispatchProxy</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/lib/netstandard2.0/System.Reflection.DispatchProxy.cs
+++ b/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/lib/netstandard2.0/System.Reflection.DispatchProxy.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Reflection.DispatchProxy")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Reflection.DispatchProxy")]
+[assembly: System.Reflection.AssemblyFileVersion("4.800.125.11301")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.8.1+3b65679f5812b0a1f7f173730bd7f628e1197425")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Reflection.DispatchProxy")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.6.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Reflection
+{
+    public abstract partial class DispatchProxy
+    {
+        public static T Create<T, TProxy>()
+            where TProxy : DispatchProxy { throw null; }
+
+        protected abstract object Invoke(MethodInfo targetMethod, object[] args);
+    }
+}

--- a/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/lib/netstandard2.1/System.Reflection.DispatchProxy.cs
+++ b/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/lib/netstandard2.1/System.Reflection.DispatchProxy.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName = ".NET Standard 2.1")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Reflection.DispatchProxy")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("System.Reflection.DispatchProxy")]
+[assembly: System.Reflection.AssemblyFileVersion("4.800.125.11301")]
+[assembly: System.Reflection.AssemblyInformationalVersion("4.8.1+3b65679f5812b0a1f7f173730bd7f628e1197425")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Reflection.DispatchProxy")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/maintenance-packages")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyVersionAttribute("4.0.6.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Reflection.DispatchProxy))]

--- a/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/system.reflection.dispatchproxy.nuspec
+++ b/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/system.reflection.dispatchproxy.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Reflection.DispatchProxy</id>
+    <version>4.8.1</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>System.Reflection.DispatchProxy</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="3b65679f5812b0a1f7f173730bd7f628e1197425" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Reflection.Emit" version="4.7.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/System.Runtime.CompilerServices.Unsafe.6.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/System.Runtime.CompilerServices.Unsafe.6.1.1.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/lib/net6.0/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/lib/net6.0/System.Runtime.CompilerServices.Unsafe.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.CLSCompliant(false)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.Default | System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyDescription("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyFileVersion("6.100.125.10404")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.1.1")]
+[assembly: System.Reflection.AssemblyTitle("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Runtime.CompilerServices
+{
+    public static partial class Unsafe
+    {
+        public static ref T Add<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Add<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static bool AreSame<T>(ref T left, ref T right) { throw null; }
+
+        public static T As<T>(object o)
+            where T : class { throw null; }
+
+        public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
+
+        public static unsafe void* AsPointer<T>(ref T value) { throw null; }
+
+        public static ref T AsRef<T>(in T source) { throw null; }
+
+        public static unsafe ref T AsRef<T>(void* source) { throw null; }
+
+        public static IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
+
+        public static unsafe void Copy<T>(ref T destination, void* source) { }
+
+        public static unsafe void Copy<T>(void* destination, ref T source) { }
+
+        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlock(void* destination, void* source, uint byteCount) { }
+
+        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
+
+        public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlock(void* startAddress, byte value, uint byteCount) { }
+
+        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
+
+        public static bool IsAddressGreaterThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsAddressLessThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsNullRef<T>(ref T source) { throw null; }
+
+        public static ref T NullRef<T>() { throw null; }
+
+        public static unsafe T Read<T>(void* source) { throw null; }
+
+        public static T ReadUnaligned<T>(ref byte source) { throw null; }
+
+        public static unsafe T ReadUnaligned<T>(void* source) { throw null; }
+
+        public static int SizeOf<T>() { throw null; }
+
+        public static void SkipInit<T>(out T value) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Subtract<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static ref T Unbox<T>(object box)
+            where T : struct { throw null; }
+
+        public static unsafe void Write<T>(void* destination, T value) { }
+
+        public static void WriteUnaligned<T>(ref byte destination, T value) { }
+
+        public static unsafe void WriteUnaligned<T>(void* destination, T value) { }
+    }
+}

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/lib/netstandard2.0/System.Runtime.CompilerServices.Unsafe.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET Framework")]
+[assembly: System.CLSCompliant(false)]
+[assembly: System.Reflection.AssemblyMetadata(".NETFrameworkAssembly", "")]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.Default | System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Reflection.AssemblyDescription("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyFileVersion("6.100.125.10404")]
+[assembly: System.Reflection.AssemblyInformationalVersion("6.1.1")]
+[assembly: System.Reflection.AssemblyTitle("System.Runtime.CompilerServices.Unsafe")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation.  All rights reserved.")]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyVersionAttribute("6.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Runtime.CompilerServices
+{
+    public static partial class Unsafe
+    {
+        public static ref T Add<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Add<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Add<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T AddByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static bool AreSame<T>(ref T left, ref T right) { throw null; }
+
+        public static T As<T>(object o)
+            where T : class { throw null; }
+
+        public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
+
+        public static unsafe void* AsPointer<T>(ref T value) { throw null; }
+
+        public static ref T AsRef<T>(in T source) { throw null; }
+
+        public static unsafe ref T AsRef<T>(void* source) { throw null; }
+
+        public static IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
+
+        public static unsafe void Copy<T>(ref T destination, void* source) { }
+
+        public static unsafe void Copy<T>(void* destination, ref T source) { }
+
+        public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlock(void* destination, void* source, uint byteCount) { }
+
+        public static void CopyBlockUnaligned(ref byte destination, ref byte source, uint byteCount) { }
+
+        public static unsafe void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
+
+        public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlock(void* startAddress, byte value, uint byteCount) { }
+
+        public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
+
+        public static unsafe void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
+
+        public static bool IsAddressGreaterThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsAddressLessThan<T>(ref T left, ref T right) { throw null; }
+
+        public static bool IsNullRef<T>(ref T source) { throw null; }
+
+        public static ref T NullRef<T>() { throw null; }
+
+        public static unsafe T Read<T>(void* source) { throw null; }
+
+        public static T ReadUnaligned<T>(ref byte source) { throw null; }
+
+        public static unsafe T ReadUnaligned<T>(void* source) { throw null; }
+
+        public static int SizeOf<T>() { throw null; }
+
+        public static void SkipInit<T>(out T value) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, int elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, IntPtr elementOffset) { throw null; }
+
+        public static ref T Subtract<T>(ref T source, nuint elementOffset) { throw null; }
+
+        public static unsafe void* Subtract<T>(void* source, int elementOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, IntPtr byteOffset) { throw null; }
+
+        public static ref T SubtractByteOffset<T>(ref T source, nuint byteOffset) { throw null; }
+
+        public static ref T Unbox<T>(object box)
+            where T : struct { throw null; }
+
+        public static unsafe void Write<T>(void* destination, T value) { }
+
+        public static void WriteUnaligned<T>(ref byte destination, T value) { }
+
+        public static unsafe void WriteUnaligned<T>(void* destination, T value) { }
+    }
+}

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/system.runtime.compilerservices.unsafe.nuspec
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/system.runtime.compilerservices.unsafe.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>System.Runtime.CompilerServices.Unsafe</id>
+    <version>6.1.1</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/dotnet/maintenance-packages</projectUrl>
+    <description>Provides the System.Runtime.CompilerServices.Unsafe class, which provides generic, low-level functionality for manipulating pointers.</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/maintenance-packages" commit="f9ed1720eb9cb6be22116e0e05b010bc612687b1" />
+    <dependencies>
+      <group targetFramework="net6.0" />
+      <group targetFramework="net7.0" />
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
This PR is result of testing the parallel dependency updates to ensure source-build does not break: https://github.com/dotnet/dotnet/pull/133

System.ValueTuple did not generate anything when running generate.sh against it:
```
./generate.sh --package System.ValueTuple,4.6.0
Restore complete (0.5s)
  PackageSourceGeneratorTask succeeded (3.1s) → artifacts/bin/PackageSourceGeneratorTask/Debug/net10.0/PackageSourceGeneratorTask.dll
  PackageSourceGenerator succeeded (0.2s) → Package source generation skipped for System.ValueTuple (v4.6.0) as it doesn't contain any compile items.

Build succeeded in 4.7s
```

**IMPORTANT**: I need to merge this PR at the same time as all the other PRs in the other repos, to prevent breaking the dependency ingestion in the dotnet/sdk repo.

@MichaelSimons Please remind me if we need to include the feed or not.