### PR TITLE
Add Customizations.props and change extension point

### DIFF
--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -3,22 +3,6 @@
   <Import Project="..\..\Directory.Build.props" />
 
   <PropertyGroup>
-    <CustomizationsPropsPath>$(MSBuildProjectDirectory)\$(CustomizationsPropsFile)</CustomizationsPropsPath>
-    <CustomizationsSourcePath>$(MSBuildProjectDirectory)\$(CustomizationsSourceFile)</CustomizationsSourcePath>
-  </PropertyGroup>
-
-  <!-- Customization extension point -->
-  <Import Project="$(CustomizationsPropsPath)" Condition="Exists('$(CustomizationsPropsPath)')" />
-
-  <ItemGroup>
-    <!-- Attributes for all Reference Packages -->
-    <Compile Include="$(RepoRoot)src\SourceBuildAssemblyMetdata.cs" />
-
-    <!-- Customization extension point -->
-    <Compile Include="$(CustomizationsSourcePath)" Condition="Exists('$(CustomizationsSourcePath)')" />
-  </ItemGroup>
-
-  <PropertyGroup>
     <!-- Common properties for all Reference Packages -->
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -2,10 +2,24 @@
 
   <Import Project="..\..\Directory.Build.targets" />
 
+  <PropertyGroup>
+    <CustomizationsPropsPath>$(MSBuildProjectDirectory)\$(CustomizationsPropsFile)</CustomizationsPropsPath>
+    <CustomizationsSourcePath>$(MSBuildProjectDirectory)\$(CustomizationsSourceFile)</CustomizationsSourcePath>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="ref/$(TargetFramework)/*$(DefaultLanguageSourceExtension)" />
     <Compile Include="lib/$(TargetFramework)/*$(DefaultLanguageSourceExtension)" />
+
+    <!-- Attributes for all Reference Packages -->
+    <Compile Include="$(RepoRoot)src\SourceBuildAssemblyMetdata.cs" />
+
+    <!-- Customization extension point -->
+    <Compile Include="$(CustomizationsSourcePath)" Condition="Exists('$(CustomizationsSourcePath)')" />
   </ItemGroup>
+
+    <!-- Customization extension point -->
+  <Import Project="$(CustomizationsPropsPath)" Condition="Exists('$(CustomizationsPropsPath)')" />
 
   <!--
     ### Targeting Packs section ###

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Customizations.props
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Customizations.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <!-- Microsoft.VisualStudio.Setup.Configuration.Interop was accidentally exposed by the product. -->
+    <PackageReference Remove="Microsoft.VisualStudio.Setup.Configuration.Interop" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Microsoft.Build.Tasks.Core.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build.tasks.core/17.8.3/Microsoft.Build.Tasks.Core.17.8.3.csproj
@@ -14,8 +14,7 @@
     <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
-    <!-- Microsoft.VisualStudio.Setup.Configuration.Interop was accidentally exposed by the product.
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" /> -->
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Customizations.props
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Customizations.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <!-- Microsoft.VisualStudio.Setup.Configuration.Interop was accidentally exposed by the product. -->
+    <PackageReference Remove="Microsoft.VisualStudio.Setup.Configuration.Interop" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Microsoft.Build.Utilities.Core.17.8.3.csproj
+++ b/src/referencePackages/src/microsoft.build.utilities.core/17.8.3/Microsoft.Build.Utilities.Core.17.8.3.csproj
@@ -8,8 +8,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" />
     <PackageReference Include="Microsoft.NET.StringTools" Version="17.8.3" />
-    <!-- Microsoft.VisualStudio.Setup.Configuration.Interop was accidentally exposed by the product.
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" /> -->
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.2.2146" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
   </ItemGroup>

--- a/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Customizations.props
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Customizations.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup>
+    <!-- Analyzers are excluded from SBRPs -->
+    <PackageReference Remove="Microsoft.CodeAnalysis.Analyzers" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
+++ b/src/referencePackages/src/microsoft.codeanalysis.common/4.1.0/Microsoft.CodeAnalysis.Common.4.1.0.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- Analyzers are excluded from SBRPs
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" /> -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />

--- a/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/Customizations.props
+++ b/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/Customizations.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <!-- Necessary for PermissionSet types but as a dangling compile-time only reference. -->
+    <ProjectReference Include="../../system.security.permissions/7.0.0/System.Security.Permissions.7.0.0.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/System.Configuration.ConfigurationManager.8.0.0.csproj
+++ b/src/referencePackages/src/system.configuration.configurationmanager/8.0.0/System.Configuration.ConfigurationManager.8.0.0.csproj
@@ -21,8 +21,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- Necessary for PermissionSet types but as a dangling compile-time only reference. -->
-    <PackageReference Include="System.Security.Permissions" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Extracted from https://github.com/dotnet/source-build-reference-packages/pull/1185

Import Customizations.props after the project file so that it can modify the project content via property or item operations.
Add Customizations.props files for 4 projects