### PR TITLE
Use live built targeting packs and remove SBRP self dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,12 +8,6 @@
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="10.0.607103">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>412f115947777b9babf97716a20b056d0d77b1b9</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
-    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="10.0.0-beta.25126.4">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6d4b01bce3a29c172faff5abc0bfe2ae3d1fef3d</Sha>

--- a/src/referencePackages/Directory.Build.targets
+++ b/src/referencePackages/Directory.Build.targets
@@ -2,7 +2,22 @@
 
   <Import Project="..\..\Directory.Build.targets" />
 
+  <!-- netstandard2.0's targeting pack uses the old package reference model which doesn't support using a local layout.
+       Therefore disable the package reference download via DisableImplicitFrameworkReferences and manually import the
+       packages' targets file to receive the references. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NETStandardLibraryArtifactsDir>$(ArtifactsBinDir)NETStandard.Library.2.0.3\pack\</NETStandardLibraryArtifactsDir>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+  <Import Project="$(NETStandardLibraryArtifactsDir)build\netstandard2.0\NETStandard.Library.targets" Condition="'$(TargetFramework)' == 'netstandard2.0' and '$(ExcludeRestorePackageImports)' != 'true' and Exists('$(NETStandardLibraryArtifactsDir)')" />
+
   <PropertyGroup>
+    <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+
+    <!-- Avoid transitive framework reference downloads to minimize the number of targeting packs and prebuilts. -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+
     <CustomizationsPropsPath>$(MSBuildProjectDirectory)\$(CustomizationsPropsFile)</CustomizationsPropsPath>
     <CustomizationsSourcePath>$(MSBuildProjectDirectory)\$(CustomizationsSourceFile)</CustomizationsSourcePath>
   </PropertyGroup>
@@ -25,11 +40,6 @@
     ### Targeting Packs section ###
     Keep in sync with available targeting packs under src/targetPacks/ILsrc.
   -->
-
-  <PropertyGroup>
-    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- The SDK already sets the NETStandardImplicitPackageVersion and we don't expect it to change anymore. Hence, we don't encode it here. -->
-  </PropertyGroup>
 
   <ItemGroup>
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App'))">
@@ -93,6 +103,15 @@
         '$(TFMPackTempOutputDir)',
         '%(RelativeCompileDir.Identity)',
         '$(TargetFileName)'))" />
+  </Target>
+
+  <!-- Use local targeting packs -->
+  <Target Name="UseLocalTargetingPack" AfterTargets="ResolveFrameworkReferences">
+    <ItemGroup>
+      <ResolvedTargetingPack Path="$(ArtifactsBinDir)%(ResolvedTargetingPack.NuGetPackageId).%(ResolvedTargetingPack.NuGetPackageVersion)\pack"
+                             PackageDirectory="$(ArtifactsBinDir)%(ResolvedTargetingPack.NuGetPackageId).%(ResolvedTargetingPack.NuGetPackageVersion)\pack" />
+      <ResolvedFrameworkReference TargetingPackPath="$(ArtifactsBinDir)%(ResolvedFrameworkReference.TargetingPackName).%(ResolvedFrameworkReference.TargetingPackVersion)\pack" />
+    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
Depends on https://github.com/dotnet/source-build-reference-packages/pull/1189, https://github.com/dotnet/source-build-reference-packages/pull/1190 and https://github.com/dotnet/source-build-reference-packages/pull/1191

- Use the live built targeting packs by using the same hook that we use in runtime and various others repos. For netstandard2.0, manually import the build targets file that brings the references in.

- Remove the SBRP self dependency