### PR TITLE
Remove maintenance-packages temp feed from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -22,8 +22,6 @@
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
     <!-- Required for MSBuild 17.3.4 -->
     <add key="darc-pub-DotNet-msbuild-Trusted" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-DotNet-msbuild-Trusted-a400405b/nuget/v3/index.json" />
-    <!-- Required for maintenance-packages System.Memory 4.6.1, System.Net.WebSockets.WebSocketProtocol 5.1.1, System.Reflection.DispatchProxy 4.8.1, System.Runtime.CompilerServices.Unsafe 6.1.1, System.Threading.Tasks.Extensions 4.6.1 -->
-    <add key="darc-pub-dotnet-maintenance-packages-ab95a1f1" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/darc-pub-dotnet-maintenance-packages-ab95a1f1/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
   <auditSources>


### PR DESCRIPTION
The packages that were published in that feed are already available in nuget.org.

@MichaelSimons @ViktorHofer @ericstj