### PR TITLE
Set SourceRevisionId for external packages to match original repo commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ to .NET. The following sections describe how to add/upgrade the various types of
 1. Define a [project](src/externalPackages/projects) for the new component.
    The project is responsible for building the submodule with the appropriate configuration for source build.
    See the [existing projects](src/externalPackages/projects) for examples.
+   Include a `SourceRevisionId` property set to the submodule's commit hash.
+   This ensures the correct commit hash is embedded in the built binaries rather than the VMR's.
 
 1. [Build](#building) locally and resolve any build errors.
    Source changes must be applied via [patches](src/externalPackages/patches).
@@ -92,6 +94,7 @@ to .NET. The following sections describe how to add/upgrade the various types of
     1. Review the [repo's project](src/externalPackages/projects) to ensure it is appropriate for the new version.
        There are a number of projects that utilize MSBuild properties to specify the version.
        These need to be manually updated with each upgrade.
+       Update the `SourceRevisionId` property to match the new submodule commit hash.
 
     1. Resolve build errors.
        Source changes must be applied via [patches](src/externalPackages/patches).

--- a/src/externalPackages/projects/Directory.Build.targets
+++ b/src/externalPackages/projects/Directory.Build.targets
@@ -2,6 +2,12 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 
+  <!-- Pass the submodule's commit hash to the inner build so SourceRevisionId reflects the
+       original repo rather than the VMR. See https://github.com/dotnet/source-build/issues/5506 -->
+  <ItemGroup Condition="'$(SourceRevisionId)' != ''">
+    <EnvironmentVariables Include="SourceRevisionId=$(SourceRevisionId)" />
+  </ItemGroup>
+
   <Target Name="BuildRepoReferences" Condition="'@(RepositoryReference)' != '' and '$(SkipRepoReferences)' != 'true'">
     <Message Importance="High" Text="Building dependencies [@(RepositoryReference)] needed by '$(InnerRepoName)'." />
 

--- a/src/externalPackages/projects/MSBuildLocator.proj
+++ b/src/externalPackages/projects/MSBuildLocator.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)src/MSBuildLocator/bin/$(Configuration)/</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>694ff392b2dcf6ac58fe865afd1c982eb9449014</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/antlr4.proj
+++ b/src/externalPackages/projects/antlr4.proj
@@ -9,5 +9,6 @@
     <DotNetToolArgs>$(DotNetToolArgs) /p:Configuration=$(Configuration)</DotNetToolArgs>
 
     <BuildCommand>$(DotNetTool) build -t:Build,Pack -c $(Configuration) -f netstandard2.0 /p:TargetFrameworks=netstandard2.0 $(Antlr4ProjectPath) /bl:$(ArtifactsLogRepoDir)build.binlog</BuildCommand>
+    <SourceRevisionId>7ed420ff2c78d62883875c442d75f32e73bc86c8</SourceRevisionId>
   </PropertyGroup>
 </Project>

--- a/src/externalPackages/projects/application-insights.proj
+++ b/src/externalPackages/projects/application-insights.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)bin/$(Configuration)</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>2faa7e8b157a431daa2e71785d68abd5fa817b53</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
+++ b/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)pack</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>e67b25be77532af9ba405670b34b4d263d505fde</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/cssparser.proj
+++ b/src/externalPackages/projects/cssparser.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)src/Microsoft.Css.Parser/bin/$(Configuration)/</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>0d59611784841735a7778a67aa6e9d8d000c861f</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/docker-creds-provider.proj
+++ b/src/externalPackages/projects/docker-creds-provider.proj
@@ -5,6 +5,7 @@
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <PackagesOutput>$(ProjectDirectory)src/Valleysoft.DockerCredsProvider/bin/$(Configuration)/</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>6e1ecd0a80755f9f0e88dc23b98b52f51a77c65e</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/humanizer.proj
+++ b/src/externalPackages/projects/humanizer.proj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PackagesOutput>$(ProjectDirectory)src/Humanizer/bin/Release</PackagesOutput>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>3ebc38de585fc641a04b0e78ed69468453b0f8a1</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/newtonsoft-json.proj
+++ b/src/externalPackages/projects/newtonsoft-json.proj
@@ -18,6 +18,7 @@
     <BuildCommand>$(DotNetTool) pack $(NewtonsoftJsonProjectPath) /bl:$(ArtifactsLogRepoDir)build.binlog $(DotNetToolArgs)</BuildCommand>
 
     <PackagesOutput>$(NewtonsoftJsonDirectory)bin/$(Configuration)/</PackagesOutput>
+    <SourceRevisionId>0a2e291c0d9c0c7675d445703e51750363a549ef</SourceRevisionId>
   </PropertyGroup>
 
   <!-- The Library Frameworks was added to environment variables so as to override the frameworks in newtonsoft csproj -->

