### PR TITLE
Add PackageVersion property to projects

### DIFF
--- a/src/packageSourceGenerator/PackageProjectTemplate.xml
+++ b/src/packageSourceGenerator/PackageProjectTemplate.xml
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$$TargetFrameworks$$</TargetFrameworks>
+    <PackageVersion>$$PackageVersion$$</PackageVersion>
     <AssemblyName>$$AssemblyName$$</AssemblyName>$$KeyFileTag$$
   </PropertyGroup>
 

--- a/src/packageSourceGenerator/PackageSourceGenerator.proj
+++ b/src/packageSourceGenerator/PackageSourceGenerator.proj
@@ -342,6 +342,7 @@
     </PropertyGroup>
 
     <GenerateProject PackageId="$(RealPackageId)"
+                     PackageVersion="$(PackageVersion)"
                      ProjectTemplate="$(PackageProjectTemplate)"
                      TargetPath="$(PackageProjectTargetPath)"
                      CompileItems="@(PackageCompileItem)"

--- a/src/packageSourceGenerator/PackageSourceGeneratorTask/GenerateProject.cs
+++ b/src/packageSourceGenerator/PackageSourceGeneratorTask/GenerateProject.cs
@@ -18,6 +18,12 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
         public string? PackageId { get; set; }
 
         /// <summary>
+        /// The package version.
+        /// </summary>
+        [Required]
+        public required string PackageVersion { get; set; }
+
+        /// <summary>
         /// The path to the project template that is being transformed.
         /// </summary>
         [Required]
@@ -66,6 +72,8 @@ namespace Microsoft.DotNet.SourceBuild.Tasks
             // If no target framework is supplied, fallback to netstandard2.0.
             projectContent = projectContent.Replace("$$TargetFrameworks$$", 
                 targetFrameworks.Length > 0 ? string.Join(';', targetFrameworks) : "netstandard2.0");
