### PR TITLE
Build OpenTelemetry.Exporter.InMemory

### DIFF
--- a/src/externalPackages/projects/opentelemetry-dotnet.proj
+++ b/src/externalPackages/projects/opentelemetry-dotnet.proj
@@ -13,6 +13,7 @@
       <OTelProviderExtProject>$(ProjectDirectory)src/OpenTelemetry.Api.ProviderBuilderExtensions/OpenTelemetry.Api.ProviderBuilderExtensions.csproj</OTelProviderExtProject>
       <OTelSdkProject>$(ProjectDirectory)src/OpenTelemetry/OpenTelemetry.csproj</OTelSdkProject>
       <OTelOtlpProject>$(ProjectDirectory)src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj</OTelOtlpProject>
+      <OTelInMemoryProject>$(ProjectDirectory)src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj</OTelInMemoryProject>
 
       <CommonBuildArgs>/p:Configuration=$(Configuration)</CommonBuildArgs>
       <CommonBuildArgs>$(CommonBuildArgs) /p:DelaySign=$(DelaySign)</CommonBuildArgs>
@@ -71,6 +72,16 @@
           WorkingDirectory="$(ProjectDirectory)"
           IgnoreStandardErrorWarningFormat="true" />
     <Exec Command="&quot;$(DotNetTool)&quot; pack /bl:$(ArtifactsLogRepoDir)pack_Otlp.binlog $(OTelOtlpProject) $(PackArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+
+    <!-- 5. OpenTelemetry.Exporter.InMemory -->
+    <Exec Command="&quot;$(DotNetTool)&quot; restore /bl:$(ArtifactsLogRepoDir)restore_InMemory.binlog $(OTelInMemoryProject) $(CommonBuildArgs)"
+          EnvironmentVariables="@(EnvironmentVariables)"
+          WorkingDirectory="$(ProjectDirectory)"
+          IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command="&quot;$(DotNetTool)&quot; pack /bl:$(ArtifactsLogRepoDir)pack_InMemory.binlog $(OTelInMemoryProject) $(PackArgs)"
           EnvironmentVariables="@(EnvironmentVariables)"
           WorkingDirectory="$(ProjectDirectory)"
           IgnoreStandardErrorWarningFormat="true" />


### PR DESCRIPTION
Adds `OpenTelemetry.Exporter.InMemory` to the `opentelemetry-dotnet` custom build target so the package is restored, packed, and produced alongside the other OpenTelemetry packages.

Follows the same blueprint already used for `OpenTelemetry.Api`, `OpenTelemetry.Api.ProviderBuilderExtensions`, `OpenTelemetry` (SDK), and `OpenTelemetry.Exporter.OpenTelemetryProtocol` in `src/externalPackages/projects/opentelemetry-dotnet.proj`.

## Validation

`./build.sh -sb` succeeds and produces:

```
artifacts/packages/Release/Shipping/OpenTelemetry.Exporter.InMemory.1.15.3.nupkg
```