### PR TITLE
Exclude netstandard1.x TFMs from PackageSourceGenerator.proj

### DIFF
--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -12,7 +12,7 @@
     <ExcludeTargetFrameworks>monoandroid*;monotouch*;net20;net35;net4*;netcore50;netcoreapp2.*;portable*;uap*;win8;win81;wp8;wpa81;xamarin*</ExcludeTargetFrameworks>
     <!-- The following target frameworks should be excluded even though they are supported by the current SDK because there is no need to have them.
          Only exclude them when target frameworks to include aren't provided. -->
-    <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1</ExcludeTargetFrameworks>
+    <ExcludeTargetFrameworks Condition="'$(IncludeTargetFrameworks)' == ''">$(ExcludeTargetFrameworks);netcoreapp3.1;netstandard1*</ExcludeTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageName)' != '' and '$(PackageVersion)' != ''">

--- a/tests/SbrpTests/GenerateScriptTests.cs
+++ b/tests/SbrpTests/GenerateScriptTests.cs
@@ -24,7 +24,7 @@ public class GenerateScriptTests
         new object[] { "System.Text.Json", "8.0.5", PackageType.Reference },
         new object[] { "Microsoft.Extensions.Logging.Abstractions", "6.0.4", PackageType.Reference },
         new object[] { "Microsoft.CodeAnalysis.CSharp", "3.11.0", PackageType.Reference },
-        new object[] { "System.Security.Cryptography.ProtectedData", "9.0.2", PackageType.Reference },
+        new object[] { "System.Security.Cryptography.ProtectedData", "8.0.0", PackageType.Reference },
         new object[] { "Microsoft.Build.NoTargets", "3.7.0", PackageType.Text },
     };
     

--- a/tests/SbrpTests/GenerateScriptTests.cs
+++ b/tests/SbrpTests/GenerateScriptTests.cs
@@ -21,10 +21,10 @@ public class GenerateScriptTests
 
     public static IEnumerable<object[]> Data => new List<object[]>
     {
-        new object[] { "System.Xml.ReaderWriter", "4.3.0", PackageType.Reference },
+        new object[] { "System.Text.Json", "8.0.5", PackageType.Reference },
         new object[] { "Microsoft.Extensions.Logging.Abstractions", "6.0.4", PackageType.Reference },
         new object[] { "Microsoft.CodeAnalysis.CSharp", "3.11.0", PackageType.Reference },
-        new object[] { "System.Security.Cryptography.Encoding", "4.3.0", PackageType.Reference },
+        new object[] { "System.Security.Cryptography.ProtectedData", "9.0.2", PackageType.Reference },
         new object[] { "Microsoft.Build.NoTargets", "3.7.0", PackageType.Text },
     };
     

--- a/tests/SbrpTests/GenerateScriptTests.cs
+++ b/tests/SbrpTests/GenerateScriptTests.cs
@@ -21,7 +21,6 @@ public class GenerateScriptTests
 
     public static IEnumerable<object[]> Data => new List<object[]>
     {
-        new object[] { "System.Text.Json", "8.0.5", PackageType.Reference },
         new object[] { "Microsoft.Extensions.Logging.Abstractions", "6.0.4", PackageType.Reference },
         new object[] { "Microsoft.CodeAnalysis.CSharp", "3.11.0", PackageType.Reference },
         new object[] { "System.Security.Cryptography.ProtectedData", "8.0.0", PackageType.Reference },


### PR DESCRIPTION
Finally, https://github.com/dotnet/source-build/issues/4482 is very close to be done (just the packages are left to be removed from SBRP).

Therefore, we should filter out netstandard1.x TFMs when generating new packages with the PackageSourceGenerator tooling.