+
+            projectContent = projectContent.Replace("$$PackageVersion$$", PackageVersion);
 
             foreach (string targetFramework in targetFrameworks)
             {

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/6.0.0/Microsoft.Bcl.AsyncInterfaces.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/6.0.0/Microsoft.Bcl.AsyncInterfaces.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Bcl.AsyncInterfaces</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/7.0.0/Microsoft.Bcl.AsyncInterfaces.7.0.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/7.0.0/Microsoft.Bcl.AsyncInterfaces.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>Microsoft.Bcl.AsyncInterfaces</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.bcl.asyncinterfaces/8.0.0/Microsoft.Bcl.AsyncInterfaces.8.0.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.asyncinterfaces/8.0.0/Microsoft.Bcl.AsyncInterfaces.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>Microsoft.Bcl.AsyncInterfaces</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0/Microsoft.Bcl.HashCode.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.bcl.hashcode/6.0.0/Microsoft.Bcl.HashCode.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Bcl.HashCode</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.build.framework/17.12.6/Microsoft.Build.Framework.17.12.6.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/17.12.6/Microsoft.Build.Framework.17.12.6.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.12.6</PackageVersion>
     <AssemblyName>Microsoft.Build.Framework</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.framework/17.3.4/Microsoft.Build.Framework.17.3.4.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/17.3.4/Microsoft.Build.Framework.17.3.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.3.4</PackageVersion>
     <AssemblyName>Microsoft.Build.Framework</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.framework/17.4.0/Microsoft.Build.Framework.17.4.0.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/17.4.0/Microsoft.Build.Framework.17.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.4.0</PackageVersion>
     <AssemblyName>Microsoft.Build.Framework</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.framework/17.8.3/Microsoft.Build.Framework.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build.framework/17.8.3/Microsoft.Build.Framework.17.8.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.8.3</PackageVersion>
     <AssemblyName>Microsoft.Build.Framework</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.12.6/Microsoft.Build.Tasks.Core.17.12.6.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.12.6/Microsoft.Build.Tasks.Core.17.12.6.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.12.6</PackageVersion>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.3.4/Microsoft.Build.Tasks.Core.17.3.4.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.3.4/Microsoft.Build.Tasks.Core.17.3.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.3.4</PackageVersion>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.4.0/Microsoft.Build.Tasks.Core.17.4.0.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.4.0/Microsoft.Build.Tasks.Core.17.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.4.0</PackageVersion>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Microsoft.Build.Tasks.Core.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Microsoft.Build.Tasks.Core.17.8.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.8.3</PackageVersion>
     <AssemblyName>Microsoft.Build.Tasks.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.12.6/Microsoft.Build.Utilities.Core.17.12.6.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.12.6/Microsoft.Build.Utilities.Core.17.12.6.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.12.6</PackageVersion>
     <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.3.4/Microsoft.Build.Utilities.Core.17.3.4.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.3.4/Microsoft.Build.Utilities.Core.17.3.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.3.4</PackageVersion>
     <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.4.0/Microsoft.Build.Utilities.Core.17.4.0.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.4.0/Microsoft.Build.Utilities.Core.17.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.4.0</PackageVersion>
     <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Microsoft.Build.Utilities.Core.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Microsoft.Build.Utilities.Core.17.8.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.8.3</PackageVersion>
     <AssemblyName>Microsoft.Build.Utilities.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build/17.12.6/Microsoft.Build.17.12.6.csproj
+++ b/src/referencePackages/src/microsoft.build/17.12.6/Microsoft.Build.17.12.6.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
+    <PackageVersion>17.12.6</PackageVersion>
     <AssemblyName>Microsoft.Build</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build/17.3.4/Microsoft.Build.17.3.4.csproj
+++ b/src/referencePackages/src/microsoft.build/17.3.4/Microsoft.Build.17.3.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <PackageVersion>17.3.4</PackageVersion>
     <AssemblyName>Microsoft.Build</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.build/17.8.3/Microsoft.Build.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build/17.8.3/Microsoft.Build.17.8.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <PackageVersion>17.8.3</PackageVersion>
     <AssemblyName>Microsoft.Build</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.1.0</PackageVersion>
     <AssemblyName>Microsoft.CodeAnalysis</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.csharp/4.7.0/Microsoft.CSharp.4.7.0.csproj
+++ b/src/referencePackages/src/microsoft.csharp/4.7.0/Microsoft.CSharp.4.7.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.7.0</PackageVersion>
     <AssemblyName>Microsoft.CSharp</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.extensions.dependencymodel/6.0.0/Microsoft.Extensions.DependencyModel.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.dependencymodel/6.0.0/Microsoft.Extensions.DependencyModel.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Extensions.DependencyModel</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.extensions.fileproviders.abstractions/6.0.0/Microsoft.Extensions.FileProviders.Abstractions.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.fileproviders.abstractions/6.0.0/Microsoft.Extensions.FileProviders.Abstractions.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Extensions.FileProviders.Abstractions</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.extensions.filesystemglobbing/6.0.0/Microsoft.Extensions.FileSystemGlobbing.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.filesystemglobbing/6.0.0/Microsoft.Extensions.FileSystemGlobbing.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Extensions.FileSystemGlobbing</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.4/Microsoft.Extensions.Logging.Abstractions.6.0.4.csproj
+++ b/src/referencePackages/src/microsoft.extensions.logging.abstractions/6.0.4/Microsoft.Extensions.Logging.Abstractions.6.0.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.4</PackageVersion>
     <AssemblyName>Microsoft.Extensions.Logging.Abstractions</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.extensions.primitives/6.0.0/Microsoft.Extensions.Primitives.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.extensions.primitives/6.0.0/Microsoft.Extensions.Primitives.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Extensions.Primitives</AssemblyName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.net.stringtools/17.12.6/Microsoft.NET.StringTools.17.12.6.csproj
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.12.6/Microsoft.NET.StringTools.17.12.6.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.12.6</PackageVersion>
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.net.stringtools/17.3.4/Microsoft.NET.StringTools.17.3.4.csproj
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.3.4/Microsoft.NET.StringTools.17.3.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.3.4</PackageVersion>
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.net.stringtools/17.4.0/Microsoft.NET.StringTools.17.4.0.csproj
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.4.0/Microsoft.NET.StringTools.17.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.4.0</PackageVersion>
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.net.stringtools/17.8.3/Microsoft.NET.StringTools.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.net.stringtools/17.8.3/Microsoft.NET.StringTools.17.8.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>17.8.3</PackageVersion>
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.visualbasic/10.3.0/Microsoft.VisualBasic.10.3.0.csproj
+++ b/src/referencePackages/src/microsoft.visualbasic/10.3.0/Microsoft.VisualBasic.10.3.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>10.3.0</PackageVersion>
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.win32.registry/5.0.0/Microsoft.Win32.Registry.5.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.registry/5.0.0/Microsoft.Win32.Registry.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/microsoft.win32.systemevents/6.0.0/Microsoft.Win32.SystemEvents.6.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.systemevents/6.0.0/Microsoft.Win32.SystemEvents.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>Microsoft.Win32.SystemEvents</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/microsoft.win32.systemevents/7.0.0/Microsoft.Win32.SystemEvents.7.0.0.csproj
+++ b/src/referencePackages/src/microsoft.win32.systemevents/7.0.0/Microsoft.Win32.SystemEvents.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>Microsoft.Win32.SystemEvents</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.commands/6.11.0/NuGet.Commands.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.commands/6.11.0/NuGet.Commands.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Commands</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.common/6.11.0/NuGet.Common.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.common/6.11.0/NuGet.Common.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Common</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.common/6.12.1/NuGet.Common.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.common/6.12.1/NuGet.Common.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Common</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.common/6.8.1/NuGet.Common.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.common/6.8.1/NuGet.Common.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Common</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.configuration/6.11.0/NuGet.Configuration.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.configuration/6.11.0/NuGet.Configuration.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Configuration</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.configuration/6.12.1/NuGet.Configuration.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.configuration/6.12.1/NuGet.Configuration.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Configuration</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.configuration/6.8.1/NuGet.Configuration.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.configuration/6.8.1/NuGet.Configuration.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Configuration</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.credentials/6.11.0/NuGet.Credentials.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.credentials/6.11.0/NuGet.Credentials.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Credentials</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.credentials/6.8.1/NuGet.Credentials.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.credentials/6.8.1/NuGet.Credentials.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Credentials</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.11.0/NuGet.DependencyResolver.Core.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.11.0/NuGet.DependencyResolver.Core.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.DependencyResolver.Core</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.dependencyresolver.core/6.12.1/NuGet.DependencyResolver.Core.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.dependencyresolver.core/6.12.1/NuGet.DependencyResolver.Core.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.DependencyResolver.Core</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.frameworks/6.11.0/NuGet.Frameworks.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.frameworks/6.11.0/NuGet.Frameworks.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Frameworks</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.frameworks/6.12.1/NuGet.Frameworks.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.frameworks/6.12.1/NuGet.Frameworks.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Frameworks</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.frameworks/6.8.1/NuGet.Frameworks.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.frameworks/6.8.1/NuGet.Frameworks.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Frameworks</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.librarymodel/6.11.0/NuGet.LibraryModel.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/6.11.0/NuGet.LibraryModel.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.LibraryModel</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.librarymodel/6.12.1/NuGet.LibraryModel.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.librarymodel/6.12.1/NuGet.LibraryModel.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.LibraryModel</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.packaging/6.11.0/NuGet.Packaging.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.11.0/NuGet.Packaging.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Packaging</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.packaging/6.12.1/NuGet.Packaging.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.12.1/NuGet.Packaging.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Packaging</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.packaging/6.8.1/NuGet.Packaging.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.packaging/6.8.1/NuGet.Packaging.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Packaging</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.projectmodel/6.11.0/NuGet.ProjectModel.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/6.11.0/NuGet.ProjectModel.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.ProjectModel</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.projectmodel/6.12.1/NuGet.ProjectModel.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.projectmodel/6.12.1/NuGet.ProjectModel.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.ProjectModel</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.protocol/6.11.0/NuGet.Protocol.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.protocol/6.11.0/NuGet.Protocol.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Protocol</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.protocol/6.12.1/NuGet.Protocol.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.protocol/6.12.1/NuGet.Protocol.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Protocol</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.protocol/6.8.1/NuGet.Protocol.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.protocol/6.8.1/NuGet.Protocol.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Protocol</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/6.11.0/NuGet.Versioning.6.11.0.csproj
+++ b/src/referencePackages/src/nuget.versioning/6.11.0/NuGet.Versioning.6.11.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.11.0</PackageVersion>
     <AssemblyName>NuGet.Versioning</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/6.12.1/NuGet.Versioning.6.12.1.csproj
+++ b/src/referencePackages/src/nuget.versioning/6.12.1/NuGet.Versioning.6.12.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.12.1</PackageVersion>
     <AssemblyName>NuGet.Versioning</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/nuget.versioning/6.8.1/NuGet.Versioning.6.8.1.csproj
+++ b/src/referencePackages/src/nuget.versioning/6.8.1/NuGet.Versioning.6.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.8.1</PackageVersion>
     <AssemblyName>NuGet.Versioning</AssemblyName>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
+++ b/src/referencePackages/src/system.buffers/4.5.1/System.Buffers.4.5.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.1</PackageVersion>
     <AssemblyName>System.Buffers</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.buffers/4.6.0/System.Buffers.4.6.0.csproj
+++ b/src/referencePackages/src/system.buffers/4.6.0/System.Buffers.4.6.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.6.0</PackageVersion>
     <AssemblyName>System.Buffers</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.codedom/6.0.0/System.CodeDom.6.0.0.csproj
+++ b/src/referencePackages/src/system.codedom/6.0.0/System.CodeDom.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.CodeDom</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.codedom/7.0.0/System.CodeDom.7.0.0.csproj
+++ b/src/referencePackages/src/system.codedom/7.0.0/System.CodeDom.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.CodeDom</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.codedom/8.0.0/System.CodeDom.8.0.0.csproj
+++ b/src/referencePackages/src/system.codedom/8.0.0/System.CodeDom.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.CodeDom</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/5.0.0/System.Collections.Immutable.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Collections.Immutable</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.collections.immutable/6.0.0/System.Collections.Immutable.6.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/6.0.0/System.Collections.Immutable.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Collections.Immutable</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.collections.immutable/7.0.0/System.Collections.Immutable.7.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/7.0.0/System.Collections.Immutable.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Collections.Immutable</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.8.0.0.csproj
+++ b/src/referencePackages/src/system.collections.immutable/8.0.0/System.Collections.Immutable.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Collections.Immutable</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.componentmodel.annotations/5.0.0/System.ComponentModel.Annotations.5.0.0.csproj
+++ b/src/referencePackages/src/system.componentmodel.annotations/5.0.0/System.ComponentModel.Annotations.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.ComponentModel.Annotations</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.configuration.configurationmanager/6.0.0/System.Configuration.ConfigurationManager.6.0.0.csproj
+++ b/src/referencePackages/src/system.configuration.configurationmanager/6.0.0/System.Configuration.ConfigurationManager.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Configuration.ConfigurationManager</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.configuration.configurationmanager/7.0.0/System.Configuration.ConfigurationManager.7.0.0.csproj
+++ b/src/referencePackages/src/system.configuration.configurationmanager/7.0.0/System.Configuration.ConfigurationManager.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Configuration.ConfigurationManager</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/System.Configuration.ConfigurationManager.8.0.0.csproj
+++ b/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/System.Configuration.ConfigurationManager.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Configuration.ConfigurationManager</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.diagnosticsource/8.0.0/System.Diagnostics.DiagnosticSource.8.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.diagnosticsource/8.0.0/System.Diagnostics.DiagnosticSource.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Diagnostics.DiagnosticSource</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.eventlog/7.0.0/System.Diagnostics.EventLog.7.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.eventlog/7.0.0/System.Diagnostics.EventLog.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Diagnostics.EventLog</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.diagnostics.eventlog/8.0.0/System.Diagnostics.EventLog.8.0.0.csproj
+++ b/src/referencePackages/src/system.diagnostics.eventlog/8.0.0/System.Diagnostics.EventLog.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Diagnostics.EventLog</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.drawing.common/6.0.0/System.Drawing.Common.6.0.0.csproj
+++ b/src/referencePackages/src/system.drawing.common/6.0.0/System.Drawing.Common.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Drawing.Common</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.drawing.common/7.0.0/System.Drawing.Common.7.0.0.csproj
+++ b/src/referencePackages/src/system.drawing.common/7.0.0/System.Drawing.Common.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Drawing.Common</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.formats.asn1/5.0.0/System.Formats.Asn1.5.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/5.0.0/System.Formats.Asn1.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Formats.Asn1</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.formats.asn1/6.0.0/System.Formats.Asn1.6.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/6.0.0/System.Formats.Asn1.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Formats.Asn1</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.formats.asn1/7.0.0/System.Formats.Asn1.7.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/7.0.0/System.Formats.Asn1.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Formats.Asn1</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.formats.asn1/8.0.0/System.Formats.Asn1.8.0.0.csproj
+++ b/src/referencePackages/src/system.formats.asn1/8.0.0/System.Formats.Asn1.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Formats.Asn1</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.formats.asn1/8.0.1/System.Formats.Asn1.8.0.1.csproj
+++ b/src/referencePackages/src/system.formats.asn1/8.0.1/System.Formats.Asn1.8.0.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.1</PackageVersion>
     <AssemblyName>System.Formats.Asn1</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.io.filesystem.accesscontrol/5.0.0/System.IO.FileSystem.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.io.filesystem.accesscontrol/5.0.0/System.IO.FileSystem.AccessControl.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.IO.FileSystem.AccessControl</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
+++ b/src/referencePackages/src/system.memory/4.5.4/System.Memory.4.5.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.4</PackageVersion>
     <AssemblyName>System.Memory</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.5.5/System.Memory.4.5.5.csproj
+++ b/src/referencePackages/src/system.memory/4.5.5/System.Memory.4.5.5.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.5</PackageVersion>
     <AssemblyName>System.Memory</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.memory/4.6.0/System.Memory.4.6.0.csproj
+++ b/src/referencePackages/src/system.memory/4.6.0/System.Memory.4.6.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.6.0</PackageVersion>
     <AssemblyName>System.Memory</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.4.0/System.Numerics.Vectors.4.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.4.0</PackageVersion>
     <AssemblyName>System.Numerics.Vectors</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.5.0/System.Numerics.Vectors.4.5.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.0</PackageVersion>
     <AssemblyName>System.Numerics.Vectors</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.numerics.vectors/4.6.0/System.Numerics.Vectors.4.6.0.csproj
+++ b/src/referencePackages/src/system.numerics.vectors/4.6.0/System.Numerics.Vectors.4.6.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.6.0</PackageVersion>
     <AssemblyName>System.Numerics.Vectors</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/System.Reflection.DispatchProxy.4.8.1.csproj
+++ b/src/referencePackages/src/system.reflection.dispatchproxy/4.8.1/System.Reflection.DispatchProxy.4.8.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>4.8.1</PackageVersion>
     <AssemblyName>System.Reflection.DispatchProxy</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.emit.ilgeneration/4.7.0/System.Reflection.Emit.ILGeneration.4.7.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit.ilgeneration/4.7.0/System.Reflection.Emit.ILGeneration.4.7.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.7.0</PackageVersion>
     <AssemblyName>System.Reflection.Emit.ILGeneration</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.emit/4.7.0/System.Reflection.Emit.4.7.0.csproj
+++ b/src/referencePackages/src/system.reflection.emit/4.7.0/System.Reflection.Emit.4.7.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.7.0</PackageVersion>
     <AssemblyName>System.Reflection.Emit</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.metadata/5.0.0/System.Reflection.Metadata.5.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/5.0.0/System.Reflection.Metadata.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Reflection.Metadata</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.metadata/6.0.0/System.Reflection.Metadata.6.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/6.0.0/System.Reflection.Metadata.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Reflection.Metadata</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.metadata/7.0.0/System.Reflection.Metadata.7.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/7.0.0/System.Reflection.Metadata.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Reflection.Metadata</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.metadata/8.0.0/System.Reflection.Metadata.8.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadata/8.0.0/System.Reflection.Metadata.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Reflection.Metadata</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.reflection.metadataloadcontext/6.0.0/System.Reflection.MetadataLoadContext.6.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadataloadcontext/6.0.0/System.Reflection.MetadataLoadContext.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Reflection.MetadataLoadContext</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadataloadcontext/7.0.0/System.Reflection.MetadataLoadContext.7.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadataloadcontext/7.0.0/System.Reflection.MetadataLoadContext.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Reflection.MetadataLoadContext</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.reflection.metadataloadcontext/8.0.0/System.Reflection.MetadataLoadContext.8.0.0.csproj
+++ b/src/referencePackages/src/system.reflection.metadataloadcontext/8.0.0/System.Reflection.MetadataLoadContext.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Reflection.MetadataLoadContext</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.resources.extensions/6.0.0/System.Resources.Extensions.6.0.0.csproj
+++ b/src/referencePackages/src/system.resources.extensions/6.0.0/System.Resources.Extensions.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Resources.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.resources.extensions/7.0.0/System.Resources.Extensions.7.0.0.csproj
+++ b/src/referencePackages/src/system.resources.extensions/7.0.0/System.Resources.Extensions.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Resources.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.resources.extensions/8.0.0/System.Resources.Extensions.8.0.0.csproj
+++ b/src/referencePackages/src/system.resources.extensions/8.0.0/System.Resources.Extensions.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Resources.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.2/System.Runtime.CompilerServices.Unsafe.4.5.2.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.2</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/4.5.3/System.Runtime.CompilerServices.Unsafe.4.5.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.3</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/5.0.0/System.Runtime.CompilerServices.Unsafe.5.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/5.0.0/System.Runtime.CompilerServices.Unsafe.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.6.0.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.0.0/System.Runtime.CompilerServices.Unsafe.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0/System.Runtime.CompilerServices.Unsafe.6.1.0.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.0/System.Runtime.CompilerServices.Unsafe.6.1.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.1.0</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/System.Runtime.CompilerServices.Unsafe.6.1.1.csproj
+++ b/src/referencePackages/src/system.runtime.compilerservices.unsafe/6.1.1/System.Runtime.CompilerServices.Unsafe.6.1.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.1.1</PackageVersion>
     <AssemblyName>System.Runtime.CompilerServices.Unsafe</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.accesscontrol/5.0.0/System.Security.AccessControl.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/5.0.0/System.Security.AccessControl.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Security.AccessControl</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.accesscontrol/6.0.0/System.Security.AccessControl.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.accesscontrol/6.0.0/System.Security.AccessControl.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Security.AccessControl</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.cng/5.0.0/System.Security.Cryptography.Cng.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.cng/5.0.0/System.Security.Cryptography.Cng.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Cng</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/6.0.0/System.Security.Cryptography.Pkcs.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/6.0.0/System.Security.Cryptography.Pkcs.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/6.0.1/System.Security.Cryptography.Pkcs.6.0.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/6.0.1/System.Security.Cryptography.Pkcs.6.0.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.1</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/6.0.4/System.Security.Cryptography.Pkcs.6.0.4.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/6.0.4/System.Security.Cryptography.Pkcs.6.0.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.4</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/7.0.0/System.Security.Cryptography.Pkcs.7.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/7.0.0/System.Security.Cryptography.Pkcs.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/7.0.2/System.Security.Cryptography.Pkcs.7.0.2.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/7.0.2/System.Security.Cryptography.Pkcs.7.0.2.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>7.0.2</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/System.Security.Cryptography.Pkcs.8.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.pkcs/8.0.0/System.Security.Cryptography.Pkcs.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Pkcs</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/4.4.0/System.Security.Cryptography.ProtectedData.4.4.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.4.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.ProtectedData</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/6.0.0/System.Security.Cryptography.ProtectedData.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/6.0.0/System.Security.Cryptography.ProtectedData.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.ProtectedData</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/7.0.0/System.Security.Cryptography.ProtectedData.7.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/7.0.0/System.Security.Cryptography.ProtectedData.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.ProtectedData</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.protecteddata/8.0.0/System.Security.Cryptography.ProtectedData.8.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.protecteddata/8.0.0/System.Security.Cryptography.ProtectedData.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.ProtectedData</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.security.cryptography.xml/6.0.0/System.Security.Cryptography.Xml.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/6.0.0/System.Security.Cryptography.Xml.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.xml/6.0.1/System.Security.Cryptography.Xml.6.0.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/6.0.1/System.Security.Cryptography.Xml.6.0.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.1</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.xml/7.0.1/System.Security.Cryptography.Xml.7.0.1.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/7.0.1/System.Security.Cryptography.Xml.7.0.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.1</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.0/System.Security.Cryptography.Xml.8.0.0.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.0/System.Security.Cryptography.Xml.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.permissions/6.0.0/System.Security.Permissions.6.0.0.csproj
+++ b/src/referencePackages/src/system.security.permissions/6.0.0/System.Security.Permissions.6.0.0.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- Generated ref pack for net5.0 was removed as it was not used by any repo/package -->
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Security.Permissions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.permissions/7.0.0/System.Security.Permissions.7.0.0.csproj
+++ b/src/referencePackages/src/system.security.permissions/7.0.0/System.Security.Permissions.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Security.Permissions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.security.principal.windows/5.0.0/System.Security.Principal.Windows.5.0.0.csproj
+++ b/src/referencePackages/src/system.security.principal.windows/5.0.0/System.Security.Principal.Windows.5.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyName>System.Security.Principal.Windows</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.text.encoding.codepages/4.5.1/System.Text.Encoding.CodePages.4.5.1.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/4.5.1/System.Text.Encoding.CodePages.4.5.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.1</PackageVersion>
     <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.text.encoding.codepages/6.0.0/System.Text.Encoding.CodePages.6.0.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/6.0.0/System.Text.Encoding.CodePages.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.text.encoding.codepages/7.0.0/System.Text.Encoding.CodePages.7.0.0.csproj
+++ b/src/referencePackages/src/system.text.encoding.codepages/7.0.0/System.Text.Encoding.CodePages.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.text.encodings.web/6.0.0/System.Text.Encodings.Web.6.0.0.csproj
+++ b/src/referencePackages/src/system.text.encodings.web/6.0.0/System.Text.Encodings.Web.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Text.Encodings.Web</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.encodings.web/7.0.0/System.Text.Encodings.Web.7.0.0.csproj
+++ b/src/referencePackages/src/system.text.encodings.web/7.0.0/System.Text.Encodings.Web.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Text.Encodings.Web</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.encodings.web/8.0.0/System.Text.Encodings.Web.8.0.0.csproj
+++ b/src/referencePackages/src/system.text.encodings.web/8.0.0/System.Text.Encodings.Web.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Text.Encodings.Web</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.json/6.0.0/System.Text.Json.6.0.0.csproj
+++ b/src/referencePackages/src/system.text.json/6.0.0/System.Text.Json.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Text.Json</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.json/7.0.3/System.Text.Json.7.0.3.csproj
+++ b/src/referencePackages/src/system.text.json/7.0.3/System.Text.Json.7.0.3.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>7.0.3</PackageVersion>
     <AssemblyName>System.Text.Json</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.json/8.0.4/System.Text.Json.8.0.4.csproj
+++ b/src/referencePackages/src/system.text.json/8.0.4/System.Text.Json.8.0.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.4</PackageVersion>
     <AssemblyName>System.Text.Json</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.text.json/8.0.5/System.Text.Json.8.0.5.csproj
+++ b/src/referencePackages/src/system.text.json/8.0.5/System.Text.Json.8.0.5.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>8.0.5</PackageVersion>
     <AssemblyName>System.Text.Json</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.threading.channels/7.0.0/System.Threading.Channels.7.0.0.csproj
+++ b/src/referencePackages/src/system.threading.channels/7.0.0/System.Threading.Channels.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Threading.Channels</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.dataflow/6.0.0/System.Threading.Tasks.Dataflow.6.0.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/6.0.0/System.Threading.Tasks.Dataflow.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.threading.tasks.dataflow/7.0.0/System.Threading.Tasks.Dataflow.7.0.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/7.0.0/System.Threading.Tasks.Dataflow.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.threading.tasks.dataflow/8.0.0/System.Threading.Tasks.Dataflow.8.0.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.dataflow/8.0.0/System.Threading.Tasks.Dataflow.8.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>8.0.0</PackageVersion>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
   </PropertyGroup>
 

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.5.4/System.Threading.Tasks.Extensions.4.5.4.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.5.4</PackageVersion>
     <AssemblyName>System.Threading.Tasks.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.threading.tasks.extensions/4.6.0/System.Threading.Tasks.Extensions.4.6.0.csproj
+++ b/src/referencePackages/src/system.threading.tasks.extensions/4.6.0/System.Threading.Tasks.Extensions.4.6.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.6.0</PackageVersion>
     <AssemblyName>System.Threading.Tasks.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.windows.extensions/6.0.0/System.Windows.Extensions.6.0.0.csproj
+++ b/src/referencePackages/src/system.windows.extensions/6.0.0/System.Windows.Extensions.6.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <PackageVersion>6.0.0</PackageVersion>
     <AssemblyName>System.Windows.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/referencePackages/src/system.windows.extensions/7.0.0/System.Windows.Extensions.7.0.0.csproj
+++ b/src/referencePackages/src/system.windows.extensions/7.0.0/System.Windows.Extensions.7.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <PackageVersion>7.0.0</PackageVersion>
     <AssemblyName>System.Windows.Extensions</AssemblyName>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/textOnlyPackages/src/microbuild.core/0.3.0/microbuild.core.0.3.0.csproj
+++ b/src/textOnlyPackages/src/microbuild.core/0.3.0/microbuild.core.0.3.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>0.3.0</PackageVersion>
+    <AssemblyName>MicroBuild.Core</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.build.notargets/3.7.0/Microsoft.Build.NoTargets.3.7.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.7.0</PackageVersion>
     <AssemblyName>Microsoft.Build.NoTargets</AssemblyName>
   </PropertyGroup>
 

--- a/src/textOnlyPackages/src/microsoft.build.traversal/3.4.0/microsoft.build.traversal.3.4.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.build.traversal/3.4.0/microsoft.build.traversal.3.4.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.4.0</PackageVersion>
+    <AssemblyName>Microsoft.Build.Traversal</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.codeanalysis.collections/4.2.0-1.22102.8/microsoft.codeanalysis.collections.4.2.0-1.22102.8.csproj
+++ b/src/textOnlyPackages/src/microsoft.codeanalysis.collections/4.2.0-1.22102.8/microsoft.codeanalysis.collections.4.2.0-1.22102.8.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>4.2.0-1.22102.8</PackageVersion>
+    <AssemblyName>Microsoft.CodeAnalysis.Collections</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.docker.sdk/1.1.0/microsoft.docker.sdk.1.1.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.docker.sdk/1.1.0/microsoft.docker.sdk.1.1.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>1.1.0</PackageVersion>
+    <AssemblyName>Microsoft.Docker.Sdk</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.extensions.commandlineutils.sources/3.0.0-preview6.19253.5/microsoft.extensions.commandlineutils.sources.3.0.0-preview6.19253.5.csproj
+++ b/src/textOnlyPackages/src/microsoft.extensions.commandlineutils.sources/3.0.0-preview6.19253.5/microsoft.extensions.commandlineutils.sources.3.0.0-preview6.19253.5.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.0.0-preview6.19253.5</PackageVersion>
+    <AssemblyName>Microsoft.Extensions.CommandLineUtils.Sources</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.netcore.platforms/1.1.0/microsoft.netcore.platforms.1.1.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>1.1.0</PackageVersion>
+    <AssemblyName>Microsoft.NETCore.Platforms</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.csproj
+++ b/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyName>Microsoft.NETCore.Platforms</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/microsoft.private.intellisense/9.0.0-preview-20241010.1/Microsoft.Private.Intellisense.9.0.0-preview-20241010.1.csproj
+++ b/src/textOnlyPackages/src/microsoft.private.intellisense/9.0.0-preview-20241010.1/Microsoft.Private.Intellisense.9.0.0-preview-20241010.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>9.0.0-preview-20241010.1</PackageVersion>
     <AssemblyName>Microsoft.Private.Intellisense</AssemblyName>
   </PropertyGroup>
 

--- a/src/textOnlyPackages/src/wcwidth.sources/1.0.0/wcwidth.sources.1.0.0.csproj
+++ b/src/textOnlyPackages/src/wcwidth.sources/1.0.0/wcwidth.sources.1.0.0.csproj
@@ -1,1 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk" />
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>1.0.0</PackageVersion>
+    <AssemblyName>Wcwidth.Sources</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/textOnlyPackages/src/wcwidth.sources/2.0.0/Wcwidth.Sources.2.0.0.csproj
+++ b/src/textOnlyPackages/src/wcwidth.sources/2.0.0/Wcwidth.Sources.2.0.0.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageVersion>2.0.0</PackageVersion>
     <AssemblyName>Wcwidth.Sources</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
Extracted from https://github.com/dotnet/source-build-reference-packages/pull/1185
Contributes to https://github.com/dotnet/source-build/issues/1690

The SDK uses the PackageVersion property as an input to NuGet package pruning and conflict resolution.

Having correct inputs passed to conflict resolution is essential to support ProjectReferences in this repository as it handles deciding which asset to compile against (framework vs P2P).

Until now, all projects use the default repository wide version information which is wrong.

Therefore, update the task, template and msbuild generate project entrypoint to emit the PackageVersion property into the project files.

**Commit 2 is auto-generated via `generate.sh`, only with unrelated files reverted. Commit 3 was applied manually.**