### PR TITLE
Document guidelines for porting new packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ generated packages show changes when being regenerated.
 
 You can search for known issues in the [Known Generator Issues Markdown file](docs/known_generator_issues.md).
 
+**Note:** When porting new packages between branches, you must regenerate the packages when crossing the 10.0/9.0 boundary.
+This is because in 10.0 the generated projects switched from using PackageReference to PojectReference.
+Porting new packages across 10.0/9.0 boundary will introduce prebuilts.
+See the workflow documented in the servicing branch readmes for additional requirements when adding new packages pre 10.0.
+
 ### Targeting
 
 Generating new targeting packages is not supported. No new targeting packs should be needed/added. If you feel


### PR DESCRIPTION
This is something that was brought to attention in https://github.com/dotnet/source-build-reference-packages/pull/1205#issuecomment-2740581443