### PR TITLE
Set spectre.console version properties

### DIFF
--- a/src/externalPackages/projects/spectre-console.proj
+++ b/src/externalPackages/projects/spectre-console.proj
@@ -14,7 +14,10 @@
       <BuildCommandArgs>$(BuildCommandArgs) /p:PublicSign=$(PublicSign)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:AssemblyVersion=$(SpectreConsoleReleaseVersion.Split('.')[0]).0.0.0</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:Version=$(SpectreConsoleReleaseVersion)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:FileVersion=$(SpectreConsoleReleaseVersion).0</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:InformationalVersion=$(SpectreConsoleReleaseVersion)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:TargetFrameworks=$(NetCurrent)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:UseBuildTimeTools=false</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:IsAotCompatible=false</BuildCommandArgs>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5466

Spectre.console repo produces assembly with `AssemblyVersion` set to `0.0.0.0`. When building in this repo, `MinVer` package will be used for automatic versioning. It sets various version properties according to https://github.com/adamralph/minver?tab=readme-ov-file#version-numbers

Since `AssemblyVersion` gets set by `MinVer` target/task, SDK's `GetAssemblyVersion` target gets skipped.

When building in SBRP repo, or in VMR, we build `Spectre.Console` with a custom command line as specified in https://github.com/dotnet/source-build-reference-packages/blob/main/src/externalPackages/projects/spectre-console.proj

We did not want to include additional dependent packages, like `MinVer` so we had set `UseBuildTimeTools` to `false` which excludes additional external package dependencies: https://github.com/spectreconsole/spectre.console/blob/e097281ca8a50268b1022453fe6efd9112123a28/src/Directory.Build.props#L53-L54

The fix is to explicitly set `AssemblyVersion`. Since setting this property would cause the build to skip `GetAssemblyVersion` target, we are also setting `FileVersion` and `InformationalVersion` properties that would have been set in `GetAssemblyVersion` target.