### PR TITLE
Update containers used in AzDO

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -14,7 +14,7 @@ stages:
         name: $(DncEngInternalBuildPool)
         image: 1es-ubuntu-2204
         os: linux
-    container: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8
+    container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
     steps:
     - template: ${{ parameters.engCommonTemplatesDir }}/steps/source-build.yml
 
@@ -41,7 +41,6 @@ stages:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
-    container: mcr.microsoft.com/windows/servercore:ltsc2022
     steps:
     - checkout: self
       clean: true


### PR DESCRIPTION
1. Updated Linux legs to use Azure Linux.  Current CentOS image is EOL.
2. Removed the use of containers in the Windows leg.  This provided no value and takes 7-9 minutes to pull.  This was causing the Windows leg to take 2X more time than the Linux leg.  This is significant considering the Windows leg only runs the tests - no build.