### PR TITLE
NoWarn NuGet package pruning warnings

### DIFF
--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -107,6 +107,10 @@
     <NoWarn>$(NoWarn);RS1025</NoWarn>
     <!-- Don't warn on RS1026 - Enable concurrent execution -->
     <NoWarn>$(NoWarn);RS1026</NoWarn>
+
+    <!-- Disable package and project pruning warnings. All dependencies in this repository mirror the
+         original package's dependencies and shouldn't get changed here. -->
+    <NoWarn>$(NoWarn);NU1510;NU1511</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46642

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

NoWarn the new warnings as SBRP packages should be a mirror of the source-shipping packages and not change dependencies.