### PR TITLE
Change global.json sdk.rollForward to latestPatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "10.0.100-rc.1.25420.111",
     "allowPrerelease": true,
-    "rollForward": "latestFeature",
+    "rollForward": "latestPatch",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build-reference-packages/issues/1433

The rollForward policy can cause the build to use a vulnerable version form a newer feature band if it exists on the build agent.  Additionally for source build repos like this, it is best to always use an SDK from the specified feature band.

This should get backported to 10 once merged.