### PR TITLE
Add missing Version.Details.xml dependencies added in VMR

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,6 +2,14 @@
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="source-build-reference-packages" Sha="2fd058a2011cf1842cb3a42531e34987e948602e" BarId="273672" />
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.Build" Version="17.15.0-preview-25316-103">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>20343176cfd35b56036dc4ca9d9ddd2a201a4e92</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.15.0-preview-25316-103">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>20343176cfd35b56036dc4ca9d9ddd2a201a4e92</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25330.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>2fd058a2011cf1842cb3a42531e34987e948602e</Sha>


### PR DESCRIPTION
These dependencies were made in https://github.com/dotnet/dotnet/pull/1236 but didn't backflow in https://github.com/dotnet/source-build-reference-packages/pull/1278 and I missed adding them.