### PR TITLE
Don't use the global nuget cache when building on Windows

### DIFF
--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,0 +1,3 @@
+# This repository should never write to the global nuget package cache as it creates
+# and then later restores packages with a partial layout.
+$script:useGlobalNuGetCache = $false


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/source-build-reference-packages/commit/942cda80b77d28bb9a7c6c55c21bc09c8b2bf8dd

The build.sh entry point isn't impacted as it passes the "-sb" switch in which already disables the global package cache: https://github.com/dotnet/source-build-reference-packages/blob/942cda80b77d28bb9a7c6c55c21bc09c8b2bf8dd/build.sh#L20