### PR TITLE
[release/9.0] Add CG.ignoreDirectories in ci.yml and specify sdk in global.json

### DIFF
--- a/azure-pipelines/builds/ci.yml
+++ b/azure-pipelines/builds/ci.yml
@@ -25,6 +25,10 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
     sdl:
+      componentgovernance:
+        # These directories need to be kept in-sync with the 'componentGovernanceIgnoreDirectories'
+        # specified in ../templates/stages/build.yml
+        ignoreDirectories: "src/referencePackages,artifacts/sb"
       policheck:
         enabled: true
       sourceAnalysisPool:

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -18,6 +18,8 @@ stages:
     steps:
     - template: ${{ parameters.engCommonTemplatesDir }}/steps/source-build.yml
       parameters:
+        # These directories need to be kept in-sync with the 'componentGovernance/ignoreDirectories'
+        # specified in ../../builds/ci.yml
         componentGovernanceIgnoreDirectories:
         - src/referencePackages
         - artifacts/sb

--- a/global.json
+++ b/global.json
@@ -1,4 +1,13 @@
 {
+  "sdk": {
+    "version": "9.0.111",
+    "rollForward": "latestPatch",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
+  },
   "tools": {
     "dotnet": "9.0.111"
   },


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build-reference-packages/issues/1433

There are two issues being addressed:

1. 1ES template CG step is detecting the reference packages themselves.  These are intended to be ignored as seen in the [arcade SB template](https://github.com/dotnet/arcade/blob/release/9.0/eng/common/core-templates/steps/source-build.yml#L125).  Something changes in the templates causing the 1EST template to catch these.
2. global.json was not specifying the sdk settings therefore the latest SDK on the build agent was getting picked up which was vulnerable (unpatched newer feature band).