### PR TITLE
Optimize CI artifact publishing: targeted packages instead of full artifacts dir

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -9,7 +9,6 @@ stages:
     parameters:
       artifacts:
         publish:
-          artifacts: true
           logs: true
       enablePublishTestResults: true
       enableTelemetry: true
@@ -36,6 +35,7 @@ stages:
           submodules: recursive
         - script: ./build.sh --ci --test -bl -c Release
           displayName: Build and Test
+        - template: /azure-pipelines/templates/steps/publish-packages.yml
 
       - job: windows
         displayName: Windows
@@ -57,3 +57,4 @@ stages:
           submodules: recursive
         - script: .\build.cmd -ci -test -bl -configuration Release
           displayName: Build and Test
+        - template: /azure-pipelines/templates/steps/publish-packages.yml

--- a/azure-pipelines/templates/steps/publish-packages.yml
+++ b/azure-pipelines/templates/steps/publish-packages.yml
@@ -1,0 +1,16 @@
+steps:
+- task: CopyFiles@2
+  displayName: Gather packages for publish
+  inputs:
+    SourceFolder: 'artifacts/packages'
+    Contents: '**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+  continueOnError: true
+  condition: always()
+- task: PublishPipelineArtifact@1
+  displayName: Publish packages
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+    artifactName: 'Packages_$(Agent.Os)_$(_BuildConfig)'
+  continueOnError: true
+  condition: always()

--- a/azure-pipelines/templates/steps/publish-packages.yml
+++ b/azure-pipelines/templates/steps/publish-packages.yml
@@ -7,10 +7,19 @@ steps:
     TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
   continueOnError: true
   condition: always()
-- task: PublishPipelineArtifact@1
-  displayName: Publish packages
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
-    artifactName: 'Packages_$(Agent.Os)_$(_BuildConfig)'
-  continueOnError: true
-  condition: always()
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - task: PublishPipelineArtifact@1
+    displayName: Publish packages
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+      artifactName: 'Packages_$(Agent.Os)_$(_BuildConfig)'
+    continueOnError: true
+    condition: always()
+- ${{ else }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: Publish packages
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+      artifactName: 'Packages_$(Agent.Os)_$(_BuildConfig)'
+    continueOnError: true
+    condition: always()


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build-assets/issues/1623

This is a second attempt as the [first one broke in internal CI](https://github.com/dotnet/source-build-assets/pull/1624)

Verified in an official pipeline run - https://dev.azure.com/dnceng/internal/_build/results?buildId=2949973