### PR TITLE
IdentityModel CodeQL suppression

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  library:
+    - "src/externalPackages/src/azure-activedirectory-identitymodel-extensions-for-dotnet/**"


### PR DESCRIPTION
This will suppress the CodeQL violations that are showing up for the `azure-activedirectory-identitymodel-extensions-for-dotnet` repo. That team has given the ok that these are safe.

Related: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/3297