### PR TITLE
Use release version of Spectre.Console

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,6 @@
     <HumanizerReleaseVersion>2.14.1</HumanizerReleaseVersion>
     <MSBuildLocatorReleaseVersion>1.6.10</MSBuildLocatorReleaseVersion>
     <SolutionPersistenceVersion>1.0.52</SolutionPersistenceVersion>
-    <SpectreConsoleReleaseVersion>0.48.0</SpectreConsoleReleaseVersion>
     <XunitReleaseVersion>2.9.2</XunitReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/externalPackages/projects/spectre-console.proj
+++ b/src/externalPackages/projects/spectre-console.proj
@@ -12,7 +12,7 @@
       <BuildCommandArgs>$(BuildCommandArgs) /p:Configuration=$(Configuration)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
-      <BuildCommandArgs>$(BuildCommandArgs) /p:Version=$(SpectreConsoleReleaseVersion)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:Version=0.50.0</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:TargetFrameworks=$(NetCurrent)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:UseBuildTimeTools=false</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:IsAotCompatible=false</BuildCommandArgs>


### PR DESCRIPTION
Without this PR, the spectre-console submodule is based on `main` (which is a prerelease) and the version number was outdated (wasn't removed with the rest of the submodule so I missed updating it when reverting the removal).