### PR TITLE
Use azurelinux 3 build image on Linux

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -22,12 +22,12 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+            demands: ImageOverride -equals build.azurelinux.3.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: $(DncEngInternalBuildPool)
-            image: 1es-ubuntu-2204
+            image: build.azurelinux.3.amd64
             os: linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
         variables:
         - _BuildConfig: Release
         steps:


### PR DESCRIPTION
This is just the host, the actual build runs in the container (which I also fixed from net10.0 to net11.0)

The 1es-ubuntu-2204 image has disk space problems recently.