### PR TITLE
Document common GenAPI workaround files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,6 +115,15 @@ If `./build.sh -sb` produces API compatibility errors (CP0001, CP0002, CP0008, C
 | CP0008 | Missing `[Serializable]` attribute | No issue filed yet |
 | CP0002 | Missing event accessors (add_/remove_) | No issue filed yet |
 
+### Common Compilation Errors and Shared Workaround Files
+
+The `src/referencePackages/common/` directory contains shared
+   source files that fix known GenAPI limitations (e.g. `IsExternalInit.cs`,
+   `RequiredModifierAttributes.cs`). Including these via `Customizations.props` is
+   preferred over hand-editing generated code. See the
+   [Known Generator Issues](../docs/known_generator_issues.md#common-source-files) documentation
+   for the full list and usage instructions.
+
 ## Validation Checklist
 
 After any package changes:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ generated packages show changes when being regenerated.
    You can search the code base to see example usages.
    The benefit of using these files is that they will be preserved when the packages are regenerated.
 
+   1. Common source files - The `src/referencePackages/common/` directory contains shared
+   source files that fix known GenAPI limitations (e.g. `IsExternalInit.cs`,
+   `RequiredModifierAttributes.cs`). Including these via `Customizations.props` is
+   preferred over hand-editing generated code. See the
+   [Known Generator Issues](docs/known_generator_issues.md#common-source-files) documentation
+   for the full list and usage instructions.
+
 1. Add comments calling out any modifications to the generated code that were necessary.
 
 You can search for known issues in the [Known Generator Issues Markdown file](docs/known_generator_issues.md).

--- a/docs/known_generator_issues.md
+++ b/docs/known_generator_issues.md
@@ -1,5 +1,29 @@
 # Known issues
 
+## Common Source Files
+
+The `src/referencePackages/common/` directory contains shared source files that address
+known GenAPI limitations. These files are preferred over hand-editing generated code
+because they are preserved across package regeneration when included via `Customizations.props`.
+
+The `$(CommonSrc)` MSBuild property (defined in `src/referencePackages/Directory.Build.props`)
+points to this directory. To include a common file, add it to the package's `Customizations.props`:
+
+```xml
+<Project>
+  <ItemGroup>
+    <Compile Include="$(CommonSrc)IsExternalInit.cs" />
+  </ItemGroup>
+</Project>
+```
+
+### Available common files
+
+| File                            | Resolves                                                                                                    |
+|---------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `IsExternalInit.cs`             | `error CS0518: Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported` |
+| `RequiredModifierAttributes.cs` | `error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RequiredMemberAttribute..ctor'` and related `CompilerFeatureRequiredAttribute` / `SetsRequiredMembersAttribute` errors |
+
 ## The explicit declaration of `TupleElementNamesAttribute` attribute
 
 ```text


### PR DESCRIPTION
## Summary

Document the shared source files in `src/referencePackages/common/` (`IsExternalInit.cs`, `RequiredModifierAttributes.cs`) that fix known GenAPI limitations. These should be included via `Customizations.props` rather than hand-editing generated code, ensuring fixes survive package regeneration.

## Changes

- **docs/known_generator_issues.md**: New "Common Source Files" section with usage instructions and available files table
- **README.md**: Added common source files bullet in the Reference workflow section
- **.github/copilot-instructions.md**: Added pointer to common workaround docs

Fixes https://github.com/dotnet/source-build-assets/issues/1320