### PR TITLE
Don't make assetless publish-build-assets wait on build jobs

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -14,6 +14,10 @@ stages:
       enableTelemetry: true
       isAssetlessBuild: true
       publishAssetsImmediately: true
+      # Assetless builds don't consume artifacts from the build jobs, so don't make the
+      # publish-build-assets job wait on Linux/Windows. An empty list overrides the default
+      # in eng/common/core-templates/jobs/jobs.yml, which would otherwise depend on every job.
+      publishBuildAssetsDependsOn: []
 
       jobs:
       - job: linux


### PR DESCRIPTION
The publish-build-assets job is wired by Arcade's `eng/common/core-templates/jobs/jobs.yml` to depend on every job under `parameters.jobs` when `publishBuildAssetsDependsOn` is left unset. For an assetless build, that job doesn't consume any artifacts from the build jobs, so making it wait on Linux/Windows is unnecessary and delays BAR registration.

This sets `publishBuildAssetsDependsOn: []` so the publish job starts immediately in parallel with the build jobs.