### PR TITLE
Use assetless build for official build

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -55,3 +55,11 @@ stages:
         testResultsFiles: '**/artifacts/TestResults/Release/*.xml'
         testRunTitle: 'Windows_SBRP_tests'
       condition: always()
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+      parameters:
+        dependsOn:
+        - Linux
+        - Windows
+        publishAssetsImmediately: true
+        isAssetlessBuild: true


### PR DESCRIPTION
Similar to https://github.com/dotnet/source-build-externals/pull/479

Follow-up on 8b468af13646bed28c0c88febbc2bab226a36fd1 which removed the publish action from the source-build template. Make the official build an assetless build so that source changes flow into the VMR.

This is a partial revert of https://github.com/dotnet/source-build-reference-packages/commit/8b468af13646bed28c0c88febbc2bab226a36fd1 (the build.yml changes). I didn't realize that by removing the publish job, the VMR doesn't get new source changes.