### PR TITLE
Add note about servicing branch differences in README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,14 +25,24 @@ All general documentation is maintained in the [README.md](../README.md) to avoi
 - **ALWAYS** validate commands work on Linux (primary platform for source-build)
 - **ALWAYS** preserve intentional code comments explaining manual fixes
 
+## Branch Awareness
+
+The instructions in this file and the README apply to the `main` branch.
+**Servicing branches (e.g. `release/9.0`) may have different tools, scripts, and
+workflows for generating and adding packages.** When working on a servicing branch,
+always read the README and copilot instructions from that branch — do not assume
+the `main` branch instructions are correct.
+
 ## Workflow Patterns
 
 ### When User Asks to "Add a Package"
 
-1. Determine package type first: External, Reference, Targeting, or Text-only
-2. For Reference packages: Use `./generate.sh --package name,version`
-3. For External packages: Requires submodule + project creation + patches1
-4. Check README for detailed workflows
+1. Confirm which branch the work targets — if it is a servicing branch, read that
+   branch's README for the correct process before proceeding
+2. Determine package type first: External, Reference, Targeting, or Text-only
+3. For Reference packages: Use `./generate.sh --package name,version`
+4. For External packages: Requires submodule + project creation + patches
+5. Check README for detailed workflows
 
 ### When Regenerating Packages
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ New packages are needed from time to time as
 and [new dependencies are added](https://github.com/dotnet/source-build/blob/main/Documentation/sourcebuild-in-repos/new-dependencies.md)
 to .NET. The following sections describe how to add/upgrade the various types of packages.
 
+> **Note:** The instructions below apply to the `main` branch. Servicing branches (e.g. `release/9.0`)
+> may have different processes for generating and adding packages. When working on a servicing branch,
+> always refer to the README on that branch for the correct instructions.
+
 * [External](#external)
 
 * [Reference](#reference)


### PR DESCRIPTION
The package generation instructions in the README and Copilot instructions apply to the `main` branch. Servicing branches may have different processes, so this PR:

1. Adds a callout in the README directing users to check the README on the servicing branch they are working on.
2. Adds a "Branch Awareness" section to the Copilot instructions and updates the package addition workflow to prompt checking the target branch first.

Ref: https://github.com/dotnet/source-build-assets/pull/1657#issuecomment-4409133464