--- a/src/externalPackages/projects/spectre-console.proj
+++ b/src/externalPackages/projects/spectre-console.proj
@@ -4,6 +4,7 @@
     <PackagesOutput>$(ProjectDirectory)src/Spectre.Console/bin/$(Configuration)/</PackagesOutput>
     <GlobalJsonFile>$(ProjectDirectory)global.json</GlobalJsonFile>
     <CustomRepoBuild>true</CustomRepoBuild>
+    <SourceRevisionId>e097281ca8a50268b1022453fe6efd9112123a28</SourceRevisionId>
   </PropertyGroup>
 
   <Target Name="CustomRepoBuild">

--- a/src/externalPackages/projects/vs-solutionpersistence.proj
+++ b/src/externalPackages/projects/vs-solutionpersistence.proj
@@ -18,6 +18,7 @@
     <DotNetToolArgs>$(DotNetToolArgs) /p:PackageVersion=$(SolutionPersistenceVersion)</DotNetToolArgs>
 
     <BuildCommand>$(DotNetTool) pack $(SlnPersistenceProjectPath) /bl:$(ArtifactsLogRepoDir)build.binlog $(DotNetToolArgs)</BuildCommand>
+    <SourceRevisionId>0b6f82a4073ce0ff0419991ea0cd6dd6898a51ac</SourceRevisionId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SbrpTests/ExternalPackageTests.cs
+++ b/tests/SbrpTests/ExternalPackageTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SbrpTests;
+
+public class ExternalPackageTests
+{
+    public ITestOutputHelper Output { get; set; }
+
+    public ExternalPackageTests(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// Validates that the SourceRevisionId property in each external package .proj file
+    /// matches the commit hash of the corresponding git submodule. This ensures the correct
+    /// repo commit hash is embedded in the built packages rather than the VMR's commit hash.
+    /// See https://github.com/dotnet/source-build/issues/5506
+    /// </summary>
+    [Fact]
+    public void SourceRevisionIdMatchesSubmoduleCommit()
+    {
+        string repoRoot = PathUtilities.GetRepoRoot().TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string projectsDir = Path.Combine(repoRoot, "src", "externalPackages", "projects");
+        string submodulesDir = Path.Combine(repoRoot, "src", "externalPackages", "src");
+
+        string[] projFiles = Directory.GetFiles(projectsDir, "*.proj");
+        Assert.True(projFiles.Length > 0, $"No .proj files found in {projectsDir}");
+
+        List<string> errors = new();
+        int checkedCount = 0;
+
+        foreach (string projFile in projFiles)
+        {
+            string packageName = Path.GetFileNameWithoutExtension(projFile);
+            string submoduleDir = Path.Combine(submodulesDir, packageName);
+
+            // Skip packages that don't have a corresponding submodule
+            if (!Directory.Exists(submoduleDir) || !Directory.EnumerateFileSystemEntries(submoduleDir).Any())
+            {
+                Output.WriteLine($"Skipping {packageName}: submodule directory not found or empty.");
+                continue;
+            }
+
+            // Get the submodule's commit hash
+            var result = ExecuteHelper.ExecuteProcess("git", $"-C {submoduleDir} rev-parse HEAD", Output);
+            if (result.Process.ExitCode != 0)
+            {
+                Output.WriteLine($"Skipping {packageName}: unable to resolve submodule commit hash.");
+                continue;
+            }
+
+            string submoduleHash = result.StdOut.Trim();
+
+            // Parse SourceRevisionId from the .proj file
+            XDocument doc = XDocument.Load(projFile);
+            string? sourceRevisionId = doc.Descendants("SourceRevisionId").FirstOrDefault()?.Value;
+
+            if (string.IsNullOrEmpty(sourceRevisionId))
+            {
+                errors.Add($"{packageName}.proj: Missing SourceRevisionId property. Expected '{submoduleHash}'.");
+            }
+            else if (!string.Equals(submoduleHash, sourceRevisionId, StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add($"{packageName}.proj: SourceRevisionId '{sourceRevisionId}' does not match submodule commit '{submoduleHash}'.");
+            }
+
+            checkedCount++;
+        }
+
+        Assert.True(checkedCount > 0, "No external packages with initialized submodules were found to validate.");
+        Assert.True(errors.Count == 0,
+            $"SourceRevisionId validation failed:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
+    }
+}


### PR DESCRIPTION
When building external packages, SourceLink resolves SourceRevisionId from the current git repository, which during source-build is the VMR rather than the individual package's repo. This causes the ProductVersion to embed the wrong commit hash.

Fix this by storing each submodule's commit hash as a SourceRevisionId property in the corresponding .proj file and passing it to the inner build as an environment variable. MSBuild imports environment variables as properties, so SourceLink's InitializeSourceControlInformation target sees it as already set and skips its own resolution.

This approach works without git because the hashes are static values in the source tree, supporting builds from tarballs and the VMR where submodule metadata is not available.

Fixes https://github.com/dotnet/source-build/issues/5506