### PR TITLE
Add labeler GH action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'untriaged' label to any issue that gets opened
+untriaged:
+- '/.*/'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.4
+      with:
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
Port of the existing [dotnet/source-build labeler](https://github.com/dotnet/source-build/blob/main/.github/workflows/labeler.yml).

This is useful now that issues are enabled in this repo.