### PR TITLE
Various infra improvements

### DIFF
--- a/src/referencePackages/Directory.Build.props
+++ b/src/referencePackages/Directory.Build.props
@@ -34,9 +34,6 @@
     <LangVersion>latest</LangVersion>
 
     <CommonSrc>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'common'))</CommonSrc>
-
-    <!-- Make RAR not unify assembly dependencies. This is necessary to make P2Ps with same package ids but different versions work. -->
-    <_FindDependencies>false</_FindDependencies>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -3,9 +3,21 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
+    <!-- Disable RAR from transitively discovering dependencies for references. This is required as we don't copy
+         dependencies over into the output directory which means RAR can't resolve them.
+         This is also necessary to make P2Ps with same package ids but different versions work. -->
+    <_FindDependencies>false</_FindDependencies>
+
     <CustomizationsPropsPath>$(MSBuildProjectDirectory)\$(CustomizationsPropsFile)</CustomizationsPropsPath>
     <CustomizationsSourcePath>$(MSBuildProjectDirectory)\$(CustomizationsSourceFile)</CustomizationsSourcePath>
   </PropertyGroup>
+
+  <!-- Project references don't need to be copied to the output. That makes the build significantly faster. -->
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemDefinitionGroup>
 
   <ItemGroup>
     <Compile Include="ref/$(TargetFramework)/*$(DefaultLanguageSourceExtension)" />
@@ -21,21 +33,22 @@
   <!-- Customization extension point -->
   <Import Project="$(CustomizationsPropsPath)" Condition="Exists('$(CustomizationsPropsPath)')" />
 
-  <!--
-    ### Targeting Packs section ###
-    Keep in sync with available targeting packs under src/targetPacks/ILsrc.
-  -->
-
   <PropertyGroup>
+    <!-- Avoid transitive framework reference downloads to minimize the number of targeting packs and prebuilts. -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
     <!-- The SDK already sets the NETStandardImplicitPackageVersion and we don't expect it to change anymore. Hence, we don't encode it here. -->
   </PropertyGroup>
 
+  <!-- Keep in sync with available targeting packs under src/targetPacks/ILsrc. -->
   <ItemGroup>
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App'))">
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.0'">3.0.0</TargetingPackVersion>
       <TargetingPackVersion Condition="'%(TargetFramework)' == 'netcoreapp3.1'">3.1.0</TargetingPackVersion>
       <TargetingPackVersion Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(TargetFramework)', '^net\d+\.0$'))">$([System.Text.RegularExpressions.Regex]::Match('%(TargetFramework)', '\d+').Value).0.0</TargetingPackVersion>
+    </KnownFrameworkReference>
+
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App'))">
+      <TargetingPackVersion Condition="'%(TargetFramework)' == 'net6.0'">6.0.2</TargetingPackVersion>
     </KnownFrameworkReference>
 
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'NETStandard.Library'))">
@@ -58,22 +71,12 @@
           DependsOnTargets="ResolveProjectReferences"
           AfterTargets="ResolveTargetingPackAssets">
     <ItemGroup>
-      <_targetingPackReferenceExclusion Include="$(TargetName)" />
-    </ItemGroup>
-    <ItemGroup>
-      <_targetingPackReferenceWithProjectName Include="@(Reference->WithMetadataValue('ExternallyResolved', 'true')->Metadata('Filename'))"
-                                              OriginalIdentity="%(Identity)" />
-      <_targetingPackIncludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
-                                                      Exclude="@(_targetingPackReferenceExclusion)" />
-      <_targetingPackExcludedReferenceWithProjectName Include="@(_targetingPackReferenceWithProjectName)"
-                                                      Exclude="@(_targetingPackIncludedReferenceWithProjectName)" />
-      <Reference Remove="@(_targetingPackExcludedReferenceWithProjectName->Metadata('OriginalIdentity'))" />
+      <Reference Remove="@(Reference->WithMetadataValue('ExternallyResolved', 'true')->WithMetadataValue('Filename', '$(TargetName)'))" />
     </ItemGroup>
   </Target>
 
   <Target Name="CopyBuildOutputToTempOutput"
           AfterTargets="CopyFilesToOutputDirectory">
-
     <ItemGroup>
       <CompileWithRelativePath Include="@(Compile)" Condition="!$([System.String]::new('%(Identity)').StartsWith('%(RootDir)'))" />
     </ItemGroup>


### PR DESCRIPTION
- Simplify FilterImplicitAssemblyReferences target
- Add comments to a few settings
- Add missing aspnetcore KnownFrameworkReference targeting pack setting
- Disable P2Ps getting copied to a lib's output which makes the build significantly faster.
- Move the _FindDependencies property from props to targets and extend the comment on why the setting is necessary.